### PR TITLE
Fix the bug of ADOEJListener(use zk EPHEMERAL_SEQUENTIAL node)

### DIFF
--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
@@ -59,7 +59,7 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
     @Override
     public final void beforeJobExecuted(final ShardingContexts shardingContexts) {
         guaranteeService.registerStart(shardingContexts.getShardingItemParameters().keySet());
-        if (guaranteeService.isAllStarted()) {
+        if (guaranteeService.isAllStarted() && guaranteeService.isQualifiedBeforeAllStarted()) {
             doBeforeJobExecutedAtLastStarted(shardingContexts);
             guaranteeService.clearAllStartedInfo();
             return;
@@ -81,7 +81,7 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
     @Override
     public final void afterJobExecuted(final ShardingContexts shardingContexts) {
         guaranteeService.registerComplete(shardingContexts.getShardingItemParameters().keySet());
-        if (guaranteeService.isAllCompleted()) {
+        if (guaranteeService.isAllCompleted() && guaranteeService.isQualifiedAfterAllCompleted()) {
             doAfterJobExecutedAtLastCompleted(shardingContexts);
             guaranteeService.clearAllCompletedInfo();
             return;

--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/guarantee/GuaranteeNode.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/guarantee/GuaranteeNode.java
@@ -31,7 +31,15 @@ public final class GuaranteeNode {
     
     static final String STARTED_ROOT = ROOT + "/started";
     
+    static final String STARTED_SEQUENTIAL_ROOT = ROOT + "/started_sequential";
+    
+    static final String STARTED_SEQUENTIAL_NODE = STARTED_SEQUENTIAL_ROOT + "/instance";
+    
     static final String COMPLETED_ROOT = ROOT + "/completed";
+    
+    static final String COMPLETED_SEQUENTIAL_ROOT = ROOT + "/completed_sequential";
+    
+    static final String COMPLETED_SEQUENTIAL_NODE = COMPLETED_SEQUENTIAL_ROOT + "/instance";
     
     private final JobNodePath jobNodePath;
     

--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/storage/JobNodeStorage.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/storage/JobNodeStorage.java
@@ -141,6 +141,16 @@ public final class JobNodeStorage {
     }
     
     /**
+     * 创建临时有序作业节点.
+     *
+     * @param node 作业节点名称
+     * @return the node
+     */
+    public String createEphemeralSequentialJobNode(final String node) {
+        return regCenter.persistEphemeralSequential(jobNodePath.getFullPath(node));
+    }
+    
+    /**
      * 更新节点数据.
      * 
      * @param node 作业节点名称

--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/reg/base/CoordinatorRegistryCenter.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/reg/base/CoordinatorRegistryCenter.java
@@ -71,8 +71,9 @@ public interface CoordinatorRegistryCenter extends RegistryCenter {
      * 持久化临时顺序注册数据.
      * 
      * @param key 键
+     * @return the node
      */
-    void persistEphemeralSequential(String key);
+    String persistEphemeralSequential(String key);
     
     /**
      * 添加本地缓存.

--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/reg/zookeeper/ZookeeperRegistryCenter.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/reg/zookeeper/ZookeeperRegistryCenter.java
@@ -264,14 +264,15 @@ public final class ZookeeperRegistryCenter implements CoordinatorRegistryCenter 
     }
     
     @Override
-    public void persistEphemeralSequential(final String key) {
+    public String persistEphemeralSequential(final String key) {
         try {
-            client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath(key);
-        //CHECKSTYLE:OFF
+            return client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath(key);
+            //CHECKSTYLE:OFF
         } catch (final Exception ex) {
-        //CHECKSTYLE:ON
+            //CHECKSTYLE:ON
             RegExceptionHandler.handleException(ex);
         }
+        return null;
     }
     
     @Override

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
@@ -68,6 +68,7 @@ public final class DistributeOnceElasticJobListenerTest {
     @Test
     public void assertBeforeJobExecutedWhenIsAllStarted() {
         when(guaranteeService.isAllStarted()).thenReturn(true);
+        when(guaranteeService.isQualifiedBeforeAllStarted()).thenReturn(true);
         distributeOnceElasticJobListener.beforeJobExecuted(shardingContexts);
         verify(guaranteeService).registerStart(Sets.newHashSet(0, 1));
         verify(elasticJobListenerCaller).before();
@@ -95,6 +96,7 @@ public final class DistributeOnceElasticJobListenerTest {
     @Test
     public void assertAfterJobExecutedWhenIsAllCompleted() {
         when(guaranteeService.isAllCompleted()).thenReturn(true);
+        when(guaranteeService.isQualifiedAfterAllCompleted()).thenReturn(true);
         distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
         verify(guaranteeService).registerComplete(Sets.newHashSet(0, 1));
         verify(elasticJobListenerCaller).after();

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
@@ -31,7 +31,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.unitils.util.ReflectionUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -87,9 +89,33 @@ public final class GuaranteeServiceTest {
     }
     
     @Test
+    public void assertIsQualifiedBeforeAllStarted() {
+        when(jobNodeStorage.createEphemeralSequentialJobNode(GuaranteeNode.STARTED_SEQUENTIAL_NODE)).thenReturn("instance0000000000");
+        List<String> children = new ArrayList<String>();
+        children.add("instance0000000001");
+        children.add("instance0000000002");
+        children.add("instance0000000000");
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.STARTED_SEQUENTIAL_ROOT)).thenReturn(children);
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.STARTED_ROOT)).thenReturn(children);
+        assertTrue(guaranteeService.isQualifiedBeforeAllStarted());
+    }
+    
+    @Test
+    public void assertIsNotQualifiedBeforeAllStarted() {
+        when(jobNodeStorage.createEphemeralSequentialJobNode(GuaranteeNode.STARTED_SEQUENTIAL_NODE)).thenReturn("instance0000000001");
+        List<String> children = new ArrayList<String>();
+        children.add("instance0000000000");
+        children.add("instance0000000001");
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.STARTED_SEQUENTIAL_ROOT)).thenReturn(children);
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.STARTED_ROOT)).thenReturn(children);
+        assertFalse(guaranteeService.isQualifiedBeforeAllStarted());
+    }
+    
+    @Test
     public void assertClearAllStartedInfo() {
         guaranteeService.clearAllStartedInfo();
         verify(jobNodeStorage).removeJobNodeIfExisted("guarantee/started");
+        verify(jobNodeStorage).removeJobNodeIfExisted("guarantee/started_sequential");
     }
     
     @Test
@@ -124,8 +150,32 @@ public final class GuaranteeServiceTest {
     }
     
     @Test
+    public void assertIsQualifiedAfterAllCompleted() {
+        when(jobNodeStorage.createEphemeralSequentialJobNode(GuaranteeNode.COMPLETED_SEQUENTIAL_NODE)).thenReturn("instance0000000000");
+        List<String> children = new ArrayList<String>();
+        children.add("instance0000000001");
+        children.add("instance0000000002");
+        children.add("instance0000000000");
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_SEQUENTIAL_ROOT)).thenReturn(children);
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_ROOT)).thenReturn(children);
+        assertTrue(guaranteeService.isQualifiedAfterAllCompleted());
+    }
+    
+    @Test
+    public void assertIsNotQualifiedAfterAllCompleted() {
+        when(jobNodeStorage.createEphemeralSequentialJobNode(GuaranteeNode.COMPLETED_SEQUENTIAL_NODE)).thenReturn("instance0000000001");
+        List<String> children = new ArrayList<String>();
+        children.add("instance0000000000");
+        children.add("instance0000000001");
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_SEQUENTIAL_ROOT)).thenReturn(children);
+        when(jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_ROOT)).thenReturn(children);
+        assertFalse(guaranteeService.isQualifiedAfterAllCompleted());
+    }
+    
+    @Test
     public void assertClearAllCompletedInfo() {
         guaranteeService.clearAllCompletedInfo();
         verify(jobNodeStorage).removeJobNodeIfExisted("guarantee/completed");
+        verify(jobNodeStorage).removeJobNodeIfExisted("guarantee/completed_sequential");
     }
 }

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/storage/JobNodeStorageTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/storage/JobNodeStorageTest.java
@@ -144,6 +144,12 @@ public final class JobNodeStorageTest {
     }
     
     @Test
+    public void assertcreateEphemeralSequentialJobNode() {
+        jobNodeStorage.createEphemeralSequentialJobNode("test_ephemeral_sequential");
+        verify(regCenter).persistEphemeralSequential("/test_job/test_ephemeral_sequential");
+    }
+    
+    @Test
     public void assertUpdateJobNode() {
         jobNodeStorage.updateJobNode("config/cron", "0/1 * * * * ?");
         verify(regCenter).update("/test_job/config/cron", "0/1 * * * * ?");


### PR DESCRIPTION
Fixes #631 #487.

Changes proposed in this pull request:
- Mak the function of listener executing only once  when conditions are met in the distributed case.
https://github.com/elasticjob/elastic-job-lite/issues/487#issuecomment-540497821
- According to the feature of  EPHEMERAL_SEQUENTIAL node in zk . 

