### PR TITLE
支持com.mysql.cj.jdbc.Driver

### DIFF
--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/event/rdb/JobEventRdbStorage.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/event/rdb/JobEventRdbStorage.java
@@ -71,7 +71,7 @@ final class JobEventRdbStorage {
     
     private void createJobExecutionTableAndIndexIfNeeded(final Connection conn) throws SQLException {
         DatabaseMetaData dbMetaData = conn.getMetaData();
-        try (ResultSet resultSet = dbMetaData.getTables(null, null, TABLE_JOB_EXECUTION_LOG, new String[]{"TABLE"})) {
+        try (ResultSet resultSet = dbMetaData.getTables(conn.getCatalog(), null, TABLE_JOB_EXECUTION_LOG, new String[]{"TABLE"})) {
             if (!resultSet.next()) {
                 createJobExecutionTable(conn);
             }
@@ -80,7 +80,7 @@ final class JobEventRdbStorage {
     
     private void createJobStatusTraceTableAndIndexIfNeeded(final Connection conn) throws SQLException {
         DatabaseMetaData dbMetaData = conn.getMetaData();
-        try (ResultSet resultSet = dbMetaData.getTables(null, null, TABLE_JOB_STATUS_TRACE_LOG, new String[]{"TABLE"})) {
+        try (ResultSet resultSet = dbMetaData.getTables(conn.getCatalog(), null, TABLE_JOB_STATUS_TRACE_LOG, new String[]{"TABLE"})) {
             if (!resultSet.next()) {
                 createJobStatusTraceTable(conn);
             }
@@ -90,7 +90,7 @@ final class JobEventRdbStorage {
     
     private void createTaskIdIndexIfNeeded(final Connection conn, final String tableName, final String indexName) throws SQLException {
         DatabaseMetaData dbMetaData = conn.getMetaData();
-        try (ResultSet resultSet = dbMetaData.getIndexInfo(null, null, tableName, false, false)) {
+        try (ResultSet resultSet = dbMetaData.getIndexInfo(conn.getCatalog(), null, tableName, false, false)) {
             boolean hasTaskIdIndex = false;
             while (resultSet.next()) {
                 if (indexName.equals(resultSet.getString("INDEX_NAME"))) {


### PR DESCRIPTION
Fixes #628.

Changes proposed in this pull request:
-目前版本支持com.mysql.jdbc.Driver，而现在大部分人都使用com.mysql.cj.jdbc.Driver。
-当数据库中有多个database时，例如：dba,dbb。当dba中有job_execution_log和job_status_trace_log时，
在dbb中是无法自动创建的，导致错误。
-本次修改代码，无论使用com.mysql.jdbc.Driver还是com.mysql.cj.jdbc.Driver，都会在相应的database中创建两张日志表。
