### PR TITLE
Improve flexibility of (de)serializer

### DIFF
--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactory.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.elasticjob.restful.deserializer.factory.DeserializerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -78,22 +79,18 @@ public final class RequestBodyDeserializerFactory {
         if (null == deserializer) {
             synchronized (RequestBodyDeserializerFactory.class) {
                 if (null == REQUEST_BODY_DESERIALIZERS.get(contentType)) {
-                    deserializer = getRequestBodyDeserializerFromFactories(contentType);
+                    instantiateRequestBodyDeserializerFromFactories(contentType);
                 }
+                deserializer = REQUEST_BODY_DESERIALIZERS.get(contentType);
             }
         }
         return deserializer != MISSING_DESERIALIZER ? deserializer : null;
     }
     
-    private static RequestBodyDeserializer getRequestBodyDeserializerFromFactories(final String contentType) {
+    private static void instantiateRequestBodyDeserializerFromFactories(final String contentType) {
         RequestBodyDeserializer deserializer;
         DeserializerFactory factory = DEFAULT_REQUEST_BODY_DESERIALIZER_FACTORIES.get(contentType);
-        if (null != factory) {
-            deserializer = factory.createDeserializer();
-        } else {
-            deserializer = MISSING_DESERIALIZER;
-        }
+        deserializer = Optional.ofNullable(factory).map(DeserializerFactory::createDeserializer).orElse(MISSING_DESERIALIZER);
         REQUEST_BODY_DESERIALIZERS.put(contentType, deserializer);
-        return deserializer;
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/DeserializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/DeserializerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.deserializer.factory;
+
+import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
+
+/**
+ * Deserializer factory.
+ *
+ * @see RequestBodyDeserializer
+ * @see org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializerFactory
+ */
+public interface DeserializerFactory {
+    
+    /**
+     * Specify which type would be deserialized by the deserializer created by this factory.
+     *
+     * @return MIME type
+     */
+    String mimeType();
+    
+    /**
+     * Deserializer factory method.
+     *
+     * @return Instance of deserializer
+     */
+    RequestBodyDeserializer createDeserializer();
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/impl/DefaultJsonRequestBodyDeserializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/impl/DefaultJsonRequestBodyDeserializerFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.deserializer.factory.impl;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.factory.DeserializerFactory;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.impl.DefaultJsonRequestBodyDeserializer;
+
+public final class DefaultJsonRequestBodyDeserializerFactory implements DeserializerFactory {
+    
+    @Override
+    public String mimeType() {
+        return HttpHeaderValues.APPLICATION_JSON.toString();
+    }
+    
+    @Override
+    public RequestBodyDeserializer createDeserializer() {
+        return new DefaultJsonRequestBodyDeserializer();
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/impl/DefaultTextPlainRequestBodyDeserializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/factory/impl/DefaultTextPlainRequestBodyDeserializerFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.deserializer.factory.impl;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.factory.DeserializerFactory;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.impl.DefaultTextPlainRequestBodyDeserializer;
+
+public final class DefaultTextPlainRequestBodyDeserializerFactory implements DeserializerFactory {
+    
+    @Override
+    public String mimeType() {
+        return HttpHeaderValues.TEXT_PLAIN.toString();
+    }
+    
+    @Override
+    public RequestBodyDeserializer createDeserializer() {
+        return new DefaultTextPlainRequestBodyDeserializer();
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultJsonRequestBodyDeserializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultJsonRequestBodyDeserializer.java
@@ -17,30 +17,30 @@
 
 package org.apache.shardingsphere.elasticjob.restful.deserializer.impl;
 
+import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
 import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
 
 import java.nio.charset.StandardCharsets;
-import java.text.MessageFormat;
 
 /**
- * Deserializer for <code>text/plain</code>.
+ * Deserializer for <code>application/json</code>.
  */
-public final class TextPlainRequestBodyDeserializer implements RequestBodyDeserializer {
+public final class DefaultJsonRequestBodyDeserializer implements RequestBodyDeserializer {
+    
+    private final Gson gson = GsonFactory.getGson();
     
     @Override
     public String mimeType() {
-        return HttpHeaderValues.TEXT_PLAIN.toString();
+        return HttpHeaderValues.APPLICATION_JSON.toString();
     }
     
     @Override
     public <T> T deserialize(final Class<T> targetType, final byte[] requestBodyBytes) {
-        if (byte[].class.equals(targetType)) {
-            return (T) requestBodyBytes;
+        if (0 == requestBodyBytes.length) {
+            return null;
         }
-        if (String.class.isAssignableFrom(targetType)) {
-            return (T) new String(requestBodyBytes, StandardCharsets.UTF_8);
-        }
-        throw new UnsupportedOperationException(MessageFormat.format("Cannot deserialize [{0}] into [{1}]", mimeType(), targetType.getName()));
+        return gson.fromJson(new String(requestBodyBytes, StandardCharsets.UTF_8), targetType);
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultTextPlainRequestBodyDeserializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultTextPlainRequestBodyDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.deserializer.impl;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
+
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+
+/**
+ * Default deserializer for <code>text/plain</code>.
+ */
+public final class DefaultTextPlainRequestBodyDeserializer implements RequestBodyDeserializer {
+    
+    @Override
+    public String mimeType() {
+        return HttpHeaderValues.TEXT_PLAIN.toString();
+    }
+    
+    @Override
+    public <T> T deserialize(final Class<T> targetType, final byte[] requestBodyBytes) {
+        if (byte[].class.equals(targetType)) {
+            return (T) requestBodyBytes;
+        }
+        if (String.class.isAssignableFrom(targetType)) {
+            return (T) new String(requestBodyBytes, StandardCharsets.UTF_8);
+        }
+        throw new UnsupportedOperationException(MessageFormat.format("Cannot deserialize [{0}] into [{1}]", mimeType(), targetType.getName()));
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactory.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.elasticjob.restful.serializer;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.elasticjob.restful.serializer.factory.SerializerFactory;
 
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -32,19 +33,67 @@ public final class ResponseBodySerializerFactory {
     
     private static final Map<String, ResponseBodySerializer> RESPONSE_BODY_SERIALIZERS = new ConcurrentHashMap<>();
     
+    private static final Map<String, SerializerFactory> RESPONSE_BODY_SERIALIZER_FACTORIES = new ConcurrentHashMap<>();
+    
+    private static final ResponseBodySerializer MISSING_SERIALIZER = new ResponseBodySerializer() {
+        @Override
+        public String mimeType() {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public byte[] serialize(final Object responseBody) {
+            throw new UnsupportedOperationException();
+        }
+    };
+    
     static {
         for (ResponseBodySerializer serializer : ServiceLoader.load(ResponseBodySerializer.class)) {
             RESPONSE_BODY_SERIALIZERS.put(serializer.mimeType(), serializer);
+        }
+        for (SerializerFactory factory : ServiceLoader.load(SerializerFactory.class)) {
+            RESPONSE_BODY_SERIALIZER_FACTORIES.put(factory.mimeType(), factory);
         }
     }
     
     /**
      * Get serializer for specific HTTP content type.
      *
+     * <p>
+     * This method will look for a serializer instance of specific MIME type.
+     * If serializer not found, this method would look for serializer factory by MIME type.
+     * If it is still not found, the MIME type would be marked as <code>MISSING_SERIALIZER</code>.
+     * </p>
+     *
+     * <p>
+     * Some default serializer will be provided by {@link SerializerFactory},
+     * so developers can implement {@link ResponseBodySerializer} and register it by SPI to override default serializer.
+     * </p>
+     *
      * @param contentType HTTP content type
      * @return Serializer
      */
     public static ResponseBodySerializer getResponseBodySerializer(final String contentType) {
-        return RESPONSE_BODY_SERIALIZERS.get(contentType);
+        ResponseBodySerializer serializer = RESPONSE_BODY_SERIALIZERS.get(contentType);
+        if (null == serializer) {
+            synchronized (ResponseBodySerializerFactory.class) {
+                if (null == RESPONSE_BODY_SERIALIZERS.get(contentType)) {
+                    serializer = getResponseBodySerializerFromFactories(contentType);
+                }
+            }
+        }
+        return serializer != MISSING_SERIALIZER ? serializer : null;
+    }
+    
+    private static ResponseBodySerializer getResponseBodySerializerFromFactories(final String contentType) {
+        ResponseBodySerializer serializer;
+        SerializerFactory factory = RESPONSE_BODY_SERIALIZER_FACTORIES.get(contentType);
+        if (null != factory) {
+            serializer = factory.createSerializer();
+        } else {
+            serializer = MISSING_SERIALIZER;
+        }
+        RESPONSE_BODY_SERIALIZERS.put(contentType, serializer);
+        return serializer;
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactory.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.elasticjob.restful.serializer.factory.SerializerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -78,22 +79,18 @@ public final class ResponseBodySerializerFactory {
         if (null == serializer) {
             synchronized (ResponseBodySerializerFactory.class) {
                 if (null == RESPONSE_BODY_SERIALIZERS.get(contentType)) {
-                    serializer = getResponseBodySerializerFromFactories(contentType);
+                    instantiateResponseBodySerializerFromFactories(contentType);
                 }
+                serializer = RESPONSE_BODY_SERIALIZERS.get(contentType);
             }
         }
         return serializer != MISSING_SERIALIZER ? serializer : null;
     }
     
-    private static ResponseBodySerializer getResponseBodySerializerFromFactories(final String contentType) {
+    private static void instantiateResponseBodySerializerFromFactories(final String contentType) {
         ResponseBodySerializer serializer;
         SerializerFactory factory = RESPONSE_BODY_SERIALIZER_FACTORIES.get(contentType);
-        if (null != factory) {
-            serializer = factory.createSerializer();
-        } else {
-            serializer = MISSING_SERIALIZER;
-        }
+        serializer = Optional.ofNullable(factory).map(SerializerFactory::createSerializer).orElse(MISSING_SERIALIZER);
         RESPONSE_BODY_SERIALIZERS.put(contentType, serializer);
-        return serializer;
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/factory/SerializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/factory/SerializerFactory.java
@@ -15,28 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.restful.serializer.impl;
+package org.apache.shardingsphere.elasticjob.restful.serializer.factory;
 
-import com.google.gson.Gson;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer;
 
-import java.nio.charset.StandardCharsets;
-
 /**
- * Serializer for <code>application/json</code>.
+ * Serializer factory.
+ *
+ * @see ResponseBodySerializer
+ * @see org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializerFactory
  */
-public final class JsonResponseBodySerializer implements ResponseBodySerializer {
+public interface SerializerFactory {
     
-    private final Gson gson = new Gson();
+    /**
+     * Specify which type would be serialized by the serializer created by this factory.
+     *
+     * @return MIME type
+     */
+    String mimeType();
     
-    @Override
-    public String mimeType() {
-        return HttpHeaderValues.APPLICATION_JSON.toString();
-    }
-    
-    @Override
-    public byte[] serialize(final Object responseBody) {
-        return gson.toJson(responseBody).getBytes(StandardCharsets.UTF_8);
-    }
+    /**
+     * Serializer factory method.
+     *
+     * @return Instance of serializer
+     */
+    ResponseBodySerializer createSerializer();
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/factory/impl/DefaultJsonResponseBodySerializerFactory.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/factory/impl/DefaultJsonResponseBodySerializerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.serializer.factory.impl;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer;
+import org.apache.shardingsphere.elasticjob.restful.serializer.factory.SerializerFactory;
+import org.apache.shardingsphere.elasticjob.restful.serializer.impl.DefaultJsonResponseBodySerializer;
+
+/**
+ * Factory for {@link DefaultJsonResponseBodySerializer}.
+ */
+public final class DefaultJsonResponseBodySerializerFactory implements SerializerFactory {
+    
+    @Override
+    public String mimeType() {
+        return HttpHeaderValues.APPLICATION_JSON.toString();
+    }
+    
+    @Override
+    public ResponseBodySerializer createSerializer() {
+        return new DefaultJsonResponseBodySerializer();
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/impl/DefaultJsonResponseBodySerializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/impl/DefaultJsonResponseBodySerializer.java
@@ -15,20 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.restful.deserializer.impl;
+package org.apache.shardingsphere.elasticjob.restful.serializer.impl;
 
 import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
+import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
+import org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer;
 
 import java.nio.charset.StandardCharsets;
 
 /**
- * Deserializer for <code>application/json</code>.
+ * Default serializer for <code>application/json</code>.
  */
-public final class JsonRequestBodyDeserializer implements RequestBodyDeserializer {
+public final class DefaultJsonResponseBodySerializer implements ResponseBodySerializer {
     
-    private final Gson gson = new Gson();
+    private final Gson gson = GsonFactory.getGson();
     
     @Override
     public String mimeType() {
@@ -36,7 +37,10 @@ public final class JsonRequestBodyDeserializer implements RequestBodyDeserialize
     }
     
     @Override
-    public <T> T deserialize(final Class<T> targetType, final byte[] requestBodyBytes) {
-        return gson.fromJson(new String(requestBodyBytes, StandardCharsets.UTF_8), targetType);
+    public byte[] serialize(final Object responseBody) {
+        if (responseBody instanceof String) {
+            return ((String) responseBody).getBytes(StandardCharsets.UTF_8);
+        }
+        return gson.toJson(responseBody).getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.deserializer.factory.DeserializerFactory
+++ b/elasticjob-infra/elasticjob-restful/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.deserializer.factory.DeserializerFactory
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.elasticjob.restful.serializer.impl.JsonResponseBodySerializer
+org.apache.shardingsphere.elasticjob.restful.deserializer.factory.impl.DefaultJsonRequestBodyDeserializerFactory
+org.apache.shardingsphere.elasticjob.restful.deserializer.factory.impl.DefaultTextPlainRequestBodyDeserializerFactory

--- a/elasticjob-infra/elasticjob-restful/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.serializer.factory.SerializerFactory
+++ b/elasticjob-infra/elasticjob-restful/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.serializer.factory.SerializerFactory
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.elasticjob.restful.deserializer.impl.JsonRequestBodyDeserializer
-org.apache.shardingsphere.elasticjob.restful.deserializer.impl.TextPlainRequestBodyDeserializer
+org.apache.shardingsphere.elasticjob.restful.serializer.factory.impl.DefaultJsonResponseBodySerializerFactory

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.deserializer;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class RequestBodyDeserializerFactoryTest {
+    
+    @Test
+    public void assertGetJsonDefaultDeserializer() {
+        RequestBodyDeserializer deserializer = RequestBodyDeserializerFactory.getRequestBodyDeserializer(HttpHeaderValues.APPLICATION_JSON.toString());
+        assertNotNull(deserializer);
+    }
+    
+    @Test
+    public void assertDeserializerNotFound() {
+        RequestBodyDeserializer deserializer = RequestBodyDeserializerFactory.getRequestBodyDeserializer("Unknown");
+        assertNull(deserializer);
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.serializer;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ResponseBodySerializerFactoryTest {
+    
+    @Test
+    public void assertGetJsonDefaultSerializer() {
+        ResponseBodySerializer serializer = ResponseBodySerializerFactory.getResponseBodySerializer(HttpHeaderValues.APPLICATION_JSON.toString());
+        assertNotNull(serializer);
+    }
+    
+    @Test
+    public void assertSerializerNotFound() {
+        ResponseBodySerializer serializer = ResponseBodySerializerFactory.getResponseBodySerializer("Unknown");
+        assertNull(serializer);
+    }
+}


### PR DESCRIPTION
Ref #1284 .

Changes proposed in this pull request:
- Improved flexibility of (de)serializer

**Before**
The default (de)serializer can not be override by developers.

**After**
When a serializer was missing, defaut serializer factory method will be invoked to create an instance of default serializer.
Developers can implement a custom serializer and registry by the SPI mechanism.

