### PR TITLE
Load job configuration and error handler at task staging each time

### DIFF
--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandler.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandler.java
@@ -20,10 +20,13 @@ package org.apache.shardingsphere.elasticjob.error.handler;
 import org.apache.shardingsphere.elasticjob.infra.spi.SPIPostProcessor;
 import org.apache.shardingsphere.elasticjob.infra.spi.TypedSPI;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 /**
  * Job error handler.
  */
-public interface JobErrorHandler extends TypedSPI, SPIPostProcessor {
+public interface JobErrorHandler extends TypedSPI, SPIPostProcessor, Closeable {
     
     /**
      * Handle exception.
@@ -32,4 +35,13 @@ public interface JobErrorHandler extends TypedSPI, SPIPostProcessor {
      * @param cause failure cause
      */
     void handleException(String jobName, Throwable cause);
+    
+    /**
+     * Default close method.
+     *
+     * @throws IOException IOException
+     */
+    @Override
+    default void close() throws IOException {
+    }
 }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandler.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandler.java
@@ -72,19 +72,6 @@ public final class DingtalkJobErrorHandler implements JobErrorHandler {
         secret = props.getProperty(DingtalkPropertiesConstants.SECRET);
         connectTimeoutMilliseconds = Integer.parseInt(props.getProperty(DingtalkPropertiesConstants.CONNECT_TIMEOUT_MILLISECONDS, DingtalkPropertiesConstants.DEFAULT_CONNECT_TIMEOUT_MILLISECONDS));
         readTimeoutMilliseconds = Integer.parseInt(props.getProperty(DingtalkPropertiesConstants.READ_TIMEOUT_MILLISECONDS, DingtalkPropertiesConstants.DEFAULT_READ_TIMEOUT_MILLISECONDS));
-        registerShutdownHook();
-    }
-    
-    private void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread("DingtalkJobErrorHandler Shutdown-Hook") {
-            
-            @SneakyThrows
-            @Override
-            public void run() {
-                log.info("Shutting down HTTP client...");
-                httpclient.close();
-            }
-        });
     }
     
     @Override
@@ -154,5 +141,10 @@ public final class DingtalkJobErrorHandler implements JobErrorHandler {
     @Override
     public String getType() {
         return "DINGTALK";
+    }
+    
+    @Override
+    public void close() throws IOException {
+        httpclient.close();
     }
 }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandler.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandler.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.elasticjob.error.handler.wechat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -58,19 +57,6 @@ public final class WechatJobErrorHandler implements JobErrorHandler {
         webhook = props.getProperty(WechatPropertiesConstants.WEBHOOK);
         connectTimeoutMilliseconds = Integer.parseInt(props.getProperty(WechatPropertiesConstants.CONNECT_TIMEOUT_MILLISECONDS, WechatPropertiesConstants.DEFAULT_CONNECT_TIMEOUT_MILLISECONDS));
         readTimeoutMilliseconds = Integer.parseInt(props.getProperty(WechatPropertiesConstants.READ_TIMEOUT_MILLISECONDS, WechatPropertiesConstants.DEFAULT_READ_TIMEOUT_MILLISECONDS));
-        registerShutdownHook();
-    }
-    
-    private void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread("WechatJobErrorHandler Shutdown-Hook") {
-            
-            @SneakyThrows
-            @Override
-            public void run() {
-                log.info("Shutting down HTTP client...");
-                httpclient.close();
-            }
-        });
     }
     
     @Override
@@ -118,5 +104,10 @@ public final class WechatJobErrorHandler implements JobErrorHandler {
     @Override
     public String getType() {
         return "WECHAT";
+    }
+    
+    @Override
+    public void close() throws IOException {
+        httpclient.close();
     }
 }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -62,6 +63,7 @@ public final class ElasticJobExecutorTest {
     @Before
     public void setUp() {
         jobConfig = createJobConfiguration();
+        when(jobFacade.loadJobConfiguration(anyBoolean())).thenReturn(jobConfig);
         elasticJobExecutor = new ElasticJobExecutor(fooJob, jobConfig, jobFacade);
         setJobItemExecutor();
     }


### PR DESCRIPTION
Fixes #1544

Changes proposed in this pull request:
- `JobErrorHandler` implements `Closeable`. 
- Load job configuration at the beginning of `ElasticJobExecutor#execute`
- Lazy init instance of `JobErrorHandler` in `ElasticJobExecutor`.
