### PR TITLE
Add WechatJobErrorHandler to support sending message

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/pom.xml
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.apache.shardingsphere.elasticjob</groupId>
+        <artifactId>elasticjob-error-handler</artifactId>
+        <version>3.0.0-beta-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>elasticjob-error-handler-wechat</artifactId>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere.elasticjob</groupId>
+            <artifactId>elasticjob-error-handler-general</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere.elasticjob</groupId>
+            <artifactId>elasticjob-restful</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.wechat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public final class WechatConfiguration {
+    
+    private final Integer defaultConnectTimeout = 1000 * 5;
+    
+    private final Integer defaultReadTimeout = 1000 * 3;
+    
+    private final String webhook;
+    
+    private final Integer connectTimeout;
+    
+    private final Integer readTimeout;
+    
+    /**
+     * Get connect timeout config or default value.
+     *
+     * @return connect timeout value
+     */
+    public Integer getConnectTimeoutOrDefault() {
+        if (null == connectTimeout) {
+            return defaultConnectTimeout;
+        }
+        return connectTimeout;
+    }
+    
+    /**
+     * Get read timeout config or default value.
+     *
+     * @return read timeout value
+     */
+    public Integer getReadTimeoutOrDefault() {
+        if (null == readTimeout) {
+            return defaultReadTimeout;
+        }
+        return readTimeout;
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandler.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandler.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.wechat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandler;
+import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
+import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
+
+/**
+ * Job error handler for wechat error message.
+ */
+@Slf4j
+public final class WechatJobErrorHandler implements JobErrorHandler {
+    
+    private static final String CONFIG_PREFIX = "wechat";
+    
+    private static final String ERROR_HANDLER_CONFIG = "conf/error-handler-wechat.yaml";
+    
+    @Setter
+    private WechatConfiguration wechatConfiguration;
+    
+    private final CloseableHttpClient httpclient = HttpClients.createDefault();
+    
+    public WechatJobErrorHandler() {
+        registerShutdownHook();
+    }
+    
+    @Override
+    public void handleException(final String jobName, final Throwable cause) {
+        if (null == wechatConfiguration) {
+            InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(ERROR_HANDLER_CONFIG);
+            wechatConfiguration = YamlEngine.unmarshal(CONFIG_PREFIX, inputStream, WechatConfiguration.class);
+        }
+        HttpPost httpPost = new HttpPost(getUrl());
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(wechatConfiguration.getConnectTimeoutOrDefault())
+                .setSocketTimeout(wechatConfiguration.getReadTimeoutOrDefault())
+                .build();
+        httpPost.setConfig(requestConfig);
+        StringEntity entity = new StringEntity(getParamJson(getMsg(jobName, cause)), StandardCharsets.UTF_8);
+        entity.setContentEncoding(StandardCharsets.UTF_8.name());
+        entity.setContentType("application/json");
+        httpPost.setEntity(entity);
+        try (CloseableHttpResponse response = httpclient.execute(httpPost)) {
+            int status = response.getStatusLine().getStatusCode();
+            if (HttpURLConnection.HTTP_OK == status) {
+                JsonObject resp = GsonFactory.getGson().fromJson(EntityUtils.toString(response.getEntity()), JsonObject.class);
+                if (!"0".equals(resp.get("errcode").getAsString())) {
+                    log.error("An exception has occurred in Job '{}', But failed to send alert by wechat because of: {}", jobName, resp.get("errmsg").getAsString(), cause);
+                } else {
+                    log.error("An exception has occurred in Job '{}', Notification to wechat was successful.", jobName, cause);
+                }
+            } else {
+                log.error("An exception has occurred in Job '{}', But failed to send alert by wechat because of: Unexpected response status: {}", jobName, status, cause);
+            }
+        } catch (IOException ex) {
+            log.error("An exception has occurred in Job '{}', But failed to send alert by wechat because of", jobName, ex);
+        }
+    }
+    
+    private String getParamJson(final String msg) {
+        return GsonFactory.getGson().toJson(ImmutableMap.of(
+                "msgtype", "text", "text", Collections.singletonMap("content", msg)
+        ));
+    }
+    
+    private String getMsg(final String jobName, final Throwable cause) {
+        StringWriter sw = new StringWriter();
+        cause.printStackTrace(new PrintWriter(sw, true));
+        return String.format("Job '%s' exception occur in job processing, caused by %s", jobName, sw.toString());
+    }
+    
+    private String getUrl() {
+        String webhook = wechatConfiguration.getWebhook();
+        if (Objects.isNull(webhook)) {
+            throw new RuntimeException("Please specify the wechat webhook address");
+        }
+        return webhook;
+    }
+    
+    @Override
+    public String getType() {
+        return "WECHAT";
+    }
+    
+    private void registerShutdownHook() {
+        Thread t = new Thread("WechatJobErrorHandler Shutdown-Hook") {
+            @SneakyThrows
+            @Override
+            public void run() {
+                log.info("Shutting down httpclient...");
+                httpclient.close();
+            }
+        };
+        Runtime.getRuntime().addShutdownHook(t);
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/resources/META-INF.services/org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandler
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/resources/META-INF.services/org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandler
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.error.handler.wechat.WechatJobErrorHandler

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/resources/conf/error-handler-wechat.yaml
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/main/resources/conf/error-handler-wechat.yaml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+wechat:
+  webhook:
+  connectTimeout:
+  readTimeout:

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.wechat;
+
+import lombok.SneakyThrows;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.apache.shardingsphere.elasticjob.error.handler.wechat.fixture.WechatInternalController;
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
+import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
+import org.apache.shardingsphere.elasticjob.restful.RestfulService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class WechatJobErrorHandlerTest {
+    
+    private static final int PORT = 9876;
+    
+    private static final String HOST = "localhost";
+    
+    private static RestfulService restfulService;
+    
+    @Mock
+    private Logger log;
+    
+    @BeforeClass
+    public static void init() {
+        NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
+        configuration.setHost(HOST);
+        configuration.addControllerInstance(new WechatInternalController());
+        restfulService = new NettyRestfulService(configuration);
+        restfulService.startup();
+    }
+    
+    @Test
+    public void assertHandleExceptionWithNotifySuccessful() {
+        WechatJobErrorHandler actual = new WechatJobErrorHandler();
+        setStaticFieldValue(actual);
+        Throwable cause = new RuntimeException("test");
+        actual.handleException("test_job", cause);
+        verify(log).error("An exception has occurred in Job '{}', Notification to wechat was successful.", "test_job", cause);
+    }
+    
+    @Test
+    public void assertHandleExceptionWithWrongToken() {
+        WechatJobErrorHandler actual = new WechatJobErrorHandler();
+        actual.setWechatConfiguration(new WechatConfiguration(getHost() + "/send?key=wrongToken", 3000, 500));
+        setStaticFieldValue(actual);
+        Throwable cause = new RuntimeException("test");
+        actual.handleException("test_job", cause);
+        verify(log).error("An exception has occurred in Job '{}', But failed to send alert by wechat because of: {}", "test_job", "token is invalid", cause);
+    }
+    
+    @Test
+    public void assertHandleExceptionWithWrongUrl() {
+        WechatJobErrorHandler actual = new WechatJobErrorHandler();
+        actual.setWechatConfiguration(new WechatConfiguration(getHost() + "/404?access_token=wrongToken", 3000, 500));
+        setStaticFieldValue(actual);
+        Throwable cause = new RuntimeException("test");
+        actual.handleException("test_job", cause);
+        verify(log).error("An exception has occurred in Job '{}', But failed to send alert by wechat because of: Unexpected response status: {}", "test_job", 404, cause);
+    }
+    
+    @Test
+    public void assertGetType() {
+        WechatJobErrorHandler actual = new WechatJobErrorHandler();
+        assertThat(actual.getType(), is("WECHAT"));
+    }
+    
+    @SneakyThrows
+    private void setStaticFieldValue(final WechatJobErrorHandler wechatJobErrorHandler) {
+        Field field = wechatJobErrorHandler.getClass().getDeclaredField("log");
+        field.setAccessible(true);
+        Field modifiers = field.getClass().getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(wechatJobErrorHandler, log);
+    }
+    
+    private String getHost() {
+        return String.format("http://%s:%s", HOST, PORT);
+    }
+    
+    @AfterClass
+    public static void close() {
+        if (null != restfulService) {
+            restfulService.shutdown();
+        }
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/fixture/WechatInternalController.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/fixture/WechatInternalController.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.wechat.fixture;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
+import org.apache.shardingsphere.elasticjob.restful.Http;
+import org.apache.shardingsphere.elasticjob.restful.RestfulController;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
+import org.apache.shardingsphere.elasticjob.restful.annotation.Param;
+import org.apache.shardingsphere.elasticjob.restful.annotation.ParamSource;
+
+@Slf4j
+public final class WechatInternalController implements RestfulController {
+    
+    private static final String KEY = "TLQEC0cPivqV1MkT0IPMtzunTBBVyIV3";
+    
+    /**
+     * Send wechat message.
+     *
+     * @param key access token
+     * @return Send Result.
+     */
+    @SneakyThrows
+    @Mapping(method = Http.POST, path = "/send")
+    public String send(@Param(name = "key", source = ParamSource.QUERY) final String key) {
+        if (!KEY.equals(key)) {
+            return GsonFactory.getGson().toJson(ImmutableMap.of("errcode", 1, "errmsg", "token is invalid"));
+        }
+        return GsonFactory.getGson().toJson(ImmutableMap.of("errcode", 0, "errmsg", "ok"));
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/resources/conf/error-handler-wechat.yaml
+++ b/elasticjob-error-handler/elasticjob-error-handler-wechat/src/test/resources/conf/error-handler-wechat.yaml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+wechat:
+  webhook: http://localhost:9876/send?key=TLQEC0cPivqV1MkT0IPMtzunTBBVyIV3
+  connectTimeout: 5000
+  readTimeout: 3000
+
+

--- a/elasticjob-error-handler/pom.xml
+++ b/elasticjob-error-handler/pom.xml
@@ -34,5 +34,6 @@
         <module>elasticjob-error-handler-email</module>
         <module>elasticjob-error-handler-sms</module>
         <module>elasticjob-error-handler-dingtalk</module>
+        <module>elasticjob-error-handler-wechat</module>
     </modules>
 </project>


### PR DESCRIPTION
Fixes #1461.

Changes proposed in this pull request:
- create a new module - elasticjob-error-handler/elasticjob-error-handler-wechat.
- load config from specified conf.
- use http-client pool to send messages.
