### PR TITLE
Add support jobListenerTypes in module elasticjob-lite-spring-boot-starter and complete testcases

### DIFF
--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationProperties.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationProperties.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Properties;
 
 /**
@@ -61,6 +63,8 @@ public final class ElasticJobConfigurationProperties {
     
     private String jobErrorHandlerType;
     
+    private Collection<String> jobListenerTypes = new LinkedList<>();
+    
     private String description;
     
     private Properties props = new Properties();
@@ -81,7 +85,7 @@ public final class ElasticJobConfigurationProperties {
                 .monitorExecution(monitorExecution).failover(failover).misfire(misfire)
                 .maxTimeDiffSeconds(maxTimeDiffSeconds).reconcileIntervalMinutes(reconcileIntervalMinutes)
                 .jobShardingStrategyType(jobShardingStrategyType).jobExecutorServiceHandlerType(jobExecutorServiceHandlerType).jobErrorHandlerType(jobErrorHandlerType)
-                .description(description).disabled(disabled).overwrite(overwrite).build();
+                .jobListenerTypes(jobListenerTypes.toArray(new String[0])).description(description).disabled(disabled).overwrite(overwrite).build();
         for (Object each : props.keySet()) {
             result.getProps().setProperty(each.toString(), props.get(each.toString()).toString());
         }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/listener/LogElasticJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/listener/LogElasticJobListener.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
+
+/**
+ * Log elastic job listener.
+ */
+@Slf4j
+public final class LogElasticJobListener implements ElasticJobListener {
+    
+    @Override
+    public void beforeJobExecuted(final ShardingContexts shardingContexts) {
+        log.info("Before job executed. {}", shardingContexts);
+    }
+    
+    @Override
+    public void afterJobExecuted(final ShardingContexts shardingContexts) {
+        log.info("After job executed. {}", shardingContexts);
+    }
+    
+    @Override
+    public String getType() {
+        return "LOG";
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/listener/NoopElasticJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/listener/NoopElasticJobListener.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.listener;
+
+import org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
+
+/**
+ * No operation elastic job listener.
+ */
+public final class NoopElasticJobListener implements ElasticJobListener {
+    
+    @Override
+    public void beforeJobExecuted(final ShardingContexts shardingContexts) {
+    }
+    
+    @Override
+    public void afterJobExecuted(final ShardingContexts shardingContexts) {
+    }
+    
+    @Override
+    public String getType() {
+        return "NOOP";
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener
@@ -15,30 +15,5 @@
 # limitations under the License.
 #
 
-spring:
-  datasource:
-    url: jdbc:h2:mem:job_event_storage
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-elasticjob:
-  tracing:
-    type: RDB
-  regCenter:
-    serverLists: localhost:18181
-    namespace: elasticjob-lite-spring-boot-starter
-  jobs:
-    customTestJob:
-      elasticJobClass: org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.job.impl.CustomTestJob
-      jobBootstrapBeanName: customTestJobBean
-      shardingTotalCount: 3
-      jobListenerTypes:
-        - NOOP
-        - LOG
-    printTestJob:
-      elasticJobType: PRINT
-      jobBootstrapBeanName: printTestJobBean
-      shardingTotalCount: 3
-      props:
-        print.content: "test print job"
+org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.listener.NoopElasticJobListener
+org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.listener.LogElasticJobListener


### PR DESCRIPTION
Fixes #1360

Changes proposed in this pull request:
- Add "jobListenerTypes" to ElasticJobConfigurationProperties.
- Complete testcase for ElasticJobConfigurationProperties.
