### PR TITLE
Improve trailing slash handling

### DIFF
--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -55,5 +55,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
+    </build>
 </project>

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/NettyRestfulServiceConfiguration.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/NettyRestfulServiceConfiguration.java
@@ -41,6 +41,12 @@ public final class NettyRestfulServiceConfiguration {
     @Setter
     private String host;
     
+    /**
+     * If trailing slash sensitive, <code>/foo/bar</code> is not equals to <code>/foo/bar/</code>.
+     */
+    @Setter
+    private boolean trailingSlashSensitive;
+    
     private final List<RestfulController> controllerInstances = new ArrayList<>();
     
     private final Map<Class<? extends Throwable>, ExceptionHandler<? extends Throwable>> exceptionHandlers = new HashMap<>();

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/mapping/RegexPathMatcher.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/mapping/RegexPathMatcher.java
@@ -33,7 +33,7 @@ public final class RegexPathMatcher implements PathMatcher {
     
     private static final String PATH_SEPARATOR = "/";
     
-    private static final Pattern PATH_PATTERN = Pattern.compile("^(?:/|(/[^/{}?]+|/\\{[^/{}?]+})+)$");
+    private static final Pattern PATH_PATTERN = Pattern.compile("^/(([^/{}]+|\\{[^/{}]+})(/([^/{}]+|\\{[^/{}]+}))*/?)?$");
     
     private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{(?<template>[^/]+)}");
     

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoder.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoder.java
@@ -22,7 +22,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.QueryStringDecoder;
@@ -102,9 +101,6 @@ public final class HandlerParameterDecoder extends ChannelInboundHandlerAdapter 
                     String mimeType = Optional.ofNullable(HttpUtil.getMimeType(httpRequest))
                             .orElseGet(() -> HttpUtil.getMimeType(Http.DEFAULT_CONTENT_TYPE)).toString();
                     RequestBodyDeserializer deserializer = RequestBodyDeserializerFactory.getRequestBodyDeserializer(mimeType);
-                    if (null == deserializer) {
-                        throw new UnsupportedMessageTypeException(MessageFormat.format("Unsupported MIME type [{0}]", mimeType));
-                    }
                     Object parsedBodyValue = deserializer.deserialize(targetType, bytes);
                     parsedValue = parsedBodyValue;
                     Preconditions.checkArgument(nullable || null != parsedBodyValue, "Missing request body");

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
@@ -38,7 +38,7 @@ public final class RestfulServiceChannelInitializer extends ChannelInitializer<C
     private final ExceptionHandling exceptionHandling;
     
     public RestfulServiceChannelInitializer(final NettyRestfulServiceConfiguration configuration) {
-        httpRequestDispatcher = new HttpRequestDispatcher(configuration.getControllerInstances());
+        httpRequestDispatcher = new HttpRequestDispatcher(configuration.getControllerInstances(), configuration.isTrailingSlashSensitive());
         handlerParameterDecoder = new HandlerParameterDecoder();
         handleMethodExecutor = new HandleMethodExecutor();
         exceptionHandling = new ExceptionHandling(configuration.getExceptionHandlers());

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexPathMatcherTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexPathMatcherTest.java
@@ -59,12 +59,17 @@ public class RegexPathMatcherTest {
     public void assertValidatePathPattern() {
         PathMatcher pathMatcher = new RegexPathMatcher();
         assertTrue(pathMatcher.isValidPathPattern("/"));
+        assertTrue(pathMatcher.isValidPathPattern("/app"));
         assertTrue(pathMatcher.isValidPathPattern("/app/job"));
+        assertTrue(pathMatcher.isValidPathPattern("/app/job/"));
         assertTrue(pathMatcher.isValidPathPattern("/app/{jobName}"));
         assertTrue(pathMatcher.isValidPathPattern("/{appName}/{jobName}/status"));
         assertFalse(pathMatcher.isValidPathPattern("/app/jobName}"));
         assertFalse(pathMatcher.isValidPathPattern("/app/{jobName"));
         assertFalse(pathMatcher.isValidPathPattern("/app/{job}Name"));
+        assertFalse(pathMatcher.isValidPathPattern("/app//jobName"));
+        assertFalse(pathMatcher.isValidPathPattern("//app/jobName"));
+        assertFalse(pathMatcher.isValidPathPattern("app/jobName"));
         assertFalse(pathMatcher.isValidPathPattern(""));
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/controller/IndexController.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/controller/IndexController.java
@@ -15,32 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.restful.annotation;
+package org.apache.shardingsphere.elasticjob.restful.controller;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.elasticjob.restful.Http;
+import org.apache.shardingsphere.elasticjob.restful.RestfulController;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
 
-/**
- * Declare what HTTP method and path is used to invoke the handler.
- */
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Mapping {
+@Slf4j
+public class IndexController implements RestfulController {
     
     /**
-     * Http method.
+     * A mapping declare path implicit, meaning it mapped index.
      *
-     * @return Http method
+     * @return a string
      */
-    String method();
-    
-    /**
-     * Path pattern of this handler. Starts with '/'.
-     * Such as <code>/app/{jobName}/enable</code>.
-     *
-     * @return Path pattern
-     */
-    String path() default "";
+    @Mapping(method = Http.GET)
+    public String index() {
+        return "hello, elastic-job";
+    }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/controller/TrailingSlashTestController.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/controller/TrailingSlashTestController.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.controller;
+
+import org.apache.shardingsphere.elasticjob.restful.Http;
+import org.apache.shardingsphere.elasticjob.restful.RestfulController;
+import org.apache.shardingsphere.elasticjob.restful.annotation.ContextPath;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Returning;
+
+@ContextPath("/trailing")
+public final class TrailingSlashTestController implements RestfulController {
+    
+    /**
+     * A mapping without trailing slash.
+     *
+     * @return a string
+     */
+    @Mapping(method = Http.GET, path = "/slash")
+    @Returning(contentType = "text/plain; charset=utf-8")
+    public String withoutTrailingSlash() {
+        return "without trailing slash";
+    }
+    
+    /**
+     * A mapping with trailing slash.
+     *
+     * @return a string
+     */
+    @Mapping(method = Http.GET, path = "/slash/")
+    @Returning(contentType = "text/plain; charset=utf-8")
+    public String withTrailingSlash() {
+        return "with trailing slash";
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.QueryStringEncoder;
+import org.apache.shardingsphere.elasticjob.restful.Http;
+import org.apache.shardingsphere.elasticjob.restful.RestfulController;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Param;
+import org.apache.shardingsphere.elasticjob.restful.annotation.ParamSource;
+import org.apache.shardingsphere.elasticjob.restful.annotation.RequestBody;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HandlerParameterDecoderTest {
+    
+    private EmbeddedChannel channel;
+    
+    @Before
+    public void setUp() {
+        HttpRequestDispatcher httpRequestDispatcher = new HttpRequestDispatcher(Collections.singletonList(new DecoderTestController()), false);
+        HandlerParameterDecoder handlerParameterDecoder = new HandlerParameterDecoder();
+        HandleMethodExecutor handleMethodExecutor = new HandleMethodExecutor();
+        channel = new EmbeddedChannel(httpRequestDispatcher, handlerParameterDecoder, handleMethodExecutor);
+    }
+    
+    @Test
+    public void assertDecodeParameters() {
+        QueryStringEncoder queryStringEncoder = new QueryStringEncoder("/myApp/C");
+        queryStringEncoder.addParam("cron", "0 * * * * ?");
+        queryStringEncoder.addParam("integer", "30");
+        queryStringEncoder.addParam("bool", "true");
+        queryStringEncoder.addParam("long", "3000");
+        queryStringEncoder.addParam("double", "23.33");
+        String uri = queryStringEncoder.toString();
+        ByteBuf body = Unpooled.wrappedBuffer("BODY".getBytes());
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set("Message", "some_message");
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, body, headers, headers);
+        channel.writeInbound(httpRequest);
+        FullHttpResponse httpResponse = channel.readOutbound();
+        assertThat(httpResponse.status().code(), is(200));
+        assertThat(new String(ByteBufUtil.getBytes(httpResponse.content())), is("ok"));
+    }
+    
+    public static class DecoderTestController implements RestfulController {
+        
+        /**
+         * A handle method for decode testing.
+         *
+         * @param appName     string from path
+         * @param ch          character from path
+         * @param cron        cron from query
+         * @param message     message from header
+         * @param body        from request body
+         * @param integer     integer from query
+         * @param bool        boolean from query
+         * @param longValue   long from query
+         * @param doubleValue double from query
+         * @return OK
+         */
+        @Mapping(method = Http.GET, path = "/{appName}/{ch}")
+        public String handle(
+                final @Param(source = ParamSource.PATH, name = "appName") String appName,
+                final @Param(source = ParamSource.PATH, name = "ch") char ch,
+                final @Param(source = ParamSource.QUERY, name = "cron") String cron,
+                final @Param(source = ParamSource.HEADER, name = "Message") String message,
+                final @RequestBody String body,
+                final @Param(source = ParamSource.QUERY, name = "integer") int integer,
+                final @Param(source = ParamSource.QUERY, name = "bool") Boolean bool,
+                final @Param(source = ParamSource.QUERY, name = "long") Long longValue,
+                final @Param(source = ParamSource.QUERY, name = "double") double doubleValue
+        ) {
+            assertThat(appName, is("myApp"));
+            assertThat(ch, is('C'));
+            assertThat(cron, is("0 * * * * ?"));
+            assertThat(message, is("some_message"));
+            assertThat(body, is("BODY"));
+            assertThat(integer, is(30));
+            assertThat(bool, is(true));
+            assertThat(longValue, is(3000L));
+            assertThat(doubleValue, is(23.33));
+            return "ok";
+        }
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpClient.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpClient.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +50,8 @@ public class HttpClient {
      * @param timeoutSeconds Wait for consume
      * @throws InterruptedException interrupted
      */
-    public static void request(final String host, final int port, final FullHttpRequest request, final Consumer<FullHttpResponse> consumer, final Long timeoutSeconds) throws InterruptedException {
+    @SneakyThrows
+    public static void request(final String host, final int port, final FullHttpRequest request, final Consumer<FullHttpResponse> consumer, final Long timeoutSeconds) {
         CountDownLatch countDownLatch = new CountDownLatch(1);
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
         Channel channel = new Bootstrap()

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
@@ -31,7 +31,7 @@ public class HttpRequestDispatcherTest {
     
     @Test(expected = HandlerNotFoundException.class)
     public void assertDispatcherHandlerNotFound() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDispatcher(Lists.newArrayList(new JobController())));
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDispatcher(Lists.newArrayList(new JobController()), false));
         FullHttpRequest fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/myJob/myCron");
         channel.writeInbound(fullHttpRequest);
     }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
@@ -26,10 +26,10 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
-import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
+import org.apache.shardingsphere.elasticjob.restful.controller.IndexController;
 import org.apache.shardingsphere.elasticjob.restful.controller.JobController;
 import org.apache.shardingsphere.elasticjob.restful.handler.CustomIllegalStateExceptionHandler;
 import org.apache.shardingsphere.elasticjob.restful.pojo.JobPojo;
@@ -37,6 +37,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -45,6 +46,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class NettyRestfulServiceTest {
+    
+    private static final long TESTCASE_TIMEOUT = 10000L;
     
     private static final String HOST = "localhost";
     
@@ -56,15 +59,14 @@ public class NettyRestfulServiceTest {
     public static void init() {
         NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
         configuration.setHost(HOST);
-        configuration.addControllerInstance(new JobController());
+        configuration.addControllerInstance(new JobController(), new IndexController());
         configuration.addExceptionHandler(IllegalStateException.class, new CustomIllegalStateExceptionHandler());
         restfulService = new NettyRestfulService(configuration);
         restfulService.startup();
     }
     
-    @SneakyThrows
-    @Test(timeout = 10000L)
-    public void assertRequestWithParameters() {
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertRequestWithParameters() throws InterruptedException, UnsupportedEncodingException {
         String cron = "0 * * * * ?";
         String uri = String.format("/job/myGroup/myJob?cron=%s", URLEncoder.encode(cron, "UTF-8"));
         String description = "Descriptions about this job.";
@@ -82,43 +84,59 @@ public class NettyRestfulServiceTest {
             assertThat(jobPojo.getGroup(), is("myGroup"));
             assertThat(jobPojo.getName(), is("myJob"));
             assertThat(jobPojo.getDescription(), is(description));
-        }, 10000L);
+        }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = 10000L)
-    public void assertCustomExceptionHandler() {
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertCustomExceptionHandler() throws InterruptedException {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalState");
         request.headers().set("Exception-Message", "An illegal state exception message.");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             // Handle by CustomExceptionHandler
             assertThat(httpResponse.status().code(), is(403));
-        }, 10000L);
+        }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = 10000L)
-    public void assertUsingDefaultExceptionHandler() {
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertUsingDefaultExceptionHandler() throws InterruptedException {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalArgument");
         request.headers().set("Exception-Message", "An illegal argument exception message.");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             // Handle by DefaultExceptionHandler
             assertThat(httpResponse.status().code(), is(500));
-        }, 10000L);
+        }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = 10000L)
-    public void assertReturnStatusCode() {
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertReturnStatusCode() throws InterruptedException {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/code/204");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             assertThat(httpResponse.status().code(), is(204));
-        }, 10000L);
+        }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = 10000L)
-    public void assertHandlerNotFound() {
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertHandlerNotFound() throws InterruptedException {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/not/found");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             assertThat(httpResponse.status().code(), is(404));
-        }, 10000L);
+        }, TESTCASE_TIMEOUT);
+    }
+    
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertRequestIndexWithSlash() throws InterruptedException {
+        DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
+            assertThat(httpResponse.status().code(), is(200));
+        }, TESTCASE_TIMEOUT);
+    }
+    
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertRequestIndexWithoutSlash() throws InterruptedException {
+        DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
+        HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
+            assertThat(httpResponse.status().code(), is(200));
+        }, TESTCASE_TIMEOUT);
     }
     
     @AfterClass

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
@@ -37,7 +38,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -65,8 +65,9 @@ public class NettyRestfulServiceTest {
         restfulService.startup();
     }
     
