### PR TITLE
Exclude .flattened-pom.xml from src distribution

### DIFF
--- a/elasticjob-distribution/elasticjob-src-distribution/src/main/assembly/source-distribution.xml
+++ b/elasticjob-distribution/elasticjob-src-distribution/src/main/assembly/source-distribution.xml
@@ -44,6 +44,7 @@
                 <exclude>**/*.zip</exclude>
                 <exclude>**/*.tar</exclude>
                 <exclude>**/*.tar.gz</exclude>
+                <exclude>**/.flattened-pom.xml</exclude>
                 
                 <!-- maven plugin ignore -->
                 <exclude>release.properties</exclude>


### PR DESCRIPTION
Fixes #1686

Changes proposed in this pull request:
- Exclude .flattened-pom.xml from src distribution.
