### PR TITLE
Error occurred if placeholder is used in 'reconcile-interval-minutes'

### DIFF
--- a/elastic-job-lite-spring/src/main/resources/META-INF/namespace/job.xsd
+++ b/elastic-job-lite-spring/src/main/resources/META-INF/namespace/job.xsd
@@ -38,7 +38,7 @@
                 <xsd:attribute name="monitor-port" type="xsd:string" default="-1"/>
                 <xsd:attribute name="max-time-diff-seconds" type="xsd:string" default="-1"/>
                 <xsd:attribute name="failover" type="xsd:string" default="false"/>
-                <xsd:attribute name="reconcile-interval-minutes" type="xsd:int" default="10"/>
+                <xsd:attribute name="reconcile-interval-minutes" type="xsd:string" default="10"/>
                 <xsd:attribute name="misfire" type="xsd:string" default="true"/>
                 <xsd:attribute name="job-sharding-strategy-class" type="xsd:string" />
                 <xsd:attribute name="description" type="xsd:string" />


### PR DESCRIPTION
Fixes #689: change the type of 'reconcile-interval-minutes' in job.xsd from int to string. 