### PR TITLE
Specify upper bound of Spring Framework version in dependencyManagement

### DIFF
--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <springboot.version>2.3.1.RELEASE</springboot.version>
-        <springframework.version>[3.1.0.RELEASE,)</springframework.version>
+        <springframework.version>[3.1.0.RELEASE,5.2.7.RELEASE]</springframework.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes #1667

Changes proposed in this pull request:
- Specify highest version of Spring Framework to `5.2.7.RELEASE`.
