### PR TITLE
为了兼容一些开源框架的升级，升级elastic-job所一些版本的依赖

### DIFF
--- a/elastic-job-lite-console/pom.xml
+++ b/elastic-job-lite-console/pom.xml
@@ -45,8 +45,8 @@
             <artifactId>unitils-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/elastic-job-lite-console/src/main/java/io/elasticjob/lite/console/restful/EventTraceHistoryRestfulApi.java
+++ b/elastic-job-lite-console/src/main/java/io/elasticjob/lite/console/restful/EventTraceHistoryRestfulApi.java
@@ -25,7 +25,6 @@ import io.elasticjob.lite.console.util.SessionEventTraceDataSourceConfiguration;
 import io.elasticjob.lite.event.rdb.JobEventRdbSearch;
 import io.elasticjob.lite.event.type.JobExecutionEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent;
-import org.apache.commons.dbcp.BasicDataSource;
 
 import javax.sql.DataSource;
 import javax.ws.rs.Consumes;
@@ -41,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 /**
  * 事件追踪历史记录的RESTful API.

--- a/elastic-job-lite-core/pom.xml
+++ b/elastic-job-lite-core/pom.xml
@@ -44,8 +44,8 @@
             <artifactId>curator-recipes</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbConfigurationTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbConfigurationTest.java
@@ -18,7 +18,7 @@
 package io.elasticjob.lite.event.rdb;
 
 import io.elasticjob.lite.event.JobEventListenerConfigurationException;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbListenerTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbListenerTest.java
@@ -24,7 +24,7 @@ import io.elasticjob.lite.event.type.JobExecutionEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.Source;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.State;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbSearchTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbSearchTest.java
@@ -22,7 +22,7 @@ import io.elasticjob.lite.event.type.JobExecutionEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.Source;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.State;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbStorageTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/event/rdb/JobEventRdbStorageTest.java
@@ -22,7 +22,7 @@ import io.elasticjob.lite.event.type.JobExecutionEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.Source;
 import io.elasticjob.lite.event.type.JobStatusTraceEvent.State;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/statistics/rdb/StatisticRdbRepositoryTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/statistics/rdb/StatisticRdbRepositoryTest.java
@@ -23,7 +23,7 @@ import io.elasticjob.lite.statistics.type.job.JobRegisterStatistics;
 import io.elasticjob.lite.statistics.type.job.JobRunningStatistics;
 import io.elasticjob.lite.statistics.type.task.TaskResultStatistics;
 import io.elasticjob.lite.statistics.type.task.TaskRunningStatistics;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/elastic-job-lite-spring/pom.xml
+++ b/elastic-job-lite-spring/pom.xml
@@ -68,8 +68,8 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/elastic-job-lite-spring/src/test/resources/META-INF/job/base.xml
+++ b/elastic-job-lite-spring/src/test/resources/META-INF/job/base.xml
@@ -13,7 +13,7 @@
     <context:property-placeholder location="classpath:conf/job/conf.properties" />
     <reg:zookeeper id="regCenter" server-lists="${regCenter.serverLists}" namespace="${regCenter.namespace}" base-sleep-time-milliseconds="${regCenter.baseSleepTimeMilliseconds}" max-sleep-time-milliseconds="${regCenter.maxSleepTimeMilliseconds}" max-retries="${regCenter.maxRetries}" />
     <bean id="foo" class="io.elasticjob.lite.spring.fixture.service.FooServiceImpl" />
-    <bean id="elasticJobLog" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
+    <bean id="elasticJobLog" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="driverClassName" value="org.h2.Driver"/>
         <property name="url" value="jdbc:h2:mem:job_event_storage"/>
         <property name="username" value="sa"/>

--- a/pom.xml
+++ b/pom.xml
@@ -16,28 +16,28 @@
     </modules>
     
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <maven.version.range>[3.0.4,)</maven.version.range>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.locale>zh_CN</project.build.locale>
         
-        <springframework.version>[3.1.0.RELEASE,5.0.0.M1)</springframework.version>
+        <springframework.version>5.0.5.RELEASE</springframework.version>
         
-        <lombok.version>1.16.4</lombok.version>
-        <guava.version>18.0</guava.version>
-        <commons-lang3.version>3.4</commons-lang3.version>
-        <quartz.version>2.2.1</quartz.version>
-        <curator.version>2.10.0</curator.version>
-        <aspectj.version>1.8.0</aspectj.version>
-        <slf4j.version>1.7.7</slf4j.version>
-        <logback.version>1.1.2</logback.version>
-        <commons-codec.version>1.10</commons-codec.version>
+        <lombok.version>1.16.20</lombok.version>
+        <guava.version>20.0</guava.version>
+        <commons-lang3.version>3.6</commons-lang3.version>
+        <quartz.version>2.3.0</quartz.version>
+        <curator.version>4.0.1</curator.version>
+        <aspectj.version>1.8.13</aspectj.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <logback.version>1.2.3</logback.version>
+        <commons-codec.version>1.11</commons-codec.version>
         <commons-exec.version>1.3</commons-exec.version>
         <gson.version>2.6.1</gson.version>
         <jersey.version>1.19</jersey.version>
-        <jetty-all-server.version>8.1.19.v20160209</jetty-all-server.version>
-        <commons-dbcp.version>1.4</commons-dbcp.version>
-        <mysql-connector-java.version>5.1.30</mysql-connector-java.version>
+        <jetty-all-server.version>8.2.0.v20160908</jetty-all-server.version>
+        <commons-dbcp2.version>2.2.0</commons-dbcp2.version>
+        <mysql-connector-java.version>5.1.46</mysql-connector-java.version>
         <h2.version>1.4.184</h2.version>
         <junit.version>4.12</junit.version>
         <unitils.core.version>3.4.2</unitils.core.version>
@@ -204,9 +204,9 @@
                 <version>${jetty-all-server.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-dbcp</groupId>
-                <artifactId>commons-dbcp</artifactId>
-                <version>${commons-dbcp.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-dbcp2</artifactId>
+                <version>${commons-dbcp2.version}</version>
             </dependency>
             <dependency>
                 <groupId>mysql</groupId>


### PR DESCRIPTION
Changes proposed in this pull request:
-  由于项目使用了springboot2进行了集成，springboot2升级了很多依赖的版本，如果elastic-job不进行相关依赖的升级， 会导致版本的不兼容和冲突。所以升级了一些依赖版本
- 升级了使用的jdk的版本，现在jdk1.8已经是主流，spring5 和 springboot2 也只支持 jdk1.8了，所以升级了jdk的版本
