### PR TITLE
优化event trace逻辑的查询SQL

### DIFF
--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/rdb/JobEventRdbStorage.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/event/rdb/JobEventRdbStorage.java
@@ -324,7 +324,7 @@ final class JobEventRdbStorage {
     }
     
     private String getOriginalTaskId(final String taskId) {
-        String sql = String.format("SELECT original_task_id FROM %s WHERE task_id = '%s' and state='%s'", TABLE_JOB_STATUS_TRACE_LOG, taskId, State.TASK_STAGING);
+        String sql = String.format("SELECT original_task_id FROM %s WHERE task_id = '%s' and state='%s' limit 1", TABLE_JOB_STATUS_TRACE_LOG, taskId, State.TASK_STAGING);
         String result = "";
         try (
                 Connection conn = dataSource.getConnection();


### PR DESCRIPTION
优化查询SQL

Changes proposed in this pull request:
- getOriginalTaskId只需要获取一条记录，不用获取所有的查询结果（当结果集很大的时候，会严重影响数据库性能），优化为只查询一条记录。
