### PR TITLE
Determine command by platform in ScriptJobExecutorTest

### DIFF
--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/src/test/java/org/apache/shardingsphere/elasticjob/script/ScriptJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/src/test/java/org/apache/shardingsphere/elasticjob/script/ScriptJobExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.script;
 
+import org.apache.commons.exec.OS;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
@@ -78,8 +79,20 @@ public final class ScriptJobExecutorTest {
     @Test
     public void assertProcess() {
         when(jobConfig.getProps()).thenReturn(properties);
-        when(properties.getProperty(ScriptJobProperties.SCRIPT_KEY)).thenReturn("echo script-job");
+        when(properties.getProperty(ScriptJobProperties.SCRIPT_KEY)).thenReturn(determineCommandByPlatform());
         jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+    }
+
+    private String determineCommandByPlatform() {
+        return OS.isFamilyWindows() ? getWindowsEcho() : getEcho();
+    }
+
+    private String getWindowsEcho() {
+        return "cmd /c echo script-job";
+    }
+
+    private String getEcho() {
+        return "echo script-job";
     }
     
     @Test


### PR DESCRIPTION
Fixes #1671 

Changes proposed in this pull request:
- Use "cmd" to execute command in Windows environment.
