### PR TITLE
Remove protocol from EmailConfiguration and use SMTP as default protocol

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
@@ -37,8 +37,6 @@ public final class EmailConfiguration {
     
     private String password;
     
-    private String protocol;
-    
     private boolean useSsl;
     
     private String subject;
@@ -63,7 +61,6 @@ public final class EmailConfiguration {
         EmailConfiguration configuration = new EmailConfiguration();
         configuration.setHost(props.getProperty(EmailConstants.EMAIL_HOST));
         configuration.setPort(Integer.parseInt(props.getProperty(EmailConstants.EMAIL_PORT)));
-        configuration.setProtocol(props.getProperty(EmailConstants.EMAIL_PROTOCOL));
         configuration.setUsername(props.getProperty(EmailConstants.EMAIL_USERNAME));
         configuration.setPassword(props.getProperty(EmailConstants.EMAIL_PASSWORD));
         configuration.setUseSsl(Boolean.parseBoolean(props.getOrDefault(EmailConstants.EMAIL_USE_SSL, Boolean.FALSE.toString()).toString()));

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConstants.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConstants.java
@@ -29,8 +29,6 @@ public final class EmailConstants {
     
     public static final String EMAIL_PASSWORD = PREFIX + "password";
     
-    public static final String EMAIL_PROTOCOL = PREFIX + "protocol";
-    
     public static final String EMAIL_USE_SSL = PREFIX + "useSsl";
     
     public static final String EMAIL_SUBJECT = PREFIX + "subject";

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandler.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandler.java
@@ -60,7 +60,7 @@ public final class EmailJobErrorHandler implements JobErrorHandler {
         result.put("mail.smtp.host", emailConfiguration.getHost());
         result.put("mail.smtp.port", emailConfiguration.getPort());
         result.put("mail.smtp.auth", "true");
-        result.put("mail.transport.protocol", emailConfiguration.getProtocol());
+        result.put("mail.transport.protocol", "smtp");
         result.setProperty("mail.debug", Boolean.toString(emailConfiguration.isDebug()));
         if (emailConfiguration.isUseSsl()) {
             result.setProperty("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
@@ -63,7 +63,6 @@ public final class EmailJobErrorHandlerTest {
                 .setProperty(EmailConstants.EMAIL_PORT, "465")
                 .setProperty(EmailConstants.EMAIL_USERNAME, "xxx")
                 .setProperty(EmailConstants.EMAIL_PASSWORD, "xxx")
-                .setProperty(EmailConstants.EMAIL_PROTOCOL, "smtp")
                 .setProperty(EmailConstants.EMAIL_USE_SSL, "true")
                 .setProperty(EmailConstants.EMAIL_SUBJECT, "Unit test notification")
                 .setProperty(EmailConstants.EMAIL_FROM, "from@xxx.com")

--- a/examples/elasticjob-example-lite-java/src/main/java/org/apache/shardingsphere/elasticjob/lite/example/JavaMain.java
+++ b/examples/elasticjob-example-lite-java/src/main/java/org/apache/shardingsphere/elasticjob/lite/example/JavaMain.java
@@ -163,7 +163,6 @@ public final class JavaMain {
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_PORT, "465");
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_USERNAME, "username");
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_PASSWORD, "password");
-        jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_PROTOCOL, "smtp");
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_USE_SSL, "true");
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_SUBJECT, "Test elasticJob error message");
         jobConfiguration.getProps().setProperty(EmailConstants.EMAIL_FROM, "from@xxx.com");


### PR DESCRIPTION
Fixes #1561 

Changes proposed in this pull request:
- Remove 'protocol' from EmailConfiguration.
- Set 'smtp' as default protocol of email error handler.
