### PR TITLE
Move OneOffJobBootstrap.triggerAllInstances into InstanceService 

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNode.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNode.java
@@ -61,7 +61,11 @@ public final class InstanceNode {
         return path.equals(jobNodePath.getFullPath(String.format(INSTANCES, JobRegistry.getInstance().getJobInstance(jobName).getJobInstanceId())));
     }
     
-    String getLocalInstanceNode() {
-        return String.format(INSTANCES, JobRegistry.getInstance().getJobInstance(jobName).getJobInstanceId());
+    String getLocalInstancePath() {
+        return getInstancePath(JobRegistry.getInstance().getJobInstance(jobName).getJobInstanceId());
+    }
+
+    String getInstancePath(final String instanceId) {
+        return String.format(INSTANCES, instanceId);
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
@@ -46,21 +46,18 @@ public final class InstanceService {
      * Persist job online status.
      */
     public void persistOnline() {
-        jobNodeStorage.fillEphemeralJobNode(instanceNode.getLocalInstanceNode(), "");
+        jobNodeStorage.fillEphemeralJobNode(instanceNode.getLocalInstancePath(), "");
     }
     
     /**
      * Persist job instance.
      */
     public void removeInstance() {
-        jobNodeStorage.removeJobNodeIfExisted(instanceNode.getLocalInstanceNode());
+        jobNodeStorage.removeJobNodeIfExisted(instanceNode.getLocalInstancePath());
     }
     
-    /**
-     * Clear trigger flag.
-     */
-    public void clearTriggerFlag() {
-        jobNodeStorage.updateJobNode(instanceNode.getLocalInstanceNode(), "");
+    void clearTriggerFlag() {
+        jobNodeStorage.updateJobNode(instanceNode.getLocalInstancePath(), "");
     }
     
     /**
@@ -79,12 +76,16 @@ public final class InstanceService {
         return result;
     }
     
+    boolean isLocalJobInstanceExisted() {
+        return jobNodeStorage.isJobNodeExisted(instanceNode.getLocalInstancePath());
+    }
+
     /**
-     * Judge is job instance existed or not in localhost.
-     * 
-     * @return is job instance existed or not in localhost
+     * Trigger all instances.
      */
-    public boolean isLocalJobInstanceExisted() {
-        return jobNodeStorage.isJobNodeExisted(instanceNode.getLocalInstanceNode());
+    public void triggerAllInstances() {
+        for (String each : jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT)) {
+            jobNodeStorage.replaceJobNode(instanceNode.getInstancePath(each), InstanceOperation.TRIGGER.name());
+        }
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
@@ -84,8 +84,6 @@ public final class InstanceService {
      * Trigger all instances.
      */
     public void triggerAllInstances() {
-        for (String each : jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT)) {
-            jobNodeStorage.replaceJobNode(instanceNode.getInstancePath(each), InstanceOperation.TRIGGER.name());
-        }
+        jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT).forEach(each -> jobNodeStorage.replaceJobNode(instanceNode.getInstancePath(each), InstanceOperation.TRIGGER.name()));
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.lite.fixture.EmbedTestingServer;
+import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;
+import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduler;
+import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
+import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
+import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class OneOffJobBootstrapTest {
+
+    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EmbedTestingServer.getConnectionString(), OneOffJobBootstrapTest.class.getSimpleName());
+
+    private static final int SHARDING_TOTAL_COUNT = 3;
+
+    private ZookeeperRegistryCenter zkRegCenter;
+
+    @BeforeClass
+    public static void init() {
+        EmbedTestingServer.start();
+    }
+
+    @Before
+    public void setUp() {
+        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
+        zkRegCenter.init();
+    }
+
+    @After
+    public void teardown() {
+        zkRegCenter.close();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void assertConfigFailedWithCron() {
+        new OneOffJobBootstrap(zkRegCenter, (SimpleJob) shardingContext -> {
+        }, JobConfiguration.newBuilder("test_one_off_job_execute_with_config_cron", SHARDING_TOTAL_COUNT).cron("0/5 * * * * ?").build());
+    }
+
+    @Test
+    public void assertExecute() {
+        AtomicInteger counter = new AtomicInteger(0);
+        final OneOffJobBootstrap oneOffJobBootstrap = new OneOffJobBootstrap(zkRegCenter, (SimpleJob) shardingContext -> {
+            counter.incrementAndGet();
+        }, JobConfiguration.newBuilder("test_one_off_job_execute", SHARDING_TOTAL_COUNT).build());
+        oneOffJobBootstrap.execute();
+        blockUtilFinish(oneOffJobBootstrap);
+        assertThat(SHARDING_TOTAL_COUNT, is(counter.get()));
+        getJobScheduler(oneOffJobBootstrap).shutdown();
+    }
+
+    @Test
+    public void assertShutdown() throws SchedulerException {
+        OneOffJobBootstrap oneOffJobBootstrap = new OneOffJobBootstrap(zkRegCenter, (SimpleJob) shardingContext -> {
+        }, JobConfiguration.newBuilder("test_one_off_job_shutdown", SHARDING_TOTAL_COUNT).build());
+        oneOffJobBootstrap.shutdown();
+        assertTrue(getScheduler(oneOffJobBootstrap).isShutdown());
+    }
+
+    @SneakyThrows
+    private JobScheduler getJobScheduler(final OneOffJobBootstrap oneOffJobBootstrap) {
+        Field field = OneOffJobBootstrap.class.getDeclaredField("jobScheduler");
+        field.setAccessible(true);
+        return (JobScheduler) field.get(oneOffJobBootstrap);
+    }
+
+    @SneakyThrows
+    private Scheduler getScheduler(final OneOffJobBootstrap oneOffJobBootstrap) {
+        JobScheduler jobScheduler = getJobScheduler(oneOffJobBootstrap);
+        Field schedulerField = JobScheduleController.class.getDeclaredField("scheduler");
+        schedulerField.setAccessible(true);
+        return (Scheduler) schedulerField.get(jobScheduler.getJobScheduleController());
+    }
+
+    @SneakyThrows
+    private void blockUtilFinish(final OneOffJobBootstrap oneOffJobBootstrap) {
+        Scheduler scheduler = getScheduler(oneOffJobBootstrap);
+        while (!scheduler.isStarted() || !scheduler.getCurrentlyExecutingJobs().isEmpty()) {
+            Thread.sleep(100);
+        }
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
@@ -77,7 +77,7 @@ public final class OneOffJobBootstrapTest {
         }, JobConfiguration.newBuilder("test_one_off_job_execute", SHARDING_TOTAL_COUNT).build());
         oneOffJobBootstrap.execute();
         blockUtilFinish(oneOffJobBootstrap);
-        assertThat(SHARDING_TOTAL_COUNT, is(counter.get()));
+        assertThat(counter.get(), is(SHARDING_TOTAL_COUNT));
         getJobScheduler(oneOffJobBootstrap).shutdown();
     }
 

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNodeTest.java
@@ -64,6 +64,11 @@ public final class InstanceNodeTest {
     
     @Test
     public void assertGetLocalInstancePath() {
-        assertThat(instanceNode.getLocalInstanceNode(), is("instances/127.0.0.1@-@0"));
+        assertThat(instanceNode.getLocalInstancePath(), is("instances/127.0.0.1@-@0"));
+    }
+
+    @Test
+    public void assertGetInstancePath() {
+        assertThat(instanceNode.getInstancePath("127.0.0.1@-@0"), is("instances/127.0.0.1@-@0"));
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceServiceTest.java
@@ -73,12 +73,12 @@ public final class InstanceServiceTest {
     @Test
     public void assertClearTriggerFlag() {
         instanceService.clearTriggerFlag();
-        jobNodeStorage.updateJobNode("instances/127.0.0.1@-@0", "");
+        verify(jobNodeStorage).updateJobNode("instances/127.0.0.1@-@0", "");
     }
     
     @Test
     public void assertGetAvailableJobInstances() {
-        when(jobNodeStorage.getJobNodeChildrenKeys("instances")).thenReturn(Arrays.asList("127.0.0.1@-@0", "127.0.0.2@-@0"));
+        when(jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT)).thenReturn(Arrays.asList("127.0.0.1@-@0", "127.0.0.2@-@0"));
         when(serverService.isEnableServer("127.0.0.1")).thenReturn(true);
         assertThat(instanceService.getAvailableJobInstances(), is(Collections.singletonList(new JobInstance("127.0.0.1@-@0"))));
     }
@@ -87,5 +87,13 @@ public final class InstanceServiceTest {
     public void assertIsLocalJobInstanceExisted() {
         when(jobNodeStorage.isJobNodeExisted("instances/127.0.0.1@-@0")).thenReturn(true);
         assertTrue(instanceService.isLocalJobInstanceExisted());
+    }
+
+    @Test
+    public void assertTriggerAllInstances() {
+        when(jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT)).thenReturn(Arrays.asList("127.0.0.1@-@0", "127.0.0.2@-@0"));
+        instanceService.triggerAllInstances();
+        verify(jobNodeStorage).replaceJobNode("instances/127.0.0.1@-@0", InstanceOperation.TRIGGER.name());
+        verify(jobNodeStorage).replaceJobNode("instances/127.0.0.2@-@0", InstanceOperation.TRIGGER.name());
     }
 }


### PR DESCRIPTION
Move OneOffJobBootstrap.triggerAllInstances into InstanceService 
Fixes #1610.

Changes proposed in this pull request:
- Move OneOffJobBootstrap.triggerAllInstances into InstanceService
- Add test case

