### PR TITLE
Avoid NPE log on DaemonTaskSchedulerTest#assertInit test case

### DIFF
--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/DaemonTaskSchedulerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/DaemonTaskSchedulerTest.java
@@ -117,6 +117,7 @@ public final class DaemonTaskSchedulerTest {
         Field field = DaemonTaskScheduler.class.getDeclaredField("RUNNING_SCHEDULERS");
         field.setAccessible(true);
         assertTrue(((ConcurrentHashMap) field.get(scheduler)).containsKey(taskId.getValue()));
+        DaemonTaskScheduler.shutdown(taskId);
     }
     
     @Test


### PR DESCRIPTION
Fixes #1259

Changes proposed in this pull request:
- Shutdown task scheduler at the end of assertInit

The test case DaemonTaskSchedulerTest#assertInit doesn't init DaemonTaskScheduler instance parameters correctly, such as shardingContexts, elasticJob, which caused NPE. But there isn't any exception log if we only run the test case independently. Because the task has no chance to execute. The exception only happens at the task runtime.

 When we run mvn test, you will observe the NPE log
