### PR TITLE
fixing order-dependence in ZookeeperRegistryCenterModifyTest

### DIFF
--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
@@ -99,6 +99,8 @@ public final class ZookeeperRegistryCenterModifyTest {
             assertThat(each, startsWith("test_sequential"));
             assertThat(zkRegCenter.get("/sequential/" + each), startsWith("test_value"));
         }
+        zkRegCenter.remove("/sequential");
+        assertFalse(zkRegCenter.isExisted("/sequential"));
     }
     
     @Test


### PR DESCRIPTION
Fixes #635 

Changes proposed in this pull request:
- Fixing the order dependence in ZookeeperRegistryCenterModifyTest
