### PR TITLE
Skip time different checking when maxTimeDiffSeconds is negative

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationService.java
@@ -94,7 +94,7 @@ public final class ConfigurationService {
      */
     public void checkMaxTimeDiffSecondsTolerable() throws JobExecutionEnvironmentException {
         int maxTimeDiffSeconds = load(true).getMaxTimeDiffSeconds();
-        if (-1 == maxTimeDiffSeconds) {
+        if (0 > maxTimeDiffSeconds) {
             return;
         }
         long timeDiff = Math.abs(timeService.getCurrentMillis() - jobNodeStorage.getRegistryCenterTime());


### PR DESCRIPTION
Fixes #1540 

Changes proposed in this pull request:
- Skip time different checking when maxTimeDiffSeconds is negative.