### PR TITLE
Fix the bug of ADOEJListener(with item 0) 

### DIFF
--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
@@ -68,11 +68,11 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
                     guaranteeService.clearAllStartedInfo();
                     return;
                 }
-                BlockUtils.sleep(500L);
                 if (timeService.getCurrentMillis() - before >= startedTimeoutMilliseconds) {
                     guaranteeService.clearAllStartedInfo();
                     handleTimeout(startedTimeoutMilliseconds);
                 }
+                BlockUtils.sleep(500L);
             }
         } else {
             try {
@@ -100,11 +100,11 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
                     guaranteeService.clearAllCompletedInfo();
                     return;
                 }
-                BlockUtils.sleep(500L);
                 if (timeService.getCurrentMillis() - before >= completedTimeoutMilliseconds) {
                     guaranteeService.clearAllCompletedInfo();
                     handleTimeout(completedTimeoutMilliseconds);
                 }
+                BlockUtils.sleep(500L);
             }
         } else {
             try {

--- a/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/schedule/LiteJobFacade.java
+++ b/elastic-job-lite-core/src/main/java/io/elasticjob/lite/internal/schedule/LiteJobFacade.java
@@ -152,15 +152,19 @@ public final class LiteJobFacade implements JobFacade {
     
     @Override
     public void beforeJobExecuted(final ShardingContexts shardingContexts) {
-        for (ElasticJobListener each : elasticJobListeners) {
-            each.beforeJobExecuted(shardingContexts);
+        if (!shardingContexts.getShardingItemParameters().isEmpty()) {
+            for (ElasticJobListener each : elasticJobListeners) {
+                each.beforeJobExecuted(shardingContexts);
+            }
         }
     }
     
     @Override
     public void afterJobExecuted(final ShardingContexts shardingContexts) {
-        for (ElasticJobListener each : elasticJobListeners) {
-            each.afterJobExecuted(shardingContexts);
+        if (!shardingContexts.getShardingItemParameters().isEmpty()) {
+            for (ElasticJobListener each : elasticJobListeners) {
+                each.afterJobExecuted(shardingContexts);
+            }
         }
     }
     

--- a/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/schedule/LiteJobFacadeTest.java
+++ b/elastic-job-lite-core/src/test/java/io/elasticjob/lite/internal/schedule/LiteJobFacadeTest.java
@@ -43,6 +43,8 @@ import org.unitils.util.ReflectionUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -208,14 +210,30 @@ public class LiteJobFacadeTest {
     }
     
     @Test
-    public void assertBeforeJobExecuted() {
+    public void assertNotBeforeJobExecuted() {
         liteJobFacade.beforeJobExecuted(new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.<Integer, String>emptyMap()));
+        verify(caller, times(0)).before();
+    }
+    
+    @Test
+    public void assertNotAfterJobExecuted() {
+        liteJobFacade.afterJobExecuted(new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.<Integer, String>emptyMap()));
+        verify(caller, times(0)).after();
+    }
+    
+    @Test
+    public void assertBeforeJobExecuted() {
+        Map<Integer, String> shardingItems = new HashMap<Integer, String>(1);
+        shardingItems.put(0, "");
+        liteJobFacade.beforeJobExecuted(new ShardingContexts("fake_task_id", "test_job", 10, "", shardingItems));
         verify(caller).before();
     }
     
     @Test
     public void assertAfterJobExecuted() {
-        liteJobFacade.afterJobExecuted(new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.<Integer, String>emptyMap()));
+        Map<Integer, String> shardingItems = new HashMap<Integer, String>(1);
+        shardingItems.put(0, "");
+        liteJobFacade.afterJobExecuted(new ShardingContexts("fake_task_id", "test_job", 10, "", shardingItems));
         verify(caller).after();
     }
     


### PR DESCRIPTION
Fixes #631 #487.

Changes proposed in this pull request:
- Mak the function of listener executing only once  when conditions are met in the distributed case.
https://github.com/elasticjob/elastic-job-lite/issues/487#issuecomment-540948454
- Only the instance with item 0 can do the distributed once task.