### PR TITLE
Add default value to fields in JobConfigurationPOJO

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/pojo/JobConfigurationPOJO.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/pojo/JobConfigurationPOJO.java
@@ -46,7 +46,7 @@ public final class JobConfigurationPOJO {
     
     private boolean misfire;
     
-    private int maxTimeDiffSeconds;
+    private int maxTimeDiffSeconds = -1;
     
     private int reconcileIntervalMinutes;
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/pojo/JobConfigurationPOJOTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/pojo/JobConfigurationPOJOTest.java
@@ -38,7 +38,7 @@ public final class JobConfigurationPOJOTest {
             + "jobName: test_job\n"
             + "jobParameter: param\n"
             + "jobShardingStrategyType: AVG_ALLOCATION\n"
-            + "maxTimeDiffSeconds: 0\n"
+            + "maxTimeDiffSeconds: -1\n"
             + "misfire: false\n"
             + "monitorExecution: false\n"
             + "overwrite: false\n"
@@ -52,7 +52,7 @@ public final class JobConfigurationPOJOTest {
             + "disabled: false\n"
             + "failover: false\n"
             + "jobName: test_job\n"
-            + "maxTimeDiffSeconds: 0\n"
+            + "maxTimeDiffSeconds: -1\n"
             + "misfire: false\n"
             + "monitorExecution: false\n"
             + "overwrite: false\n"
@@ -130,6 +130,7 @@ public final class JobConfigurationPOJOTest {
         actual.setShardingTotalCount(3);
         actual.setShardingItemParameters("0=A,1=B,2=C");
         actual.setJobParameter("param");
+        actual.setMaxTimeDiffSeconds(-1);
         actual.setJobShardingStrategyType("AVG_ALLOCATION");
         actual.setJobExecutorServiceHandlerType("CPU");
         actual.setJobErrorHandlerType("IGNORE");
@@ -144,6 +145,7 @@ public final class JobConfigurationPOJOTest {
         actual.setJobName("test_job");
         actual.setCron("0/1 * * * * ?");
         actual.setShardingTotalCount(3);
+        actual.setMaxTimeDiffSeconds(-1);
         assertThat(YamlEngine.marshal(actual), is(YAML_WITH_NULL));
     }
     


### PR DESCRIPTION
Fixes #1052 .

Changes proposed in this pull request:
- Set `maxTimeDiffSeconds` default `-1` in `JobConfigurationPOJO`
- Complete test cases
