### PR TITLE
支持毫秒级别调度作业

### DIFF
--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/schedule/JobScheduleController.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/schedule/JobScheduleController.java
@@ -19,14 +19,9 @@ package io.elasticjob.lite.internal.schedule;
 
 import io.elasticjob.lite.exception.JobSystemException;
 import lombok.RequiredArgsConstructor;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
-import org.quartz.JobDetail;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
-import org.quartz.TriggerKey;
+import org.quartz.*;
+
+import java.util.Date;
 
 /**
  * 作业调度控制器.
@@ -41,7 +36,12 @@ public final class JobScheduleController {
     private final JobDetail jobDetail;
     
     private final String triggerIdentity;
-    
+
+    /**
+     * 毫秒级别作业 配置作业调度表达式的分隔符 分号前面是作业开始时间 分号后面是作业间隔调度的毫秒数
+     */
+    private static final String MILLISECOND_JOB_EXPRESSION_SEPARATOR = ";";
+
     /**
      * 调度作业.
      * 
@@ -50,7 +50,7 @@ public final class JobScheduleController {
     public void scheduleJob(final String cron) {
         try {
             if (!scheduler.checkExists(jobDetail.getKey())) {
-                scheduler.scheduleJob(jobDetail, createTrigger(cron));
+                scheduler.scheduleJob(jobDetail, isSimpleTriggerJob(cron) ? createSimpleTrigger(cron) : createTrigger(cron));
             }
             scheduler.start();
         } catch (final SchedulerException ex) {
@@ -64,6 +64,19 @@ public final class JobScheduleController {
      * @param cron CRON表达式
      */
     public synchronized void rescheduleJob(final String cron) {
+        if (isSimpleTriggerJob(cron)) {
+            rescheduleSimpleTriggerJob(cron);
+        } else {
+            rescheduleCronTriggerJob(cron);
+        }
+    }
+
+    /**
+     * 重新调度作业.
+     *
+     * @param cron CRON表达式
+     */
+    public void rescheduleCronTriggerJob(final String cron) {
         try {
             CronTrigger trigger = (CronTrigger) scheduler.getTrigger(TriggerKey.triggerKey(triggerIdentity));
             if (!scheduler.isShutdown() && null != trigger && !cron.equals(trigger.getCronExpression())) {
@@ -73,11 +86,32 @@ public final class JobScheduleController {
             throw new JobSystemException(ex);
         }
     }
-    
+
+    /**
+     * 重新调度作业. 毫秒级别作业
+     *
+     * @param cron CRON表达式
+     */
+    public void rescheduleSimpleTriggerJob(final String cron) {
+        try {
+            SimpleTrigger trigger = (SimpleTrigger) scheduler.getTrigger(TriggerKey.triggerKey(triggerIdentity));
+            if (!scheduler.isShutdown() && null != trigger && !cron.equals(trigger.getStartTime().getTime() + MILLISECOND_JOB_EXPRESSION_SEPARATOR + trigger.getRepeatInterval())) {
+                scheduler.rescheduleJob(TriggerKey.triggerKey(triggerIdentity), createSimpleTrigger(cron));
+            }
+        } catch (final SchedulerException ex) {
+            throw new JobSystemException(ex);
+        }
+    }
+
     private CronTrigger createTrigger(final String cron) {
         return TriggerBuilder.newTrigger().withIdentity(triggerIdentity).withSchedule(CronScheduleBuilder.cronSchedule(cron).withMisfireHandlingInstructionDoNothing()).build();
     }
-    
+
+    private SimpleTrigger createSimpleTrigger(final String cron) {
+        String[] arr = cron.split(MILLISECOND_JOB_EXPRESSION_SEPARATOR);
+        return TriggerBuilder.newTrigger().startAt(new Date(Long.parseLong(arr[0]))).withIdentity(triggerIdentity).withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInMilliseconds(Long.parseLong(arr[1])).repeatForever().withMisfireHandlingInstructionNowWithExistingCount()).build();
+    }
+
     /**
      * 判断作业是否暂停.
      * 
@@ -141,5 +175,14 @@ public final class JobScheduleController {
         } catch (final SchedulerException ex) {
             throw new JobSystemException(ex);
         }
+    }
+
+    /**
+     * 判断是否是毫秒级别的作业
+     * @param cron
+     * @return
+     */
+    private boolean isSimpleTriggerJob(final String cron) {
+        return cron.contains(MILLISECOND_JOB_EXPRESSION_SEPARATOR);
     }
 }


### PR DESCRIPTION
## EN
### A New Feature: Job Of Millisecond Level.
- Supports scheduling jobs at the millisecond level, with jobs scheduled at intervals of a certain number of milliseconds.
- In addition, this function has been applied to the production environment of large-scale options and futures trading websites and it works perfectly well.

- **Usage**: You simply only replace the cron expression of the second parameter of the JobCoreConfiguration#newBuilder method with something like "1551276000000;500", with 1551276000000 before the semicolon as the number of milliseconds for the start time of the job, and 500 after the semicolon as intervals of milliseconds for scheduling jobs.

## 中文
### 一个新特性：毫秒级别调度作业
- 支持毫秒级别调度作业，间隔一定毫秒数调度作业。
- 另外该功能已运用于大型期权期货交易网站的生产环境且效果很好。

- **用法**：仅仅需要把JobCoreConfiguration#newBuilder方法的第二个参数cron的cron表达式替换为类似"1551276000000;500”, 分号前面1551276000000为任务开始时间的毫秒数，分号后面500为每间隔500毫秒调度一次作业.