### PR TITLE
Mock Transport in email testcases to reduce test time

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-email/pom.xml
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/pom.xml
@@ -27,7 +27,11 @@
     </parent>
     
     <artifactId>elasticjob-error-handler-email</artifactId>
-    
+
+    <properties>
+        <powermock.version>1.7.0RC4</powermock.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
@@ -55,10 +59,25 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-        
+
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/elasticjob-error-handler/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
@@ -22,16 +22,24 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
+
+import javax.mail.Message;
+import javax.mail.Transport;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@PrepareForTest(Transport.class)
+@RunWith(PowerMockRunner.class)
 public final class EmailJobErrorHandlerTest {
         
     @Mock
@@ -41,8 +49,11 @@ public final class EmailJobErrorHandlerTest {
     @SneakyThrows
     public void assertHandleExceptionWithYAMLConfiguration() {
         resetSystemProperties();
+        PowerMockito.mockStatic(Transport.class);
         EmailJobErrorHandler emailJobErrorHandler = new EmailJobErrorHandler();
         emailJobErrorHandler.handleException("test job name", new RuntimeException("test exception"));
+        PowerMockito.verifyStatic();
+        Transport.send(Mockito.any(Message.class));
         Field field = emailJobErrorHandler.getClass().getDeclaredField("emailConfiguration");
         field.setAccessible(true);
         EmailConfiguration emailConfiguration = (EmailConfiguration) field.get(emailJobErrorHandler);
@@ -61,8 +72,11 @@ public final class EmailJobErrorHandlerTest {
     @SneakyThrows
     public void assertHandleExceptionWithSystemPropertiesConfiguration() {
         initSystemProperties();
+        PowerMockito.mockStatic(Transport.class);
         EmailJobErrorHandler emailJobErrorHandler = new EmailJobErrorHandler();
         emailJobErrorHandler.handleException("test job name", new RuntimeException("test exception"));
+        PowerMockito.verifyStatic();
+        Transport.send(Mockito.any(Message.class));
         Field field = emailJobErrorHandler.getClass().getDeclaredField("emailConfiguration");
         field.setAccessible(true);
         EmailConfiguration emailConfiguration = (EmailConfiguration) field.get(emailJobErrorHandler);


### PR DESCRIPTION
Fixes #1504 .

Changes proposed in this pull request:
- Use PowerMock to mock 'Transport.send()' method.
