### PR TITLE
Refactor ElasticJobServiceLoader, remove unused code and use Optional  instead of throw JobConfigurationException

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
@@ -44,12 +44,8 @@ public final class JobErrorHandlerFactory {
      */
     public static Optional<JobErrorHandler> createHandler(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return newHandlerInstance(DEFAULT_HANDLER);
+            return ElasticJobServiceLoader.newTypedServiceInstance(JobErrorHandler.class, DEFAULT_HANDLER);
         }
-        return newHandlerInstance(type);
-    }
-    
-    private static Optional<JobErrorHandler> newHandlerInstance(final String type) {
-        return Optional.of(ElasticJobServiceLoader.newTypedServiceInstance(JobErrorHandler.class, type));
+        return ElasticJobServiceLoader.newTypedServiceInstance(JobErrorHandler.class, type);
     }
 }

--- a/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/item/JobItemExecutorFactory.java
+++ b/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/item/JobItemExecutorFactory.java
@@ -67,6 +67,7 @@ public final class JobItemExecutorFactory {
      * @return job item executor
      */
     public static JobItemExecutor getExecutor(final String elasticJobType) {
-        return ElasticJobServiceLoader.getCachedInstance(TypedJobItemExecutor.class, elasticJobType);
+        return ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedJobItemExecutor.class, elasticJobType)
+                .orElseThrow(() -> new JobConfigurationException("Cannot find executor for elastic job type `%s`", elasticJobType));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.infra.handler.sharding;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
 /**
@@ -42,8 +43,11 @@ public final class JobShardingStrategyFactory {
      */
     public static JobShardingStrategy getStrategy(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return ElasticJobServiceLoader.getCachedInstance(JobShardingStrategy.class, DEFAULT_STRATEGY);
+            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobShardingStrategy.class, DEFAULT_STRATEGY)
+                    .orElseThrow(() -> new JobConfigurationException("The parameter named 'type' is null or empty," 
+                            + " and cannot find default sharding strategy using default type '%s'.", DEFAULT_STRATEGY));
         }
-        return ElasticJobServiceLoader.getCachedInstance(JobShardingStrategy.class, type);
+        return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobShardingStrategy.class, type)
+                .orElseThrow(() -> new JobConfigurationException("Cannot find sharding strategy using type '%s'.", type));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactory.java
@@ -43,9 +43,7 @@ public final class JobShardingStrategyFactory {
      */
     public static JobShardingStrategy getStrategy(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobShardingStrategy.class, DEFAULT_STRATEGY)
-                    .orElseThrow(() -> new JobConfigurationException("The parameter named 'type' is null or empty," 
-                            + " and cannot find default sharding strategy using default type '%s'.", DEFAULT_STRATEGY));
+            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobShardingStrategy.class, DEFAULT_STRATEGY).get();
         }
         return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobShardingStrategy.class, type)
                 .orElseThrow(() -> new JobConfigurationException("Cannot find sharding strategy using type '%s'.", type));

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.infra.handler.threadpool;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
 /**
@@ -42,8 +43,11 @@ public final class JobExecutorServiceHandlerFactory {
      */
     public static JobExecutorServiceHandler getHandler(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return ElasticJobServiceLoader.getCachedInstance(JobExecutorServiceHandler.class, DEFAULT_HANDLER);
+            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobExecutorServiceHandler.class, DEFAULT_HANDLER)
+                    .orElseThrow(() -> new JobConfigurationException("The parameter named 'type' is null or empty," 
+                            + " and cannot find default executor service handler using default type '%s'.", DEFAULT_HANDLER));
         }
