### PR TITLE
Redesign SPI factory to make them into one class (#1537)

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
@@ -33,7 +33,7 @@ public final class JobErrorHandlerFactory {
     private static final String DEFAULT_HANDLER = "LOG";
     
     static {
-        ElasticJobServiceLoader.register(JobErrorHandler.class);
+        ElasticJobServiceLoader.registerTypedService(JobErrorHandler.class);
     }
     
     /**
@@ -48,8 +48,8 @@ public final class JobErrorHandlerFactory {
         }
         return newHandlerInstance(type);
     }
-    
+
     private static Optional<JobErrorHandler> newHandlerInstance(final String type) {
-        return ElasticJobServiceLoader.newServiceInstances(JobErrorHandler.class).stream().filter(handler -> handler.getType().equalsIgnoreCase(type)).findFirst();
+        return Optional.of(ElasticJobServiceLoader.newTypedServiceInstance(JobErrorHandler.class, type));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
@@ -20,26 +20,18 @@ package org.apache.shardingsphere.elasticjob.infra.handler.sharding;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.ServiceLoader;
+import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
 /**
  * Job sharding sharding factory.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JobShardingStrategyFactory {
-    
-    private static final Map<String, JobShardingStrategy> STRATEGIES = new LinkedHashMap<>();
-    
+
     private static final String DEFAULT_STRATEGY = "AVG_ALLOCATION";
     
     static {
-        for (JobShardingStrategy each : ServiceLoader.load(JobShardingStrategy.class)) {
-            STRATEGIES.put(each.getType(), each);
-        }
+        ElasticJobServiceLoader.registerTypedService(JobShardingStrategy.class);
     }
     
     /**
@@ -50,11 +42,8 @@ public final class JobShardingStrategyFactory {
      */
     public static JobShardingStrategy getStrategy(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return STRATEGIES.get(DEFAULT_STRATEGY);
+            return ElasticJobServiceLoader.getCachedInstance(JobShardingStrategy.class, DEFAULT_STRATEGY);
         }
-        if (!STRATEGIES.containsKey(type)) {
-            throw new JobConfigurationException("Can not find sharding sharding type '%s'.", type);
-        }
-        return STRATEGIES.get(type);
+        return ElasticJobServiceLoader.getCachedInstance(JobShardingStrategy.class, type);
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
@@ -20,26 +20,18 @@ package org.apache.shardingsphere.elasticjob.infra.handler.threadpool;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.ServiceLoader;
+import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
 /**
  * Job executor service handler factory.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JobExecutorServiceHandlerFactory {
-    
-    private static final Map<String, JobExecutorServiceHandler> HANDLERS = new LinkedHashMap<>();
-    
+
     private static final String DEFAULT_HANDLER = "CPU";
     
     static {
-        for (JobExecutorServiceHandler each : ServiceLoader.load(JobExecutorServiceHandler.class)) {
-            HANDLERS.put(each.getType(), each);
-        }
+        ElasticJobServiceLoader.registerTypedService(JobExecutorServiceHandler.class);
     }
     
     /**
@@ -50,11 +42,8 @@ public final class JobExecutorServiceHandlerFactory {
      */
     public static JobExecutorServiceHandler getHandler(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return HANDLERS.get(DEFAULT_HANDLER);
+            return ElasticJobServiceLoader.getCachedInstance(JobExecutorServiceHandler.class, DEFAULT_HANDLER);
         }
-        if (!HANDLERS.containsKey(type)) {
-            throw new JobConfigurationException("Can not find executor service handler type '%s'.", type);
-        }
-        return HANDLERS.get(type);
+        return ElasticJobServiceLoader.getCachedInstance(JobExecutorServiceHandler.class, type);
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactory.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 public final class ElasticJobListenerFactory {
     
     static {
-        ElasticJobServiceLoader.register(ElasticJobListener.class);
+        ElasticJobServiceLoader.registerTypedService(ElasticJobListener.class);
     }
     
     /**
@@ -40,6 +40,6 @@ public final class ElasticJobListenerFactory {
      * @return optional job listener instance
      */
     public static Optional<ElasticJobListener> createListener(final String type) {
-        return ElasticJobServiceLoader.newServiceInstances(ElasticJobListener.class).stream().filter(listener -> listener.getType().equalsIgnoreCase(type)).findFirst();
+        return Optional.of(ElasticJobServiceLoader.newTypedServiceInstance(ElasticJobListener.class, type));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.elasticjob.infra.spi;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.spi.exception.ServiceLoaderInstantiationException;
 
 import java.lang.reflect.InvocationTargetException;
@@ -38,6 +39,10 @@ public final class ElasticJobServiceLoader {
     
     private static final ConcurrentMap<Class<?>, Collection<Class<?>>> SERVICES = new ConcurrentHashMap<>();
     
+    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, TypedSPI>> TYPED_SERVICES = new ConcurrentHashMap<>();
+
+    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, Class<?>>> TYPED_SERVICE_CLASSES = new ConcurrentHashMap<>();
+
     /**
      * Register SPI service.
      *
@@ -76,4 +81,59 @@ public final class ElasticJobServiceLoader {
             throw new ServiceLoaderInstantiationException(clazz, ex.getCause());
         }
     }
+
+    /**
+     * Register typeSPI service.
+     *
+     * @param typedService specific service type
+     * @param <T> type of service
+     */
+    public static <T> void registerTypedService(final Class<T> typedService) {
+        if (!TypedSPI.class.isAssignableFrom(typedService)) {
+            throw new IllegalArgumentException("Cannot register @" + typedService.getName() + "as a typed service, because its not a subClass of @" + typedService);
+        }
+        if (TYPED_SERVICES.containsKey(typedService)) {
+            return;
+        }
+        ServiceLoader.load(typedService).forEach(each -> registerTypedServiceClass(typedService, (TypedSPI) each));
+    }
+
+    private static <T> void registerTypedServiceClass(final Class<T> typedService, final TypedSPI instance) {
+        TYPED_SERVICES.computeIfAbsent(typedService, unused -> new ConcurrentHashMap<>()).putIfAbsent(instance.getType(), instance);
+        TYPED_SERVICE_CLASSES.computeIfAbsent(typedService, unused -> new ConcurrentHashMap<>()).putIfAbsent(instance.getType(), instance.getClass());
+    }
+
+    /**
+     * Get cached instance.
+     *
+     * @param typedService service type
+     * @param type         specific service type
+     * @param <T>          specific type of service
+     * @return cached service instance
+     */
+    public static <T extends TypedSPI> T getCachedInstance(final Class<T> typedService, final String type) {
+        T instance = TYPED_SERVICES.containsKey(typedService) ? (T) TYPED_SERVICES.get(typedService).get(type) : null;
+        if (instance == null) {
+            throw new JobConfigurationException("Cannot find a cached typed service instance by the interface: @" + typedService.getName() + "and type: " + type);
+        }
+        return instance;
+    }
+
+    /**
+     * New typed instance.
+     *
+     * @param typedService service type
+     * @param type         specific service type
+     * @param <T>          specific type of service
+     * @return specific typed service instance
+     */
+    public static <T extends TypedSPI> T newTypedServiceInstance(final Class<T> typedService, final String type) {
+        Class<?> instanceClass = TYPED_SERVICE_CLASSES.containsKey(typedService) ? TYPED_SERVICE_CLASSES.get(typedService).get(type) : null;
+        if (instanceClass == null) {
+            throw new JobConfigurationException("Cannot find a typed service class by the interface: @" + typedService.getName() + "and type: " + type);
+        }
+        return (T) newServiceInstance(instanceClass);
+    }
+
 }
+


### PR DESCRIPTION
Fixes #1537.

Changes proposed in this pull request:

   Redesign SPI factory to make logic about their TypedSPI into ElasticJobServiceLoader. The SPI factory class are:
- `JobShardingStrategyFactory`
- `JobExecutorServiceHandlerFactory`
- `JobErrorHandlerFactory`
- `ElasticJobListenerFactory`

The situation of `JobItemExecutorFactory `is a bit complicated and will be completed in subsequent work.
