### PR TITLE
Fix h2 create an existed table and index

### DIFF
--- a/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/java/org/apache/shardingsphere/elasticjob/lite/tracing/rdb/storage/RDBStorageSQLMapper.java
+++ b/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/java/org/apache/shardingsphere/elasticjob/lite/tracing/rdb/storage/RDBStorageSQLMapper.java
@@ -74,7 +74,7 @@ public final class RDBStorageSQLMapper {
     }
     
     private InputStream getPropertiesInputStream(final String sqlPropertiesFileName) {
-        InputStream sqlPropertiesFile = RDBJobEventStorage.class.getClassLoader().getResourceAsStream(String.format("META-INF/sql/%s.properties", sqlPropertiesFileName));
+        InputStream sqlPropertiesFile = RDBJobEventStorage.class.getClassLoader().getResourceAsStream(String.format("META-INF/sql/%s", sqlPropertiesFileName));
         return null == sqlPropertiesFile ? RDBJobEventStorage.class.getClassLoader().getResourceAsStream("META-INF/sql/sql92.properties") : sqlPropertiesFile;
     }
 }

--- a/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/resources/META-INF/sql/h2.properties
+++ b/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/resources/META-INF/sql/h2.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-JOB_EXECUTION_LOG.TABLE.CREATE=CREATE TABLE JOB_EXECUTION_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, task_id VARCHAR(255) NOT NULL, hostname VARCHAR(255) NOT NULL, ip VARCHAR(50) NOT NULL, sharding_item INT NOT NULL, execution_source VARCHAR(20) NOT NULL, failure_cause VARCHAR(4000) NULL, is_success INT NOT NULL, start_time TIMESTAMP NULL, complete_time TIMESTAMP NULL, PRIMARY KEY (id))
+JOB_EXECUTION_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_EXECUTION_LOG  (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, task_id VARCHAR(255) NOT NULL, hostname VARCHAR(255) NOT NULL, ip VARCHAR(50) NOT NULL, sharding_item INT NOT NULL, execution_source VARCHAR(20) NOT NULL, failure_cause VARCHAR(4000) NULL, is_success INT NOT NULL, start_time TIMESTAMP NULL, complete_time TIMESTAMP NULL, PRIMARY KEY (id))
 
 JOB_EXECUTION_LOG.INSERT=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 JOB_EXECUTION_LOG.INSERT_COMPLETE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time, complete_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -23,8 +23,8 @@ JOB_EXECUTION_LOG.INSERT_FAILURE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, ta
 JOB_EXECUTION_LOG.UPDATE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ? WHERE id = ?
 JOB_EXECUTION_LOG.UPDATE_FAILURE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ?, failure_cause = ? WHERE id = ?
 