+    @SneakyThrows
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertRequestWithParameters() throws InterruptedException, UnsupportedEncodingException {
+    public void assertRequestWithParameters() {
         String cron = "0 * * * * ?";
         String uri = String.format("/job/myGroup/myJob?cron=%s", URLEncoder.encode(cron, "UTF-8"));
         String description = "Descriptions about this job.";
@@ -88,7 +89,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertCustomExceptionHandler() throws InterruptedException {
+    public void assertCustomExceptionHandler() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalState");
         request.headers().set("Exception-Message", "An illegal state exception message.");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
@@ -98,7 +99,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertUsingDefaultExceptionHandler() throws InterruptedException {
+    public void assertUsingDefaultExceptionHandler() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalArgument");
         request.headers().set("Exception-Message", "An illegal argument exception message.");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
@@ -108,7 +109,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertReturnStatusCode() throws InterruptedException {
+    public void assertReturnStatusCode() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/code/204");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             assertThat(httpResponse.status().code(), is(204));
@@ -116,7 +117,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertHandlerNotFound() throws InterruptedException {
+    public void assertHandlerNotFound() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/not/found");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
             assertThat(httpResponse.status().code(), is(404));
@@ -124,7 +125,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertRequestIndexWithSlash() throws InterruptedException {
+    public void assertRequestIndexWithSlash() {
         DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
             assertThat(httpResponse.status().code(), is(200));
@@ -132,7 +133,7 @@ public class NettyRestfulServiceTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertRequestIndexWithoutSlash() throws InterruptedException {
+    public void assertRequestIndexWithoutSlash() {
         DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
         HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
             assertThat(httpResponse.status().code(), is(200));

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashInsensitiveTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashInsensitiveTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
+import org.apache.shardingsphere.elasticjob.restful.RestfulService;
+import org.apache.shardingsphere.elasticjob.restful.controller.TrailingSlashTestController;
+import org.junit.Test;
+
+public class NettyRestfulServiceTrailingSlashInsensitiveTest {
+    
+    private static final String HOST = "localhost";
+    
+    private static final int PORT = 18082;
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertPathDuplicateWhenTrailingSlashInsensitive() {
+        NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
+        configuration.setHost(HOST);
+        configuration.addControllerInstance(new TrailingSlashTestController());
+        RestfulService restfulService = new NettyRestfulService(configuration);
+        restfulService.startup();
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import io.netty.buffer.ByteBufUtil;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
+import org.apache.shardingsphere.elasticjob.restful.RestfulService;
+import org.apache.shardingsphere.elasticjob.restful.controller.TrailingSlashTestController;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class NettyRestfulServiceTrailingSlashSensitiveTest {
+    
+    private static final long TESTCASE_TIMEOUT = 10000L;
+    
+    private static final String HOST = "localhost";
+    
+    private static final int PORT = 18081;
+    
+    private static RestfulService restfulService;
+    
+    @BeforeClass
+    public static void init() {
+        NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
+        configuration.setHost(HOST);
+        configuration.setTrailingSlashSensitive(true);
+        configuration.addControllerInstance(new TrailingSlashTestController());
+        restfulService = new NettyRestfulService(configuration);
+        restfulService.startup();
+    }
+    
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertWithoutTrailingSlash() throws InterruptedException {
+        DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash");
+        HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
+            assertThat(httpResponse.status().code(), is(200));
+            byte[] bytes = ByteBufUtil.getBytes(httpResponse.content());
+            String body = new String(bytes, StandardCharsets.UTF_8);
+            assertThat(body, is("without trailing slash"));
+        }, TESTCASE_TIMEOUT);
+    }
+    
+    @Test(timeout = TESTCASE_TIMEOUT)
+    public void assertWithTrailingSlash() throws InterruptedException {
+        DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash/");
+        HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
+            assertThat(httpResponse.status().code(), is(200));
+            byte[] bytes = ByteBufUtil.getBytes(httpResponse.content());
+            String body = new String(bytes, StandardCharsets.UTF_8);
+            assertThat(body, is("with trailing slash"));
+        }, TESTCASE_TIMEOUT);
+    }
+    
+    @AfterClass
+    public static void tearDown() {
+        if (null != restfulService) {
+            restfulService.shutdown();
+        }
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
@@ -55,7 +55,7 @@ public class NettyRestfulServiceTrailingSlashSensitiveTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertWithoutTrailingSlash() throws InterruptedException {
+    public void assertWithoutTrailingSlash() {
         DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash");
         HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
             assertThat(httpResponse.status().code(), is(200));
@@ -66,7 +66,7 @@ public class NettyRestfulServiceTrailingSlashSensitiveTest {
     }
     
     @Test(timeout = TESTCASE_TIMEOUT)
-    public void assertWithTrailingSlash() throws InterruptedException {
+    public void assertWithTrailingSlash() {
         DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash/");
         HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
             assertThat(httpResponse.status().code(), is(200));

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/CustomTextPlainResponseBodySerializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/CustomTextPlainResponseBodySerializer.java
@@ -15,32 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.restful.annotation;
+package org.apache.shardingsphere.elasticjob.restful.serializer;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import io.netty.handler.codec.http.HttpHeaderValues;
 
-/**
- * Declare what HTTP method and path is used to invoke the handler.
- */
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Mapping {
+import java.nio.charset.StandardCharsets;
+
+public final class CustomTextPlainResponseBodySerializer implements ResponseBodySerializer {
     
-    /**
-     * Http method.
-     *
-     * @return Http method
-     */
-    String method();
+    @Override
+    public String mimeType() {
+        return HttpHeaderValues.TEXT_PLAIN.toString();
+    }
     
-    /**
-     * Path pattern of this handler. Starts with '/'.
-     * Such as <code>/app/{jobName}/enable</code>.
-     *
-     * @return Path pattern
-     */
-    String path() default "";
+    @Override
+    public byte[] serialize(final Object responseBody) {
+        if (responseBody instanceof String) {
+            return ((String) responseBody).getBytes(StandardCharsets.UTF_8);
+        }
+        if (responseBody instanceof byte[]) {
+            return (byte[]) responseBody;
+        }
+        throw new UnsupportedOperationException("Can not deserialize" + responseBody.getClass());
+    }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/CustomTextPlainResponseBodySerializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/CustomTextPlainResponseBodySerializer.java
@@ -21,6 +21,9 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Serializer for <code>text/plain</code>. Serialize String to bytes.
+ */
 public final class CustomTextPlainResponseBodySerializer implements ResponseBodySerializer {
     
     @Override

--- a/elasticjob-infra/elasticjob-restful/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer
+++ b/elasticjob-infra/elasticjob-restful/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.restful.serializer.CustomTextPlainResponseBodySerializer


### PR DESCRIPTION
Ref #1284 

Trailing slash is a slash at the end of uri, like "/app/job/".
If trailing slash sensitive, "/app/job" and "/app/job/" are not equivalent. Otherwise, "/app/job" and "/app/job/" will be mapped to a same handler.
Trailing slash in insensitive by default. Developers can enable trailing slash sensitive by configuring NettyResfulServiceConfiguration.

Changes proposed in this pull request:
- Add option "trailingSlashSensitive".
- Complete testcases.
