### PR TITLE
Add configuration reference for document elasticjob-lite/usage/event-trace/spring-boot-starter

### DIFF
--- a/docs/content/user-manual/elasticjob-lite/usage/event-trace/spring-boot-starter.cn.md
+++ b/docs/content/user-manual/elasticjob-lite/usage/event-trace/spring-boot-starter.cn.md
@@ -5,7 +5,7 @@ chapter = true
 +++
 
 ElasticJob-Lite 的 Spring Boot Starter 集成了 TracingConfiguration 自动配置，
-开发者只需注册一个 DataSource 到 Spring 容器中，
+开发者只需注册一个 DataSource 到 Spring 容器中并在配置文件指定事件追踪数据源类型，
 Starter 就会自动创建一个 TracingConfiguration 实例并注册到 Spring 容器中。
 
 ## 引入 Maven 依赖
@@ -29,9 +29,13 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+elasticjob:
+  tracing:
+    type: RDB
 ```
 
 ## 作业启动
 
-TracingConfiguration 会自动注册到容器中，如果与 elasticjob-lite-spring-boot-starter 配合使用，
+指定事件追踪数据源类型为 RDB，TracingConfiguration 会自动注册到容器中，如果与 elasticjob-lite-spring-boot-starter 配合使用，
 开发者无需进行其他额外的操作，作业启动器会自动使用创建的 TracingConfiguration。

--- a/docs/content/user-manual/elasticjob-lite/usage/event-trace/spring-boot-starter.en.md
+++ b/docs/content/user-manual/elasticjob-lite/usage/event-trace/spring-boot-starter.en.md
@@ -5,7 +5,7 @@ chapter = true
 +++
 
 ElasticJob-Lite Spring Boot Starter has already integrated TracingConfiguration configuration.
-What developers need to do is register a bean of DataSource into the Spring IoC Container.
+What developers need to do is register a bean of DataSource into the Spring IoC Container and set the type of data source.
 Then the Starter will create an instance of TracingConfiguration and register it into the container.
 
 ## Import Maven Dependency
@@ -29,10 +29,14 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+elasticjob:
+  tracing:
+    type: RDB
 ```
 
 ## Job Start
 
-TracingConfiguration will be registered into the IoC container imperceptibly.
+TracingConfiguration will be registered into the IoC container imperceptibly after setting tracing type to RDB.
 If elasticjob-lite-spring-boot-starter was imported, developers need to do nothing else. 
 The instances of JobBootstrap will use the TracingConfiguration automatically.


### PR DESCRIPTION
Fixes #1243 .

Changes proposed in this pull request:
- Add configuration reference for document elasticjob-lite/usage/event-trace/spring-boot-starter