### PR TITLE
Fixing flaky test ShutdownListenerManagerTest.assertIsShutdownAlready

### DIFF
--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
@@ -8,6 +8,7 @@ import io.elasticjob.lite.internal.storage.JobNodeStorage;
 import io.elasticjob.lite.reg.base.CoordinatorRegistryCenter;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type;
 import org.apache.curator.framework.recipes.cache.TreeCacheListener;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -47,6 +48,11 @@ public final class ShutdownListenerManagerTest {
         ReflectionUtils.setFieldValue(shutdownListenerManager, "schedulerFacade", schedulerFacade);
         ReflectionUtils.setFieldValue(shutdownListenerManager, shutdownListenerManager.getClass().getSuperclass().getDeclaredField("jobNodeStorage"), jobNodeStorage);
     }
+
+    @After
+    public void tearDown() {
+        JobRegistry.getInstance().shutdown("test_job");
+    }
     
     @Test
     public void assertStart() {
@@ -65,7 +71,6 @@ public final class ShutdownListenerManagerTest {
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController, regCenter);
         shutdownListenerManager.new InstanceShutdownStatusJobListener().dataChanged("/test_job/instances/127.0.0.2@-@0", Type.NODE_REMOVED, "");
         verify(schedulerFacade, times(0)).shutdownInstance();
-        JobRegistry.getInstance().shutdown("test_job");
     }
     
     @Test
@@ -73,7 +78,6 @@ public final class ShutdownListenerManagerTest {
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController, regCenter);
         shutdownListenerManager.new InstanceShutdownStatusJobListener().dataChanged("/test_job/instances/127.0.0.1@-@0", Type.NODE_UPDATED, "");
         verify(schedulerFacade, times(0)).shutdownInstance();
-        JobRegistry.getInstance().shutdown("test_job");
     }
     
     @Test


### PR DESCRIPTION
In ShutdownListenerManagerTest, test assertIsShutdownAlready has a test-order dependency and fails when run after other tests even when there’s no bug in the code.
 
More specifically, if any of the tests assertRemoveLocalInstancePathForPausedJob, assertRemoveLocalInstancePathForReconnectedRegistryCenter, or assertRemoveLocalInstancePathForPausedJob run right before assertIsShutdownAlready, then assertIsShutdownAlready will fail. The “test_job” job in the JobRegistry needs to be shut down before assertIsShutdownAlready runs, and those three tests do not properly shut down the job. Other tests like assertIsNotLocalInstancePath and assertUpdateLocalInstancePath do properly shut down the job, and assertIsShutdownAlready does not fail when run after any of these two tests. The fix creates a tearDown method that shuts down the job after *every* test.