### PR TITLE
添加spring容器关闭时关闭任务功能

### DIFF
--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/JobScheduler.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/JobScheduler.java
@@ -110,6 +110,13 @@ public class JobScheduler {
         jobScheduleController.scheduleJob(liteJobConfigFromRegCenter.getTypeConfig().getCoreConfig().getCron());
     }
     
+   /**
+    * 关闭服务
+    */
+   public void shutdown() {
+	   schedulerFacade.shutdownInstance();
+   }
+    
     private JobDetail createJobDetail(final String jobClass) {
         JobDetail result = JobBuilder.newJob(LiteJob.class).withIdentity(liteJobConfig.getJobName()).build();
         result.getJobDataMap().put(JOB_FACADE_DATA_MAP_KEY, jobFacade);

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/JobSchedulerTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/JobSchedulerTest.java
@@ -77,5 +77,6 @@ public final class JobSchedulerTest {
         Scheduler scheduler = ReflectionUtils.getFieldValue(JobRegistry.getInstance().getJobScheduleController("test_job"), JobScheduleController.class.getDeclaredField("scheduler"));
         assertThat(scheduler.getListenerManager().getTriggerListeners().get(0), instanceOf(JobTriggerListener.class));
         assertTrue(scheduler.isStarted());
+        jobScheduler.shutdown();
     }
 }

--- a/elastic-job-lite-spring/src/main/java/io/elasticjob/lite/spring/api/SpringJobScheduler.java
+++ b/elastic-job-lite-spring/src/main/java/io/elasticjob/lite/spring/api/SpringJobScheduler.java
@@ -17,6 +17,8 @@
 
 package io.elasticjob.lite.spring.api;
 
+import org.springframework.beans.factory.DisposableBean;
+
 import com.google.common.base.Optional;
 import io.elasticjob.lite.api.ElasticJob;
 import io.elasticjob.lite.api.JobScheduler;
@@ -32,7 +34,7 @@ import io.elasticjob.lite.spring.job.util.AopTargetUtils;
  * @author caohao
  * @author zhangliang
  */
-public final class SpringJobScheduler extends JobScheduler {
+public final class SpringJobScheduler extends JobScheduler implements DisposableBean {
     
     private final ElasticJob elasticJob;
     
@@ -59,4 +61,10 @@ public final class SpringJobScheduler extends JobScheduler {
     protected Optional<ElasticJob> createElasticJobInstance() {
         return Optional.fromNullable(elasticJob);
     }
+
+	@Override
+	public void destroy() throws Exception {
+		shutdown();
+	}
+    
 }


### PR DESCRIPTION
Fixes #525 #497 

Changes proposed in this pull request:
-添加spring容器关闭时任务主动关闭功能
（1）没有主动调用JobScheduler会导致spring容器销毁时，底层的quartz线程还在运行，没有关闭
（2）tomcat内存泄漏的问题也是由于quartz的线程没有主动关闭的问题

