### PR TITLE
Test case `org.apache.shardingsphere.elasticjob.lite.integrate.enable…

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManager.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.election;
 
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type;
+import org.apache.shardingsphere.elasticjob.lite.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.listener.AbstractJobListener;
 import org.apache.shardingsphere.elasticjob.lite.internal.listener.AbstractListenerManager;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
@@ -25,6 +26,8 @@ import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerNode;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerService;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
 import org.apache.shardingsphere.elasticjob.lite.reg.base.CoordinatorRegistryCenter;
+
+import java.util.Objects;
 
 /**
  * Election listener manager.
@@ -70,7 +73,11 @@ public final class ElectionListenerManager extends AbstractListenerManager {
         }
         
         private boolean isPassiveElection(final String path, final Type eventType) {
-            return isLeaderCrashed(path, eventType) && serverService.isAvailableServer(JobRegistry.getInstance().getJobInstance(jobName).getIp());
+            JobInstance jobInstance = JobRegistry.getInstance().getJobInstance(jobName);
+            if (Objects.isNull(jobInstance)) {
+                return false;
+            }
+            return isLeaderCrashed(path, eventType) && serverService.isAvailableServer(jobInstance.getIp());
         }
         
         private boolean isLeaderCrashed(final String path, final Type eventType) {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerNode.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerNode.java
@@ -17,10 +17,12 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.server;
 
+import org.apache.shardingsphere.elasticjob.lite.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodePath;
 import org.apache.shardingsphere.elasticjob.lite.util.env.IpUtils;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -58,7 +60,11 @@ public final class ServerNode {
      * @return is server path for localhost or not
      */
     public boolean isLocalServerPath(final String path) {
-        return path.equals(jobNodePath.getFullPath(String.format(SERVERS, JobRegistry.getInstance().getJobInstance(jobName).getIp())));
+        JobInstance jobInstance = JobRegistry.getInstance().getJobInstance(jobName);
+        if (Objects.isNull(jobInstance)) {
+            return false;
+        }
+        return path.equals(jobNodePath.getFullPath(String.format(SERVERS, jobInstance.getIp())));
     }
     
     String getServerNode(final String ip) {


### PR DESCRIPTION
Test case `org.apache.shardingsphere.elasticjob.lite.integrate.enable.OneOffEnabledJobIntegrateTest` may block or throw exception sometimes

Fixes #928.

Changes proposed in this pull request:
- Fix a problem where test cases may throw exceptions
