### PR TITLE
Fix distribute once listener may cause deadlock when all servers are disabled

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
@@ -53,6 +53,9 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
     @Override
     public final void beforeJobExecuted(final ShardingContexts shardingContexts) {
         Set<Integer> shardingItems = shardingContexts.getShardingItemParameters().keySet();
+        if (shardingItems.isEmpty()) {
+            return;
+        }
         guaranteeService.registerStart(shardingItems);
         while (!guaranteeService.isRegisterStartSuccess(shardingItems)) {
             BlockUtils.waitingShortTime();
@@ -79,6 +82,9 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
     @Override
     public final void afterJobExecuted(final ShardingContexts shardingContexts) {
         Set<Integer> shardingItems = shardingContexts.getShardingItemParameters().keySet();
+        if (shardingItems.isEmpty()) {
+            return;
+        }
         guaranteeService.registerComplete(shardingItems);
         while (!guaranteeService.isRegisterCompleteSuccess(shardingItems)) {
             BlockUtils.waitingShortTime();


### PR DESCRIPTION
Fixes #1689

Changes proposed in this pull request:
- Distribute once listener return immediately when missing sharding items.
