### PR TITLE
Fixing order-dependent tests

### DIFF
--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/JobSchedulerTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/JobSchedulerTest.java
@@ -28,6 +28,7 @@ import io.elasticjob.lite.internal.schedule.JobScheduleController;
 import io.elasticjob.lite.internal.schedule.JobTriggerListener;
 import io.elasticjob.lite.internal.schedule.SchedulerFacade;
 import io.elasticjob.lite.reg.base.CoordinatorRegistryCenter;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -77,5 +78,10 @@ public final class JobSchedulerTest {
         Scheduler scheduler = ReflectionUtils.getFieldValue(JobRegistry.getInstance().getJobScheduleController("test_job"), JobScheduleController.class.getDeclaredField("scheduler"));
         assertThat(scheduler.getListenerManager().getTriggerListeners().get(0), instanceOf(JobTriggerListener.class));
         assertTrue(scheduler.isStarted());
+    }
+
+    @After
+    public void tearDown() {
+        JobRegistry.getInstance().shutdown("test_job");
     }
 }

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/schedule/JobRegistryTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/schedule/JobRegistryTest.java
@@ -20,6 +20,7 @@ package io.elasticjob.lite.internal.schedule;
 import io.elasticjob.lite.api.strategy.JobInstance;
 import io.elasticjob.lite.reg.base.CoordinatorRegistryCenter;
 import org.junit.Test;
+import org.unitils.util.ReflectionUtils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -69,9 +70,10 @@ public final class JobRegistryTest {
     }
     
     @Test
-    public void assertGetCurrentShardingTotalCountIfNotNull() {
+    public void assertGetCurrentShardingTotalCountIfNotNull() throws NoSuchFieldException {
         JobRegistry.getInstance().setCurrentShardingTotalCount("exist_job_instance", 10);
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount("exist_job_instance"), is(10));
+        ReflectionUtils.setFieldValue(JobRegistry.getInstance(), "instance", null);
     }
     
     @Test

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
@@ -26,6 +26,7 @@ import io.elasticjob.lite.internal.config.ConfigurationService;
 import io.elasticjob.lite.internal.schedule.JobRegistry;
 import io.elasticjob.lite.internal.schedule.JobScheduleController;
 import io.elasticjob.lite.internal.storage.JobNodeStorage;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -64,6 +65,11 @@ public final class ExecutionServiceTest {
         MockitoAnnotations.initMocks(this);
         ReflectionUtils.setFieldValue(executionService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(executionService, "configService", configService);
+    }
+
+    @After
+    public void tearDown() {
+        JobRegistry.getInstance().shutdown("test_job");
     }
     
     @Test


### PR DESCRIPTION
Similar to #592, this pull request aims to fix several order-dependent tests that fail when run in certain orders even when there's no bug in the code.

The pull request involves shutting down jobs after tests in JobSchedulerTest and ExecutionServiceTest finish running. The pull request also resets state after JobRegistryTest.assertGetCurrentShardingTotalCountIfNotNull runs, which leads to JobRegistryTest.assertGetCurrentShardingTotalCountIfNull top fail when it is run afterwards.