### PR TITLE
Add test case for BootstrapEnvironment.getMesosRole and getFrameworkHostPort

### DIFF
--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
@@ -123,7 +123,7 @@ public final class BootstrapEnvironmentTest {
 
     @Test
     public void asserGetFrameworkHostPort() {
-       assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("127.0.0.1:8899"));
+       assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("localhost:8899"));
     }
 
 }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
@@ -111,4 +111,19 @@ public final class BootstrapEnvironmentTest {
         assertThat(configuration.getReconcileIntervalMinutes(), is(0));
         assertFalse(configuration.isEnabledReconcile());
     }
+
+    @Test
+    public void assertGetMesosRole() {
+        assertThat(bootstrapEnvironment.getMesosRole(), is(Optional.empty()));
+        Properties properties = new Properties();
+        properties.setProperty(BootstrapEnvironment.EnvironmentArgument.MESOS_ROLE.getKey(), "0");
+        ReflectionUtils.setFieldValue(bootstrapEnvironment, "properties", properties);
+        assertThat(bootstrapEnvironment.getMesosRole(), is(Optional.of("0")));
+    }
+
+    @Test
+    public void asserGetFrameworkHostPort() {
+       assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("127.0.0.1:8899"));
+    }
+
 }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
@@ -122,8 +122,8 @@ public final class BootstrapEnvironmentTest {
     }
 
     @Test
-    public void asserGetFrameworkHostPort() {
-       assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("localhost:8899"));
+    public void assertGetFrameworkHostPort() {
+        assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("localhost:8899"));
     }
 
 }


### PR DESCRIPTION
Fixes #1209 .

Changes proposed in this pull request:
Add test case for BootstrapEnvironment.getMesosRole and getFrameworkHostPort

