### PR TITLE
Remove JDBC driver dependency for elastic-job-lite-console

### DIFF
--- a/elastic-job-lite-console/README.md
+++ b/elastic-job-lite-console/README.md
@@ -1,0 +1,7 @@
+# Elastic-Job-Lite-Console
+
+Usage:
+1. Execute `mvn install`.
+2. Extract `elastic-job-lite-console/target/elastic-job-lite-console-${version}.tar.gz` and goto the extracted directory.
+3. Add JDBC Driver (Such as `mysql-connector-java-8.0.13.jar`) to directory `ext-lib`.
+4. Run Elastic-Job-Lite-Console with `bin/start.sh`

--- a/elastic-job-lite-console/pom.xml
+++ b/elastic-job-lite-console/pom.xml
@@ -62,10 +62,6 @@
             <artifactId>commons-dbcp</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/elastic-job-lite-console/src/main/resources/assembly/assembly.xml
+++ b/elastic-job-lite-console/src/main/resources/assembly/assembly.xml
@@ -33,6 +33,12 @@
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
         </fileSet>
+        <fileSet>
+            <directory>src/main/resources/ext-lib</directory>
+            <outputDirectory>ext-lib</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+        </fileSet>
     </fileSets>
     
     <dependencySets>

--- a/elastic-job-lite-console/src/main/resources/bin/start.bat
+++ b/elastic-job-lite-console/src/main/resources/bin/start.bat
@@ -13,8 +13,7 @@ set PORT=%1
 :doStart
 set CFG_DIR=%~dp0%..
 set CLASSPATH=%CFG_DIR%
-set CLASSPATH=%~dp0..\lib\*;%CLASSPATH%
-set CLASSPATH=$~dp0..\ext-lib\*;%CLASSPATH%
+set CLASSPATH=%~dp0..\lib\*;%~dp0..\ext-lib\*;CLASSPATH%
 set CONSOLE_MAIN=org.apache.shardingsphere.elasticjob.lite.console.ConsoleBootstrap
 echo on
 if ""%PORT%"" == """" set PORT=8899

--- a/elastic-job-lite-console/src/main/resources/bin/start.bat
+++ b/elastic-job-lite-console/src/main/resources/bin/start.bat
@@ -14,6 +14,7 @@ set PORT=%1
 set CFG_DIR=%~dp0%..
 set CLASSPATH=%CFG_DIR%
 set CLASSPATH=%~dp0..\lib\*;%CLASSPATH%
+set CLASSPATH=$~dp0..\ext-lib\*;%CLASSPATH%
 set CONSOLE_MAIN=org.apache.shardingsphere.elasticjob.lite.console.ConsoleBootstrap
 echo on
 if ""%PORT%"" == """" set PORT=8899

--- a/elastic-job-lite-console/src/main/resources/bin/start.sh
+++ b/elastic-job-lite-console/src/main/resources/bin/start.sh
@@ -28,8 +28,7 @@ fi
 cd `dirname $0`
 cd ..
 DEPLOY_DIR=`pwd`
-LIB_DIR=${DEPLOY_DIR}/lib/*
-LIB_DIR=${LIB_DIR}:${DEPLOY_DIR}/ext-lib/*
+LIB_DIR=${DEPLOY_DIR}/lib/*:${DEPLOY_DIR}/ext-lib/*
 CONSOLE_MAIN=org.apache.shardingsphere.elasticjob.lite.console.ConsoleBootstrap
 
 java -classpath ${LIB_DIR}:. ${CONSOLE_MAIN} $port

--- a/elastic-job-lite-console/src/main/resources/bin/start.sh
+++ b/elastic-job-lite-console/src/main/resources/bin/start.sh
@@ -29,6 +29,7 @@ cd `dirname $0`
 cd ..
 DEPLOY_DIR=`pwd`
 LIB_DIR=${DEPLOY_DIR}/lib/*
+LIB_DIR=${LIB_DIR}:${DEPLOY_DIR}/ext-lib/*
 CONSOLE_MAIN=org.apache.shardingsphere.elasticjob.lite.console.ConsoleBootstrap
 
 java -classpath ${LIB_DIR}:. ${CONSOLE_MAIN} $port

--- a/elastic-job-lite-console/src/main/resources/console/html/global/event_trace_data_source.html
+++ b/elastic-job-lite-console/src/main/resources/console/html/global/event_trace_data_source.html
@@ -53,9 +53,7 @@
                     </div>
                     <div class="form-group">
                         <label for="driver" class="control-label" data-lang="event-trace-data-source-driver"></label>
-                        <select id="driver" name="driver" class="form-control">
-                            MySQL:<option>com.mysql.jdbc.Driver</option>
-                        </select>
+                        <input type="text" class="form-control" id="driver" name="driver" required>
                     </div>
                     <div class="form-group">
                         <label for="url" class="control-label" data-lang="event-trace-data-source-url"></label>


### PR DESCRIPTION
Fixes #841 .

Changes proposed in this pull request:
- Removed MySQL JDBC driver dependency which is incompatible with ASF.
- Added ext-lib and updated start script to setup ext-lib into classpath
- Added document for using custom JDBC driver.