-JOB_STATUS_TRACE_LOG.TABLE.CREATE=CREATE TABLE JOB_STATUS_TRACE_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, original_task_id VARCHAR(255) NOT NULL, task_id VARCHAR(255) NOT NULL, slave_id VARCHAR(50) NOT NULL, source VARCHAR(50) NOT NULL, execution_type VARCHAR(20) NOT NULL, sharding_item VARCHAR(100) NOT NULL, state VARCHAR(20) NOT NULL, message VARCHAR(4000) NULL, creation_time TIMESTAMP NULL, PRIMARY KEY (id))
-TASK_ID_STATE_INDEX.INDEX.CREATE=CREATE INDEX TASK_ID_STATE_INDEX ON JOB_STATUS_TRACE_LOG (task_id, state)
+JOB_STATUS_TRACE_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_STATUS_TRACE_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, original_task_id VARCHAR(255) NOT NULL, task_id VARCHAR(255) NOT NULL, slave_id VARCHAR(50) NOT NULL, source VARCHAR(50) NOT NULL, execution_type VARCHAR(20) NOT NULL, sharding_item VARCHAR(100) NOT NULL, state VARCHAR(20) NOT NULL, message VARCHAR(4000) NULL, creation_time TIMESTAMP NULL, PRIMARY KEY (id))
+TASK_ID_STATE_INDEX.INDEX.CREATE=CREATE INDEX IF NOT EXISTS TASK_ID_STATE_INDEX ON JOB_STATUS_TRACE_LOG (task_id, state)
 
 JOB_STATUS_TRACE_LOG.INSERT=INSERT INTO JOB_STATUS_TRACE_LOG (id, job_name, original_task_id, task_id, slave_id, source, execution_type, sharding_item, state, message, creation_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 JOB_STATUS_TRACE_LOG.SELECT=SELECT * FROM JOB_STATUS_TRACE_LOG WHERE task_id = ?

--- a/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/resources/META-INF/sql/mysql.properties
+++ b/elastic-job-lite-tracing/elastic-job-lite-tracing-rdb/src/main/resources/META-INF/sql/mysql.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-JOB_EXECUTION_LOG.TABLE.CREATE=CREATE TABLE JOB_EXECUTION_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, task_id VARCHAR(255) NOT NULL, hostname VARCHAR(255) NOT NULL, ip VARCHAR(50) NOT NULL, sharding_item INT NOT NULL, execution_source VARCHAR(20) NOT NULL, failure_cause VARCHAR(4000) NULL, is_success INT NOT NULL, start_time TIMESTAMP NULL, complete_time TIMESTAMP NULL, PRIMARY KEY (id))
+JOB_EXECUTION_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_EXECUTION_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, task_id VARCHAR(255) NOT NULL, hostname VARCHAR(255) NOT NULL, ip VARCHAR(50) NOT NULL, sharding_item INT NOT NULL, execution_source VARCHAR(20) NOT NULL, failure_cause VARCHAR(4000) NULL, is_success INT NOT NULL, start_time TIMESTAMP NULL, complete_time TIMESTAMP NULL, PRIMARY KEY (id))
 
 JOB_EXECUTION_LOG.INSERT=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 JOB_EXECUTION_LOG.INSERT_COMPLETE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time, complete_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -23,7 +23,7 @@ JOB_EXECUTION_LOG.INSERT_FAILURE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, ta
 JOB_EXECUTION_LOG.UPDATE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ? WHERE id = ?
 JOB_EXECUTION_LOG.UPDATE_FAILURE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ?, failure_cause = ? WHERE id = ?
 
-JOB_STATUS_TRACE_LOG.TABLE.CREATE=CREATE TABLE JOB_STATUS_TRACE_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, original_task_id VARCHAR(255) NOT NULL, task_id VARCHAR(255) NOT NULL, slave_id VARCHAR(50) NOT NULL, source VARCHAR(50) NOT NULL, execution_type VARCHAR(20) NOT NULL, sharding_item VARCHAR(100) NOT NULL, state VARCHAR(20) NOT NULL, message VARCHAR(4000) NULL, creation_time TIMESTAMP NULL, PRIMARY KEY (id))
+JOB_STATUS_TRACE_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_STATUS_TRACE_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, original_task_id VARCHAR(255) NOT NULL, task_id VARCHAR(255) NOT NULL, slave_id VARCHAR(50) NOT NULL, source VARCHAR(50) NOT NULL, execution_type VARCHAR(20) NOT NULL, sharding_item VARCHAR(100) NOT NULL, state VARCHAR(20) NOT NULL, message VARCHAR(4000) NULL, creation_time TIMESTAMP NULL, PRIMARY KEY (id))
 TASK_ID_STATE_INDEX.INDEX.CREATE=CREATE INDEX TASK_ID_STATE_INDEX ON JOB_STATUS_TRACE_LOG (task_id(128), state)
 
 JOB_STATUS_TRACE_LOG.INSERT=INSERT INTO JOB_STATUS_TRACE_LOG (id, job_name, original_task_id, task_id, slave_id, source, execution_type, sharding_item, state, message, creation_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>elastic-job-lite-spring</module>
         <module>elastic-job-lite-lifecycle</module>
         <module>elastic-job-lite-console</module>
+        <module>examples</module>
     </modules>
     
     <properties>


### PR DESCRIPTION
Fixes #954.

Changes proposed in this pull request:
- Add IF NOT EXISTS for H2 create table and index to avoid existed table or index exception
- Add IF NOT EXISTS for Mysql create table
  Mysql doesn't support IF NOT EXISTS  syntax for creating index
- Loading SQL properties file without duplicated .properties suffix

