### PR TITLE
Support system properties as config for email error handler and updat…

### DIFF
--- a/docs/content/dev-manual/error-handler.cn.md
+++ b/docs/content/dev-manual/error-handler.cn.md
@@ -14,6 +14,7 @@ weight = 3
 | --------------------- | ------------------------------ |
 | LogJobErrorHandler    | 记录作业异常日志，但不中断作业执行 |
 | DingtalkJobErrorHandler | 记录作业异常日志，但不中断作业执行，并且发送钉钉消息通知 |
+| EmailJobErrorHandler | 记录作业异常日志，但不中断作业执行，并且发送邮件消息通知 |
 | ThrowJobErrorHandler  | 抛出系统异常并中断作业执行        |
 | IgnoreJobErrorHandler | 忽略系统异常且不中断作业执行      |
 | WechatJobErrorHandler | 记录作业异常日志，但不中断作业执行，并且发送企业微信消息通知 |

--- a/docs/content/dev-manual/error-handler.en.md
+++ b/docs/content/dev-manual/error-handler.en.md
@@ -14,6 +14,7 @@ Error handler strategy, used to handle error when exception occur during job exe
 | ---------------------- | ----------------------------------------- |
 | LogJobErrorHandler     | Log error and do not interrupt job        |
 | DingtalkJobErrorHandler  | Log error and do not interrupt job and send dingtalk message notification |
+| EmailJobErrorHandler | Log error and do not interrupt job and send email message notification |
 | ThrowJobErrorHandler   | Throw system exception and interrupt job  |
 | IgnoreJobErrorHandler  | Ignore exception and do not interrupt job |
 | WechatJobErrorHandler  | Log error and do not interrupt job and send wechat message notification |

--- a/elasticjob-error-handler/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/ConfigurationLoader.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/ConfigurationLoader.java
@@ -29,18 +29,42 @@ import java.io.InputStream;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConfigurationLoader {
     
-    private static final String ERROR_HANDLER_CONFIG = "error-handler-email.yaml";
+    private static final String ERROR_HANDLER_CONFIG = "conf/error-handler-email.yaml";
     
     /**
      * Unmarshal YAML.
      *
      * @param prefix    config prefix
-     * @param classType class type
-     * @param <T>       type of class
      * @return object from YAML
      */
-    public static <T> T buildConfigByYaml(final String prefix, final Class<T> classType) {
+    public static EmailConfiguration buildConfigByYaml(final String prefix) {
         InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(ERROR_HANDLER_CONFIG);
-        return YamlEngine.unmarshal(prefix, inputStream, classType);
+        return YamlEngine.unmarshal(prefix, inputStream, EmailConfiguration.class);
+    }
+    
+    /**
+     * read system properties.
+     *
+     * @return object from system properties
+     */
+    public static EmailConfiguration buildConfigBySystemProperties() {
+        String isBySystemProperties = System.getProperty("error-handler-email.use-system-properties");
+        if (!Boolean.valueOf(isBySystemProperties)) {
+            return null;
+        }
+        EmailConfiguration emailConfiguration = new EmailConfiguration();
+        emailConfiguration.setHost(System.getProperty("error-handler-email.host"));
+        emailConfiguration.setUsername(System.getProperty("error-handler-email.username"));
+        emailConfiguration.setPassword(System.getProperty("error-handler-email.password"));
+        emailConfiguration.setProtocol(System.getProperty("error-handler-email.protocol"));
+        emailConfiguration.setFrom(System.getProperty("error-handler-email.from"));
+        emailConfiguration.setTo(System.getProperty("error-handler-email.to"));
+        emailConfiguration.setCc(System.getProperty("error-handler-email.cc"));
+        emailConfiguration.setBcc(System.getProperty("error-handler-email.bcc"));
+        String port = System.getProperty("error-handler-email.port");
+        if (null != port) {
+            emailConfiguration.setPort(Integer.valueOf(port));
+        }
+        return emailConfiguration;
     }
 }

--- a/elasticjob-error-handler/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandler.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandler.java
@@ -68,7 +68,7 @@ public final class EmailJobErrorHandler implements JobErrorHandler {
     }
     
     private void loadConfiguration() {
-        emailConfiguration = ConfigurationLoader.buildConfigByYaml(CONFIG_PREFIX, EmailConfiguration.class);
+        emailConfiguration = ConfigurationLoader.buildConfigByYaml(CONFIG_PREFIX);
     }
     
     @Override

--- a/elasticjob-error-handler/elasticjob-error-handler-email/src/main/resources/conf/error-handler-email.yaml
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/src/main/resources/conf/error-handler-email.yaml
@@ -16,11 +16,12 @@
 #
 
 email:
-  host: test.mail.com
-  port: 123
+  host: xxx
+  port: xxx
   username: username
   password: password
   protocol: smtp
-  from: testmail@qiyi.com
-  to: xxx1@ejob.com
-  cc: xxx2@ejob.com
+  from: xxx
+  to: xxx
+  cc: xxx
+  bcc: xxx

--- a/elasticjob-error-handler/elasticjob-error-handler-email/src/test/resources/conf/error-handler-email.yaml
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/src/test/resources/conf/error-handler-email.yaml
@@ -16,11 +16,11 @@
 #
 
 email:
-  host: xxx
-  port: xxx
+  host: test.mail.com
+  port: 123
   username: username
   password: password
   protocol: smtp
-  from: xxx
-  to: xxx
-  cc: xxx
+  from: testmail@ejob.com
+  to: xxx1@ejob.com
+  cc: xxx2@ejob.com

--- a/examples/elasticjob-example-lite-java/src/main/resources/conf/error-handler-email.yaml
+++ b/examples/elasticjob-example-lite-java/src/main/resources/conf/error-handler-email.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+email:
+  host: 
+  port: 
+  username: 
+  password: 
+  protocol: 
+  from: 
+  to: 
+  cc: 
+  bcc: 


### PR DESCRIPTION
Fixes #1486 .

Changes proposed in this pull request:
- Move error-handler-email.yaml to resources/conf.
- Support system properties as config.
- Update the relative doc.
