### PR TITLE
解决Job执行报获取hostname异常导致job不能正常执行的问题

### DIFF
--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/type/JobExecutionEvent.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/type/JobExecutionEvent.java
@@ -40,7 +40,7 @@ public final class JobExecutionEvent implements JobEvent {
     
     private String id = UUID.randomUUID().toString();
     
-    private String hostname = getHostName();
+    private String hostname = getLocalHostName();
     
     private String ip = IpUtils.getIp();
     
@@ -108,7 +108,7 @@ public final class JobExecutionEvent implements JobEvent {
      * 获取本机Host名称
      * @return
      */
-	private static String getHostName() {
+	private static String getLocalHostName() {
 		try {
 			return IpUtils.getHostName();
 		} catch (Exception e) {

--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/type/JobExecutionEvent.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/type/JobExecutionEvent.java
@@ -40,7 +40,7 @@ public final class JobExecutionEvent implements JobEvent {
     
     private String id = UUID.randomUUID().toString();
     
-    private String hostname = IpUtils.getHostName();
+    private String hostname = getHostName();
     
     private String ip = IpUtils.getIp();
     
@@ -103,4 +103,19 @@ public final class JobExecutionEvent implements JobEvent {
     public enum ExecutionSource {
         NORMAL_TRIGGER, MISFIRE, FAILOVER
     }
+    
+    /**
+     * 获取本机Host名称
+     * @return
+     */
+	private static String getHostName() {
+		try {
+			return IpUtils.getHostName();
+		} catch (Exception e) {
+			//当项目部署在docker中，如果docker与宿主机的网络通过桥接的方式，该方法可能会抛异常：解析域名暂时失败
+			//为了不影响Job的执行，此处只打印异常，不抛出异常
+			e.printStackTrace();
+		}
+		return "";
+	}
 }


### PR DESCRIPTION
Fixes #442.

Changes proposed in this pull request:
Job任务启动时，会获取hostname、ip等信息以记录任务执行的环境。
当项目部署在docker容器中，同时docker与宿主机网络链接通过桥接的方式，在docker中获取hostname时，可能会报“暂时解析域名失败”的异常，故修改对该异常的处理，不向上抛，只是打印堆栈信息，以免影响job的正常执行。
