### PR TITLE
Revert "Bump junit from 4.12 to 4.13.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         
         <mysql-connector-java.version>8.0.16</mysql-connector-java.version>
         <h2.version>1.4.184</h2.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.12</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>2.7.21</mockito.version>
         


### PR DESCRIPTION
Reverts apache/shardingsphere-elasticjob#1556

Revert because assertThat is deprecated in new version, we have no time to update the assertion API at this time.