### PR TITLE
[Improvement][common]get the ip configured by hostname first

### DIFF
--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtils.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtils.java
@@ -26,7 +26,11 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.net.Inet6Address;
-import java.util.*;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
 
 /**
  * IP address utility.

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtils.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtils.java
@@ -51,6 +51,7 @@ public final class IpUtils {
         if (null != cachedIpAddress) {
             return cachedIpAddress;
         }
+
         InetAddress localAddress = null;
         try {
             localAddress = InetAddress.getLocalHost();


### PR DESCRIPTION
When obtaining the ip, the ip configured by the hostname should be obtained first. At the same time, if the user configures the ip corresponding to the hostname, there is no need to do a connectivity test at this time