-        return ElasticJobServiceLoader.getCachedInstance(JobExecutorServiceHandler.class, type);
+        return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobExecutorServiceHandler.class, type)
+                .orElseThrow(() -> new JobConfigurationException("Cannot find executor service handler using type '%s'.", type));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
@@ -43,9 +43,7 @@ public final class JobExecutorServiceHandlerFactory {
      */
     public static JobExecutorServiceHandler getHandler(final String type) {
         if (Strings.isNullOrEmpty(type)) {
-            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobExecutorServiceHandler.class, DEFAULT_HANDLER)
-                    .orElseThrow(() -> new JobConfigurationException("The parameter named 'type' is null or empty," 
-                            + " and cannot find default executor service handler using default type '%s'.", DEFAULT_HANDLER));
+            return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobExecutorServiceHandler.class, DEFAULT_HANDLER).get();
         }
         return ElasticJobServiceLoader.getCachedTypedServiceInstance(JobExecutorServiceHandler.class, type)
                 .orElseThrow(() -> new JobConfigurationException("Cannot find executor service handler using type '%s'.", type));

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactory.java
@@ -40,6 +40,6 @@ public final class ElasticJobListenerFactory {
      * @return optional job listener instance
      */
     public static Optional<ElasticJobListener> createListener(final String type) {
-        return Optional.ofNullable(ElasticJobServiceLoader.newTypedServiceInstance(ElasticJobListener.class, type));
+        return ElasticJobServiceLoader.newTypedServiceInstance(ElasticJobListener.class, type);
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
@@ -40,8 +40,8 @@ public final class ElasticJobServiceLoader {
     /**
      * Register typeSPI service.
      *
-     * @param typedService specific service type
-     * @param <T> type of service
+     * @param typedService typed service
+     * @param <T> class of service
      */
     public static <T extends TypedSPI> void registerTypedService(final Class<T> typedService) {
         if (TYPED_SERVICES.containsKey(typedService)) {
@@ -56,12 +56,12 @@ public final class ElasticJobServiceLoader {
     }
 
     /**
-     * Get cached instance.
+     * Get cached typed instance.
      *
      * @param typedServiceInterface typed service interface
-     * @param type         specific service type
-     * @param <T>          specific type of service
-     * @return cached service instance
+     * @param type type
+     * @param <T> class of service
+     * @return cached typed service instance
      */
     public static <T extends TypedSPI> Optional<T> getCachedTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
         return Optional.ofNullable(TYPED_SERVICES.get(typedServiceInterface)).map(services -> (T) services.get(type));
@@ -71,9 +71,9 @@ public final class ElasticJobServiceLoader {
      * New typed instance.
      *
      * @param typedServiceInterface typed service interface
-     * @param type         specific service type
-     * @param <T>          specific type of service
-     * @return specific typed service instance
+     * @param type type
+     * @param <T> class of service
+     * @return new typed service instance
      */
     public static <T extends TypedSPI> Optional<T> newTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
         return Optional.ofNullable(TYPED_SERVICE_CLASSES.get(typedServiceInterface))

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
@@ -33,61 +33,52 @@ import java.util.concurrent.ConcurrentMap;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ElasticJobServiceLoader {
     
-    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, TypedSPI>> TYPED_SERVICES = new ConcurrentHashMap<>();
-    
-    private static final ConcurrentMap<Class<?>, ConcurrentMap<String, Class<?>>> TYPED_SERVICE_CLASSES = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Class<? extends TypedSPI>, ConcurrentMap<String, TypedSPI>> TYPED_SERVICES = new ConcurrentHashMap<>();
 
+    private static final ConcurrentMap<Class<? extends TypedSPI>, ConcurrentMap<String, Class<? extends TypedSPI>>> TYPED_SERVICE_CLASSES = new ConcurrentHashMap<>();
+    
     /**
      * Register typeSPI service.
      *
-     * @param typedService typed service
-     * @param <T> class of service
+     * @param typedService specific service type
+     * @param <T> type of service
      */
-    public static <T> void registerTypedService(final Class<T> typedService) {
-        if (!TypedSPI.class.isAssignableFrom(typedService)) {
-            throw new IllegalArgumentException("Cannot register @" + typedService.getName() + "as a typed service, because its not a subClass of @" + TypedSPI.class.getName());
-        }
+    public static <T extends TypedSPI> void registerTypedService(final Class<T> typedService) {
         if (TYPED_SERVICES.containsKey(typedService)) {
             return;
         }
-        ServiceLoader.load(typedService).forEach(each -> registerTypedServiceClass(typedService, (TypedSPI) each));
+        ServiceLoader.load(typedService).forEach(each -> registerTypedServiceClass(typedService, each));
     }
-    
-    private static <T> void registerTypedServiceClass(final Class<T> typedService, final TypedSPI instance) {
+
+    private static <T extends TypedSPI> void registerTypedServiceClass(final Class<T> typedService, final TypedSPI instance) {
         TYPED_SERVICES.computeIfAbsent(typedService, unused -> new ConcurrentHashMap<>()).putIfAbsent(instance.getType(), instance);
         TYPED_SERVICE_CLASSES.computeIfAbsent(typedService, unused -> new ConcurrentHashMap<>()).putIfAbsent(instance.getType(), instance.getClass());
     }
-    
+
     /**
      * Get cached instance.
      *
      * @param typedServiceInterface typed service interface
-     * @param type type
-     * @param <T> class of service
-     * @return cached typed service instance
+     * @param type         specific service type
+     * @param <T>          specific type of service
+     * @return cached service instance
      */
     public static <T extends TypedSPI> Optional<T> getCachedTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
-        T instance = TYPED_SERVICES.containsKey(typedServiceInterface) ? (T) TYPED_SERVICES.get(typedServiceInterface).get(type) : null;
-        if (null == instance) {
-            return Optional.empty();
-        }
-        return Optional.of(instance);
+        return Optional.ofNullable(TYPED_SERVICES.get(typedServiceInterface)).map(services -> (T) services.get(type));
     }
-    
+
     /**
      * New typed instance.
      *
      * @param typedServiceInterface typed service interface
-     * @param type type
-     * @param <T> class of service
+     * @param type         specific service type
+     * @param <T>          specific type of service
      * @return specific typed service instance
      */
     public static <T extends TypedSPI> Optional<T> newTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
-        Class<?> instanceClass = TYPED_SERVICE_CLASSES.containsKey(typedServiceInterface) ? TYPED_SERVICE_CLASSES.get(typedServiceInterface).get(type) : null;
-        if (null == instanceClass) {
-            return Optional.empty();
-        }
-        return Optional.of((T) newServiceInstance(instanceClass));
+        return Optional.ofNullable(TYPED_SERVICE_CLASSES.get(typedServiceInterface))
+                .map(serviceClasses -> serviceClasses.get(type))
+                .map(clazz -> (T) newServiceInstance(clazz));
     }
 
     private static Object newServiceInstance(final Class<?> clazz) {

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoader.java
@@ -19,17 +19,13 @@ package org.apache.shardingsphere.elasticjob.infra.spi;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.spi.exception.ServiceLoaderInstantiationException;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
 /**
  * ElasticJob service loader.
@@ -37,60 +33,19 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ElasticJobServiceLoader {
     
-    private static final ConcurrentMap<Class<?>, Collection<Class<?>>> SERVICES = new ConcurrentHashMap<>();
-    
     private static final ConcurrentMap<Class<?>, ConcurrentMap<String, TypedSPI>> TYPED_SERVICES = new ConcurrentHashMap<>();
     
     private static final ConcurrentMap<Class<?>, ConcurrentMap<String, Class<?>>> TYPED_SERVICE_CLASSES = new ConcurrentHashMap<>();
-    
-    /**
-     * Register SPI service.
-     *
-     * @param service service type
-     * @param <T> type of service
-     */
-    public static <T> void register(final Class<T> service) {
-        if (SERVICES.containsKey(service)) {
-            return;
-        }
-        ServiceLoader.load(service).forEach(each -> registerServiceClass(service, each));
-    }
-    
-    private static <T> void registerServiceClass(final Class<T> service, final T instance) {
-        SERVICES.computeIfAbsent(service, unused -> new LinkedHashSet<>()).add(instance.getClass());
-    }
-    
-    /**
-     * New service instances.
-     *
-     * @param service service class
-     * @param <T> type of service
-     * @return service instances
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> Collection<T> newServiceInstances(final Class<T> service) {
-        return SERVICES.containsKey(service) ? SERVICES.get(service).stream().map(each -> (T) newServiceInstance(each)).collect(Collectors.toList()) : Collections.emptyList();
-    }
-    
-    private static Object newServiceInstance(final Class<?> clazz) {
-        try {
-            return clazz.getConstructor().newInstance();
-        } catch (final InstantiationException | NoSuchMethodException | IllegalAccessException ex) {
-            throw new ServiceLoaderInstantiationException(clazz, ex);
-        } catch (final InvocationTargetException ex) {
-            throw new ServiceLoaderInstantiationException(clazz, ex.getCause());
-        }
-    }
-    
+
     /**
      * Register typeSPI service.
      *
-     * @param typedService specific service type
-     * @param <T> type of service
+     * @param typedService typed service
+     * @param <T> class of service
      */
     public static <T> void registerTypedService(final Class<T> typedService) {
         if (!TypedSPI.class.isAssignableFrom(typedService)) {
-            throw new IllegalArgumentException("Cannot register @" + typedService.getName() + "as a typed service, because its not a subClass of @" + typedService);
+            throw new IllegalArgumentException("Cannot register @" + typedService.getName() + "as a typed service, because its not a subClass of @" + TypedSPI.class.getName());
         }
         if (TYPED_SERVICES.containsKey(typedService)) {
             return;
@@ -106,34 +61,42 @@ public final class ElasticJobServiceLoader {
     /**
      * Get cached instance.
      *
-     * @param typedService typed service
+     * @param typedServiceInterface typed service interface
      * @param type type
      * @param <T> class of service
-     * @return cached service instance
+     * @return cached typed service instance
      */
-    @SuppressWarnings("unchecked")
-    public static <T extends TypedSPI> T getCachedInstance(final Class<T> typedService, final String type) {
-        T result = TYPED_SERVICES.containsKey(typedService) ? (T) TYPED_SERVICES.get(typedService).get(type) : null;
-        if (null == result) {
-            throw new JobConfigurationException("Cannot find a cached typed service instance by the interface: @" + typedService.getName() + "and type: " + type);
+    public static <T extends TypedSPI> Optional<T> getCachedTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
+        T instance = TYPED_SERVICES.containsKey(typedServiceInterface) ? (T) TYPED_SERVICES.get(typedServiceInterface).get(type) : null;
+        if (null == instance) {
+            return Optional.empty();
         }
-        return result;
+        return Optional.of(instance);
     }
     
     /**
      * New typed instance.
      *
-     * @param typedService typed service
+     * @param typedServiceInterface typed service interface
      * @param type type
      * @param <T> class of service
-     * @return new service instance
+     * @return specific typed service instance
      */
-    @SuppressWarnings("unchecked")
-    public static <T extends TypedSPI> T newTypedServiceInstance(final Class<T> typedService, final String type) {
-        Class<?> instanceClass = TYPED_SERVICE_CLASSES.containsKey(typedService) ? TYPED_SERVICE_CLASSES.get(typedService).get(type) : null;
+    public static <T extends TypedSPI> Optional<T> newTypedServiceInstance(final Class<T> typedServiceInterface, final String type) {
+        Class<?> instanceClass = TYPED_SERVICE_CLASSES.containsKey(typedServiceInterface) ? TYPED_SERVICE_CLASSES.get(typedServiceInterface).get(type) : null;
         if (null == instanceClass) {
-            throw new JobConfigurationException("Cannot find a typed service class by the interface: @" + typedService.getName() + "and type: " + type);
+            return Optional.empty();
         }
-        return (T) newServiceInstance(instanceClass);
+        return Optional.of((T) newServiceInstance(instanceClass));
+    }
+
+    private static Object newServiceInstance(final Class<?> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (final InstantiationException | NoSuchMethodException | IllegalAccessException ex) {
+            throw new ServiceLoaderInstantiationException(clazz, ex);
+        } catch (final InvocationTargetException ex) {
+            throw new ServiceLoaderInstantiationException(clazz, ex.getCause());
+        }
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoaderTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoaderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.spi;
+
+import org.apache.shardingsphere.elasticjob.infra.spi.fixture.TypedFooService;
+import org.apache.shardingsphere.elasticjob.infra.spi.fixture.UnRegisteredTypedFooService;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public final class ElasticJobServiceLoaderTest {
+
+    @BeforeClass
+    public static void register() {
+        ElasticJobServiceLoader.registerTypedService(TypedFooService.class);
+    }
+
+    @Test
+    public void assertGetCacheTypedService() {
+        assertThat(ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "typedFooServiceImpl").orElse(null), instanceOf(TypedFooService.class));
+    }
+
+    @Test
+    public void assertNewTypedServiceInstance() {
+        assertThat(ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "typedFooServiceImpl").orElse(null), instanceOf(TypedFooService.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void assertGetCacheTypedServiceFailureWithUnRegisteredServiceInterface() {
+        ElasticJobServiceLoader.getCachedTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl").orElseThrow(() -> new IllegalArgumentException());
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertGetCacheTypedServiceFailureWithInvalidType() {
+        ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "INVALID").orElseThrow(() -> new IllegalArgumentException());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void assertNewTypedServiceInstanceFailureWithUnRegisteredServiceInterface() {
+        ElasticJobServiceLoader.newTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl").orElseThrow(() -> new IllegalArgumentException());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void assertNewTypedServiceInstanceFailureWithInvalidType() {
+        ElasticJobServiceLoader.newTypedServiceInstance(TypedFooService.class, "INVALID").orElseThrow(() -> new IllegalArgumentException());
+    }
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/TypedFooService.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/TypedFooService.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.spi.fixture;
+
+import org.apache.shardingsphere.elasticjob.infra.spi.TypedSPI;
+
+public interface TypedFooService extends TypedSPI {
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/UnRegisteredTypedFooService.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/UnRegisteredTypedFooService.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.spi.fixture;
+
+import org.apache.shardingsphere.elasticjob.infra.spi.TypedSPI;
+
+public interface UnRegisteredTypedFooService extends TypedSPI {
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/impl/TypedFooServiceImpl.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/impl/TypedFooServiceImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.spi.fixture.impl;
+
+import org.apache.shardingsphere.elasticjob.infra.spi.fixture.TypedFooService;
+
+public final class TypedFooServiceImpl implements TypedFooService {
+    
+    @Override
+    public String getType() {
+        return "typedFooServiceImpl";
+    }
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/impl/UnRegisteredTypedFooServiceImpl.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/fixture/impl/UnRegisteredTypedFooServiceImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.spi.fixture.impl;
+
+import org.apache.shardingsphere.elasticjob.infra.spi.fixture.UnRegisteredTypedFooService;
+
+public final class UnRegisteredTypedFooServiceImpl implements UnRegisteredTypedFooService {
+   
+    @Override
+    public String getType() {
+        return "unRegisteredTypedFooServiceImpl";
+    }
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.spi.fixture.TypedFooService
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.spi.fixture.TypedFooService
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.infra.spi.fixture.impl.TypedFooServiceImpl

--- a/elasticjob-infra/elasticjob-infra-common/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.spi.fixture.UnRegisteredTypedFooService
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.spi.fixture.UnRegisteredTypedFooService
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#  
+#     http://www.apache.org/licenses/LICENSE-2.0
+#  
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.infra.spi.fixture.impl.UnRegisteredTypedFooServiceImpl


### PR DESCRIPTION
Fixes #1566.

Changes proposed in this pull request:
- Remove unused code.
- Refactor it method to return an empty Optional instance instead of throw JobConfigurationException when cannot find the service instance.

