### PR TITLE
Trim suffix of lambda class name when using lambda expression implementation of ElasticJob

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/DefaultJobClassNameProvider.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/DefaultJobClassNameProvider.java
@@ -22,10 +22,20 @@ import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 /**
  * Simple job class name provider.
  */
-public final class SimpleJobClassNameProvider implements JobClassNameProvider {
+public final class DefaultJobClassNameProvider implements JobClassNameProvider {
     
     @Override
     public String getJobClassName(final ElasticJob elasticJob) {
-        return elasticJob.getClass().getName();
+        Class<? extends ElasticJob> elasticJobClass = elasticJob.getClass();
+        String elasticJobClassName = elasticJobClass.getName();
+        return isLambdaClass(elasticJobClass) ? trimLambdaClassSuffix(elasticJobClassName) : elasticJobClassName;
+    }
+    
+    private boolean isLambdaClass(final Class<? extends ElasticJob> elasticJobClass) {
+        return elasticJobClass.isSynthetic() && elasticJobClass.getSimpleName().contains("$$Lambda$");
+    }
+    
+    private String trimLambdaClassSuffix(final String className) {
+        return className.split("/")[0];
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactory.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactory.java
@@ -32,7 +32,7 @@ public final class JobClassNameProviderFactory {
     
     private static final List<JobClassNameProvider> PROVIDERS = new LinkedList<>();
     
-    private static final JobClassNameProvider DEFAULT_PROVIDER = new SimpleJobClassNameProvider();
+    private static final JobClassNameProvider DEFAULT_PROVIDER = new DefaultJobClassNameProvider();
     
     static {
         for (JobClassNameProvider each : ServiceLoader.load(JobClassNameProvider.class)) {

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactoryTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactoryTest.java
@@ -26,6 +26,6 @@ public final class JobClassNameProviderFactoryTest {
     
     @Test
     public void assertGetDefaultStrategy() {
-        assertThat(JobClassNameProviderFactory.getProvider(), instanceOf(SimpleJobClassNameProvider.class));
+        assertThat(JobClassNameProviderFactory.getProvider(), instanceOf(DefaultJobClassNameProvider.class));
     }
 }


### PR DESCRIPTION
Fixes #1551 .

Changes proposed in this pull request:
- Rename SimpleJobClassNameProvider to DefaultJobClassNameProvider.
- Trim suffix of lambda class name when using lambda expression implementation of ElasticJob.
