### PR TITLE
make elastic-job-lite-console can package and run

### DIFF
--- a/elastic-job-lite-console/pom.xml
+++ b/elastic-job-lite-console/pom.xml
@@ -86,6 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2-beta-5</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/resources/assembly/assembly.xml</descriptor>

--- a/elastic-job-lite-console/pom.xml
+++ b/elastic-job-lite-console/pom.xml
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2-beta-5</version>
+                <version>3.3.0</version>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/resources/assembly/assembly.xml</descriptor>
@@ -96,7 +96,7 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>assembly</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/elastic-job-lite-console/src/main/resources/assembly/assembly.xml
+++ b/elastic-job-lite-console/src/main/resources/assembly/assembly.xml
@@ -16,6 +16,7 @@
   -->
 
 <assembly>
+    <id>bin</id>
     <formats>
         <format>tar.gz</format>
     </formats>

--- a/elastic-job-lite-console/src/main/resources/bin/start.bat
+++ b/elastic-job-lite-console/src/main/resources/bin/start.bat
@@ -14,7 +14,7 @@ set PORT=%1
 set CFG_DIR=%~dp0%..
 set CLASSPATH=%CFG_DIR%
 set CLASSPATH=%~dp0..\lib\*;%CLASSPATH%
-set CONSOLE_MAIN=ConsoleBootstrap
+set CONSOLE_MAIN=org.apache.shardingsphere.elasticjob.lite.console.ConsoleBootstrap
 echo on
 if ""%PORT%"" == """" set PORT=8899
 java  -cp "%CLASSPATH%" %CONSOLE_MAIN% %PORT%


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
1.fix start.bat ,it can not run only use ConsoleBootstrap name;
2.now the elastic-job-lite-console can not be package use maven,the error are below

[ERROR] Could not find goal 'assembly' in plugin org.apache.maven.plugins:maven-assembly-plugin:3.0.0 among available goals help, single -> [Help 1]

it should be notify the version of maven-assembly-plugin ,the default version is 3.0.0.
