### PR TITLE
Add builder to create ErrorHandlerConfiguration to permit default value

### DIFF
--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkConfiguration.java
@@ -17,6 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.error.handler.dingtalk;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.error.handler.ErrorHandlerConfiguration;
@@ -34,14 +37,73 @@ public final class DingtalkConfiguration implements ErrorHandlerConfiguration {
     
     private final String secret;
     
-    // TODO default value is 3000
     private final int connectTimeoutMillisecond;
     
-    // TODO default value is 5000
     private final int readTimeoutMillisecond;
     
     @Override
     public String getType() {
         return DingtalkType.TYPE;
+    }
+    
+    /**
+     * Create DingTalk configuration builder.
+     *
+     * @param webhook webhook
+     * @param keyword keyword
+     * @param secret  secret
+     * @return DingTalk configuration builder
+     */
+    public static Builder newBuilder(final String webhook, final String keyword,
+                                     final String secret) {
+        return new Builder(webhook, keyword, secret);
+    }
+    
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Builder {
+        
+        private final String webhook;
+        
+        private final String keyword;
+        
+        private final String secret;
+        
+        private int connectTimeoutMillisecond = 3000;
+        
+        private int readTimeoutMillisecond = 5000;
+        
+        /**
+         * Set connect timeout.
+         *
+         * @param connectTimeoutMillisecond connect timeout
+         * @return DingTalk configuration builder
+         */
+        public Builder connectTimeoutMillisecond(final int connectTimeoutMillisecond) {
+            this.connectTimeoutMillisecond = connectTimeoutMillisecond;
+            return this;
+        }
+        
+        /**
+         * Set read timeout.
+         *
+         * @param readTimeoutMillisecond read timeout
+         * @return DingTalk configuration builder
+         */
+        public Builder readTimeoutMillisecond(final int readTimeoutMillisecond) {
+            this.readTimeoutMillisecond = readTimeoutMillisecond;
+            return this;
+        }
+        
+        /**
+         * Build DingTalk configuration.
+         *
+         * @return DingTalk configuration
+         */
+        public final DingtalkConfiguration build() {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(webhook), "webhook can not be empty.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(keyword), "keyword can not be empty.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(secret), "secret can not be empty.");
+            return new DingtalkConfiguration(webhook, keyword, secret, connectTimeoutMillisecond, readTimeoutMillisecond);
+        }
     }
 }

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkConfigurationTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkConfigurationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.dingtalk;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DingtalkConfigurationTest {
+    
+    private static final String WEBHOOK = "webhook";
+    
+    private static final String KEYWORD = "keyword";
+    
+    private static final String SECRET = "secret";
+    
+    private static final int CONNECT_TIMEOUT = 4000;
+    
+    private static final int CONNECT_TIMEOUT_DEFAULT_VALUE = 3000;
+    
+    private static final int READ_TIMEOUT = 4000;
+    
+    private static final int READ_TIMEOUT_DEFAULT_VALUE = 5000;
+    
+    private static final String EMPTY_STRING = "";
+    
+    @Test
+    public void assertBuildAllProperties() {
+        DingtalkConfiguration actual = DingtalkConfiguration.newBuilder(WEBHOOK, KEYWORD, SECRET)
+                .connectTimeoutMillisecond(CONNECT_TIMEOUT)
+                .readTimeoutMillisecond(READ_TIMEOUT)
+                .build();
+        assertThat(actual.getWebhook(), is(WEBHOOK));
+        assertThat(actual.getKeyword(), is(KEYWORD));
+        assertThat(actual.getSecret(), is(SECRET));
+        assertThat(actual.getConnectTimeoutMillisecond(), is(CONNECT_TIMEOUT));
+        assertThat(actual.getReadTimeoutMillisecond(), is(CONNECT_TIMEOUT));
+    }
+    
+    @Test
+    public void assertBuildRequiredProperties() {
+        DingtalkConfiguration actual = DingtalkConfiguration.newBuilder(WEBHOOK, KEYWORD, SECRET).build();
+        assertThat(actual.getWebhook(), is(WEBHOOK));
+        assertThat(actual.getKeyword(), is(KEYWORD));
+        assertThat(actual.getSecret(), is(SECRET));
+        assertThat(actual.getConnectTimeoutMillisecond(), is(CONNECT_TIMEOUT_DEFAULT_VALUE));
+        assertThat(actual.getReadTimeoutMillisecond(), is(READ_TIMEOUT_DEFAULT_VALUE));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyWebhook() {
+        DingtalkConfiguration.newBuilder(EMPTY_STRING, KEYWORD, SECRET).build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyKeyword() {
+        DingtalkConfiguration.newBuilder(WEBHOOK, EMPTY_STRING, SECRET).build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptySecret() {
+        DingtalkConfiguration.newBuilder(WEBHOOK, KEYWORD, EMPTY_STRING).build();
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
@@ -163,7 +163,7 @@ public final class EmailConfiguration implements ErrorHandlerConfiguration {
          */
         public final EmailConfiguration build() {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(host), "host can not be empty.");
-            Preconditions.checkArgument(port > 0 && port < 65535, "port should larger than 0 and small than 65535.");
+            Preconditions.checkArgument(0 < port && 65535 < port, "port should larger than 0 and small than 65535.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(username), "username can not be empty.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(password), "password can not be empty.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(from), "from can not be empty.");

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
@@ -163,7 +163,7 @@ public final class EmailConfiguration implements ErrorHandlerConfiguration {
          */
         public final EmailConfiguration build() {
             Preconditions.checkArgument(!Strings.isNullOrEmpty(host), "host can not be empty.");
-            Preconditions.checkArgument(0 < port && 65535 < port, "port should larger than 0 and small than 65535.");
+            Preconditions.checkArgument(0 < port && 65535 > port, "port should larger than 0 and small than 65535.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(username), "username can not be empty.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(password), "password can not be empty.");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(from), "from can not be empty.");

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfiguration.java
@@ -17,6 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.error.handler.email;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.error.handler.ErrorHandlerConfiguration;
@@ -36,10 +39,8 @@ public final class EmailConfiguration implements ErrorHandlerConfiguration {
     
     private final String password;
     
-    // TODO default value is true
     private final boolean useSsl;
     
-    // TODO default value is ElasticJob error message
     private final String subject;
     
     private final String from;
@@ -50,11 +51,125 @@ public final class EmailConfiguration implements ErrorHandlerConfiguration {
     
     private final String bcc;
     
-    // TODO default value is false
     private final boolean debug;
     
     @Override
     public String getType() {
         return EmailType.TYPE;
+    }
+    
+    /**
+     * Create Email configuration builder.
+     *
+     * @param host     host
+     * @param port     port
+     * @param username username
+     * @param password password
+     * @param from     from
+     * @param to       to
+     * @return Email configuration builder
+     */
+    public static Builder newBuilder(final String host, final int port, final String username,
+                                     final String password, final String from, final String to) {
+        return new Builder(host, port, username, password, from, to);
+    }
+    
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Builder {
+        
+        private final String host;
+        
+        private final int port;
+        
+        private final String username;
+        
+        private final String password;
+        
+        private boolean useSsl = true;
+        
+        private String subject = "ElasticJob error message";
+        
+        private final String from;
+        
+        private final String to;
+        
+        private String cc;
+        
+        private String bcc;
+        
+        private boolean debug;
+        
+        /**
+         * Set useSsl.
+         *
+         * @param useSsl useSsl
+         * @return Email configuration builder
+         */
+        public Builder useSsl(final boolean useSsl) {
+            this.useSsl = useSsl;
+            return this;
+        }
+        
+        /**
+         * Set subject.
+         *
+         * @param subject subject
+         * @return Email configuration builder
+         */
+        public Builder subject(final String subject) {
+            if (!Strings.isNullOrEmpty(subject)) {
+                this.subject = subject;
+            }
+            return this;
+        }
+        
+        /**
+         * Set cc.
+         *
+         * @param cc cc
+         * @return Email configuration builder
+         */
+        public Builder cc(final String cc) {
+            this.cc = cc;
+            return this;
+        }
+        
+        /**
+         * Set bcc.
+         *
+         * @param bcc bcc
+         * @return Email configuration builder
+         */
+        public Builder bcc(final String bcc) {
+            this.bcc = bcc;
+            return this;
+        }
+        
+        /**
+         * Set debug.
+         *
+         * @param debug debug
+         * @return Email configuration builder
+         */
+        public Builder debug(final boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+        
+        /**
+         * Build Email configuration.
+         *
+         * @return Email configuration
+         */
+        public final EmailConfiguration build() {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(host), "host can not be empty.");
+            Preconditions.checkArgument(port > 0 && port < 65535, "port should larger than 0 and small than 65535.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(username), "username can not be empty.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(password), "password can not be empty.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(from), "from can not be empty.");
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(to), "to can not be empty.");
+            return new EmailConfiguration(host, port, username, password, useSsl, subject,
+                    from, to, cc, bcc, debug);
+        }
     }
 }

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
@@ -119,7 +119,7 @@ public class EmailConfigurationTest {
     }
     
     @Test(expected = IllegalArgumentException.class)
-    public void assertBuildWithEmptyFROM() {
+    public void assertBuildWithEmptyFrom() {
         EmailConfiguration.newBuilder(HOST, PORT, USERNAME, PASSWORD, EMPTY_STRING, TO)
                 .build();
     }

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
@@ -27,9 +27,9 @@ import static org.junit.Assert.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class EmailConfigurationTest {
     
-    private static final String HOST = "192.168.0.8";
+    private static final String HOST = "smtp.xxx.com";
     
-    private static final int PORT = 8080;
+    private static final int PORT = 25;
     
     private static final String USERNAME = "username";
     

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailConfigurationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.email;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmailConfigurationTest {
+    
+    private static final String HOST = "192.168.0.8";
+    
+    private static final int PORT = 8080;
+    
+    private static final String USERNAME = "username";
+    
+    private static final String PASSWORD = "password";
+    
+    private static final String FROM = "from";
+    
+    private static final String TO = "to";
+    
+    private static final String SUBJECT = "subject";
+    
+    private static final String SUBJECT_DEFAULT_VALUE = "ElasticJob error message";
+    
+    private static final String CC = "cc";
+    
+    private static final String BCC = "bcc";
+    
+    private static final boolean USE_SSL = false;
+    
+    private static final boolean USE_SSL_DEFAULT_VALUE = true;
+    
+    private static final boolean DEBUG = true;
+    
+    private static final boolean DEBUG_DEFAULT_VALUE = false;
+    
+    private static final String EMPTY_STRING = "";
+    
+    @Test
+    public void assertBuildAllProperties() {
+        EmailConfiguration actual = EmailConfiguration.newBuilder(HOST, PORT, USERNAME, PASSWORD, FROM, TO)
+                .useSsl(USE_SSL)
+                .subject(SUBJECT)
+                .cc(CC)
+                .bcc(BCC)
+                .debug(DEBUG)
+                .build();
+        assertThat(actual.getHost(), is(HOST));
+        assertThat(actual.getPort(), is(PORT));
+        assertThat(actual.getUsername(), is(USERNAME));
+        assertThat(actual.getPassword(), is(PASSWORD));
+        assertThat(actual.isUseSsl(), is(USE_SSL));
+        assertThat(actual.getSubject(), is(SUBJECT));
+        assertThat(actual.getFrom(), is(FROM));
+        assertThat(actual.getTo(), is(TO));
+        assertThat(actual.getCc(), is(CC));
+        assertThat(actual.getBcc(), is(BCC));
+        assertThat(actual.isDebug(), is(DEBUG));
+    }
+    
+    @Test
+    public void assertBuildRequiredProperties() {
+        EmailConfiguration actual = EmailConfiguration.newBuilder(HOST, PORT, USERNAME, PASSWORD, FROM, TO)
+                .build();
+        assertThat(actual.getHost(), is(HOST));
+        assertThat(actual.getPort(), is(PORT));
+        assertThat(actual.getUsername(), is(USERNAME));
+        assertThat(actual.getPassword(), is(PASSWORD));
+        assertThat(actual.isUseSsl(), is(USE_SSL_DEFAULT_VALUE));
+        assertThat(actual.getSubject(), is(SUBJECT_DEFAULT_VALUE));
+        assertThat(actual.getFrom(), is(FROM));
+        assertThat(actual.getTo(), is(TO));
+        assertThat(actual.isDebug(), is(DEBUG_DEFAULT_VALUE));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyHost() {
+        EmailConfiguration.newBuilder(EMPTY_STRING, PORT, USERNAME, PASSWORD, FROM, TO)
+                .build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithInvalidPort() {
+        EmailConfiguration.newBuilder(HOST, -1, USERNAME, PASSWORD, FROM, TO)
+                .build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyUsername() {
+        EmailConfiguration.newBuilder(HOST, PORT, EMPTY_STRING, PASSWORD, FROM, TO)
+                .build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyPassword() {
+        EmailConfiguration.newBuilder(HOST, PORT, USERNAME, EMPTY_STRING, FROM, TO)
+                .build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyFROM() {
+        EmailConfiguration.newBuilder(HOST, PORT, USERNAME, PASSWORD, EMPTY_STRING, TO)
+                .build();
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyTo() {
+        EmailConfiguration.newBuilder(HOST, PORT, USERNAME, PASSWORD, FROM, EMPTY_STRING)
+                .build();
+    }
+}

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfiguration.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfiguration.java
@@ -17,6 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.error.handler.wechat;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.error.handler.ErrorHandlerConfiguration;
@@ -30,14 +33,64 @@ public final class WechatConfiguration implements ErrorHandlerConfiguration {
     
     private final String webhook;
     
-    // TODO default value is 3000
     private final int connectTimeoutMillisecond;
     
-    // TODO default value is 3000
     private final int readTimeoutMillisecond;
     
     @Override
     public String getType() {
         return WechatType.TYPE;
+    }
+    
+    /**
+     * Create WeChat configuration builder.
+     *
+     * @param webhook webhook
+     * @return WeChat configuration builder
+     */
+    public static Builder newBuilder(final String webhook) {
+        return new Builder(webhook);
+    }
+    
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Builder {
+        
+        private final String webhook;
+        
+        private int connectTimeoutMillisecond = 3000;
+        
+        private int readTimeoutMillisecond = 3000;
+        
+        /**
+         * Set connect timeout.
+         *
+         * @param connectTimeoutMillisecond connect timeout
+         * @return WeChat configuration builder
+         */
+        public Builder connectTimeoutMillisecond(final int connectTimeoutMillisecond) {
+            this.connectTimeoutMillisecond = connectTimeoutMillisecond;
+            return this;
+        }
+        
+        /**
+         * Set read timeout.
+         *
+         * @param readTimeoutMillisecond read timeout
+         * @return WeChat configuration builder
+         */
+        public Builder readTimeoutMillisecond(final int readTimeoutMillisecond) {
+            this.readTimeoutMillisecond = readTimeoutMillisecond;
+            return this;
+        }
+        
+        /**
+         * Build WeChat configuration.
+         *
+         * @return WeChat configuration
+         */
+        public final WechatConfiguration build() {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(webhook), "webhook can not be empty.");
+            return new WechatConfiguration(webhook, connectTimeoutMillisecond, readTimeoutMillisecond);
+        }
     }
 }

--- a/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfigurationTest.java
+++ b/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler.wechat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WechatConfigurationTest {
+    
+    private static final String WEBHOOK = "webhook";
+    
+    private static final int CONNECT_TIMEOUT = 5000;
+    
+    private static final int CONNECT_TIMEOUT_DEFAULT_VALUE = 3000;
+    
+    private static final int READ_TIMEOUT = 5000;
+    
+    private static final int READ_TIMEOUT_DEFAULT_VALUE = 3000;
+    
+    private static final String EMPTY_STRING = "";
+    
+    @Test
+    public void assertBuildAllProperties() {
+        WechatConfiguration actual = WechatConfiguration.newBuilder(WEBHOOK)
+                .connectTimeoutMillisecond(CONNECT_TIMEOUT)
+                .readTimeoutMillisecond(READ_TIMEOUT)
+                .build();
+        assertThat(actual.getWebhook(), is(WEBHOOK));
+        assertThat(actual.getConnectTimeoutMillisecond(), is(CONNECT_TIMEOUT));
+        assertThat(actual.getReadTimeoutMillisecond(), is(READ_TIMEOUT));
+    }
+    
+    @Test
+    public void assertBuildRequiredProperties() {
+        WechatConfiguration actual = WechatConfiguration.newBuilder(WEBHOOK).build();
+        assertThat(actual.getWebhook(), is(WEBHOOK));
+        assertThat(actual.getConnectTimeoutMillisecond(), is(CONNECT_TIMEOUT_DEFAULT_VALUE));
+        assertThat(actual.getReadTimeoutMillisecond(), is(READ_TIMEOUT_DEFAULT_VALUE));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void assertBuildWithEmptyWebhook() {
+        WechatConfiguration.newBuilder(EMPTY_STRING).build();
+    }
+}


### PR DESCRIPTION
Fixes #1599

Changes proposed in this pull request:
- Add builder to EmailConfiguration and test cases
- Add builder to WechatConfiguration and test cases
- Add builder to DingtalkConfiguration and test cases
