### PR TITLE
Extract all reloadable objects from ElasticJobExecutor

### DIFF
--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactory.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JobErrorHandlerFactory {
     
-    private static final String DEFAULT_HANDLER = "LOG";
+    public static final String DEFAULT_HANDLER = "LOG";
     
     static {
         ElasticJobServiceLoader.registerTypedService(JobErrorHandler.class);

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.elasticjob.error.handler;
 
 import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
@@ -27,6 +28,7 @@ import java.util.Properties;
 /**
  * JobErrorHandler reloadable.
  */
+@Slf4j
 public final class JobErrorHandlerReloadable implements Reloadable<JobErrorHandler> {
     
     private String jobErrorHandlerType;
@@ -45,6 +47,7 @@ public final class JobErrorHandlerReloadable implements Reloadable<JobErrorHandl
         if (newJobErrorHandlerType.equals(jobErrorHandlerType) && props.equals(jobConfig.getProps())) {
             return;
         }
+        log.debug("JobErrorHandler reload occurred in the job '{}'. Change from '{}' to '{}'.", jobConfig.getJobName(), jobErrorHandlerType, newJobErrorHandlerType);
         reload(newJobErrorHandlerType, jobConfig.getProps());
     }
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler;
+
+import com.google.common.base.Strings;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
+
+import java.util.Properties;
+
+/**
+ * JobErrorHandler reloadable.
+ */
+public final class JobErrorHandlerReloadable implements Reloadable<JobErrorHandler> {
+    
+    private String jobErrorHandlerType;
+    
+    private Properties props;
+    
+    private JobErrorHandler jobErrorHandler;
+    
+    @Override
+    public synchronized void reloadIfNecessary(final JobConfiguration jobConfig) {
+        if (null == jobErrorHandler) {
+            init(jobConfig.getJobErrorHandlerType(), jobConfig.getProps());
+            return;
+        }
+        String newJobErrorHandlerType = Strings.isNullOrEmpty(jobConfig.getJobErrorHandlerType()) ? JobErrorHandlerFactory.DEFAULT_HANDLER : jobConfig.getJobErrorHandlerType();
+        if (newJobErrorHandlerType.equals(jobErrorHandlerType) && props.equals(jobConfig.getProps())) {
+            return;
+        }
+        reload(newJobErrorHandlerType, jobConfig.getProps());
+    }
+    
+    private void init(final String jobErrorHandlerType, final Properties props) {
+        this.jobErrorHandlerType = Strings.isNullOrEmpty(jobErrorHandlerType) ? JobErrorHandlerFactory.DEFAULT_HANDLER : jobErrorHandlerType;
+        this.props = (Properties) props.clone();
+        jobErrorHandler = JobErrorHandlerFactory.createHandler(jobErrorHandlerType, props)
+                .orElseThrow(() -> new JobConfigurationException("Cannot find job error handler type '%s'.", jobErrorHandlerType));
+    }
+    
+    private void reload(final String jobErrorHandlerType, final Properties props) {
+        jobErrorHandler.close();
+        this.jobErrorHandlerType = jobErrorHandlerType;
+        this.props = (Properties) props.clone();
+        jobErrorHandler = JobErrorHandlerFactory.createHandler(jobErrorHandlerType, props)
+                .orElseThrow(() -> new JobConfigurationException("Cannot find job error handler type '%s'.", jobErrorHandlerType));
+    }
+    
+    @Override
+    public JobErrorHandler getInstance() {
+        return jobErrorHandler;
+    }
+    
+    @Override
+    public String getType() {
+        return JobErrorHandler.class.getName();
+    }
+}

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadable.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 
+import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -74,5 +75,10 @@ public final class JobErrorHandlerReloadable implements Reloadable<JobErrorHandl
     @Override
     public String getType() {
         return JobErrorHandler.class.getName();
+    }
+    
+    @Override
+    public void close() {
+        Optional.ofNullable(jobErrorHandler).ifPresent(JobErrorHandler::close);
     }
 }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.context.Reloadable
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.context.Reloadable
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerReloadable

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.error.handler;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.error.handler.general.IgnoreJobErrorHandler;
+import org.apache.shardingsphere.elasticjob.error.handler.general.LogJobErrorHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class JobErrorHandlerReloadableTest {
+    
+    @Mock
+    private JobErrorHandler mockJobErrorHandler;
+    
+    @Test
+    public void assertInitialize() {
+        JobErrorHandlerReloadable jobErrorHandlerReloadable = new JobErrorHandlerReloadable();
+        String jobErrorHandlerType = "IGNORE";
+        JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobErrorHandlerType(jobErrorHandlerType).build();
+        assertNull(jobErrorHandlerReloadable.getInstance());
+        jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
+        JobErrorHandler actual = jobErrorHandlerReloadable.getInstance();
+        assertNotNull(actual);
+        assertThat(actual.getType(), equalTo(jobErrorHandlerType));
+        assertTrue(actual instanceof IgnoreJobErrorHandler);
+    }
+    
+    @Test
+    public void assertReload() {
+        JobErrorHandlerReloadable jobErrorHandlerReloadable = new JobErrorHandlerReloadable();
+        setField(jobErrorHandlerReloadable, "jobErrorHandler", mockJobErrorHandler);
+        setField(jobErrorHandlerReloadable, "jobErrorHandlerType", "mock");
+        setField(jobErrorHandlerReloadable, "props", new Properties());
+        String newJobErrorHandlerType = "LOG";
+        JobConfiguration newJobConfig = JobConfiguration.newBuilder("job", 1).jobErrorHandlerType(newJobErrorHandlerType).build();
+        jobErrorHandlerReloadable.reloadIfNecessary(newJobConfig);
+        verify(mockJobErrorHandler).close();
+        JobErrorHandler actual = jobErrorHandlerReloadable.getInstance();
+        assertThat(actual.getType(), equalTo(newJobErrorHandlerType));
+        assertTrue(actual instanceof LogJobErrorHandler);
+    }
+    
+    @Test
+    public void assertUnnecessaryToReload() {
+        JobErrorHandlerReloadable jobErrorHandlerReloadable = new JobErrorHandlerReloadable();
+        String jobErrorHandlerType = "IGNORE";
+        JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobErrorHandlerType(jobErrorHandlerType).build();
+        jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
+        JobErrorHandler expected = jobErrorHandlerReloadable.getInstance();
+        jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
+        JobErrorHandler actual = jobErrorHandlerReloadable.getInstance();
+        assertThat(actual, is(expected));
+    }
+    
+    @Test
+    public void assertShutdown() {
+        JobErrorHandlerReloadable jobErrorHandlerReloadable = new JobErrorHandlerReloadable();
+        setField(jobErrorHandlerReloadable, "jobErrorHandler", mockJobErrorHandler);
+        jobErrorHandlerReloadable.close();
+        verify(mockJobErrorHandler).close();
+    }
+    
+    @SneakyThrows
+    private void setField(final Object target, final String fieldName, final Object value) {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        boolean originAccessible = field.isAccessible();
+        if (!originAccessible) {
+            field.setAccessible(true);
+        }
+        field.set(target, value);
+        field.setAccessible(originAccessible);
+    }
+}

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
@@ -49,7 +49,7 @@ public final class JobErrorHandlerReloadableTest {
         String jobErrorHandlerType = "IGNORE";
         JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobErrorHandlerType(jobErrorHandlerType).build();
         assertNull(jobErrorHandlerReloadable.getInstance());
-        jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
+        jobErrorHandlerReloadable.init(jobConfig);
         JobErrorHandler actual = jobErrorHandlerReloadable.getInstance();
         assertNotNull(actual);
         assertThat(actual.getType(), equalTo(jobErrorHandlerType));
@@ -76,7 +76,7 @@ public final class JobErrorHandlerReloadableTest {
         JobErrorHandlerReloadable jobErrorHandlerReloadable = new JobErrorHandlerReloadable();
         String jobErrorHandlerType = "IGNORE";
         JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobErrorHandlerType(jobErrorHandlerType).build();
-        jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
+        jobErrorHandlerReloadable.init(jobConfig);
         JobErrorHandler expected = jobErrorHandlerReloadable.getInstance();
         jobErrorHandlerReloadable.reloadIfNecessary(jobConfig);
         JobErrorHandler actual = jobErrorHandlerReloadable.getInstance();

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
@@ -66,7 +66,7 @@ public final class ElasticJobExecutor {
         this.elasticJob = elasticJob;
         this.jobFacade = jobFacade;
         this.jobItemExecutor = jobItemExecutor;
-        executorContext = new ExecutorContext();
+        executorContext = new ExecutorContext(jobFacade.loadJobConfiguration(true));
         itemErrorMessages = new ConcurrentHashMap<>(jobConfig.getShardingTotalCount(), 1);
     }
     

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -74,13 +73,11 @@ public final class ExecutorContext {
      * Shutdown all closeable instances.
      */
     public void shutdown() {
-        reloadableItems.values().stream().map(Reloadable::getInstance).forEach(each -> {
-            if (each instanceof Closeable) {
-                try {
-                    ((Closeable) each).close();
-                } catch (IOException ignored) {
-                }
+        for (Reloadable<?> each : reloadableItems.values()) {
+            try {
+                each.close();
+            } catch (final IOException ignored) {
             }
-        });
+        }
     }
 }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.elasticjob.executor.context;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
+import org.apache.shardingsphere.elasticjob.infra.context.ReloadablePostProcessor;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 
 import java.io.IOException;
@@ -41,11 +42,16 @@ public final class ExecutorContext {
     
     private final Map<String, Reloadable<?>> reloadableItems = new LinkedHashMap<>();
     
-    public ExecutorContext() {
+    public ExecutorContext(final JobConfiguration jobConfig) {
         ServiceLoader.load(Reloadable.class).forEach(each -> {
             ElasticJobServiceLoader.newTypedServiceInstance(Reloadable.class, each.getType(), new Properties())
                     .ifPresent(reloadable -> reloadableItems.put(reloadable.getType(), reloadable));
         });
+        initReloadable(jobConfig);
+    }
+    
+    private void initReloadable(final JobConfiguration jobConfig) {
+        reloadableItems.values().stream().filter(each -> each instanceof ReloadablePostProcessor).forEach(each -> ((ReloadablePostProcessor) each).init(jobConfig));
     }
     
     /**

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/context/ExecutorContext.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.executor.context;
+
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
+import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+
+/**
+ * Executor context.
+ *
+ * @see org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerReloadable
+ * @see org.apache.shardingsphere.elasticjob.infra.concurrent.ExecutorServiceReloadable
+ */
+public final class ExecutorContext {
+    
+    static {
+        ElasticJobServiceLoader.registerTypedService(Reloadable.class);
+    }
+    
+    private final Map<String, Reloadable<?>> reloadableItems = new LinkedHashMap<>();
+    
+    public ExecutorContext() {
+        ServiceLoader.load(Reloadable.class).forEach(each -> {
+            ElasticJobServiceLoader.newTypedServiceInstance(Reloadable.class, each.getType(), new Properties())
+                    .ifPresent(reloadable -> reloadableItems.put(reloadable.getType(), reloadable));
+        });
+    }
+    
+    /**
+     * Reload all reloadable item if necessary.
+     *
+     * @param jobConfiguration job configuration
+     */
+    public void reloadIfNecessary(final JobConfiguration jobConfiguration) {
+        reloadableItems.values().forEach(each -> each.reloadIfNecessary(jobConfiguration));
+    }
+    
+    /**
+     * Get instance.
+     *
+     * @param targetClass target class
+     * @param <T>         target type
+     * @return instance
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(final Class<T> targetClass) {
+        return (T) reloadableItems.get(targetClass.getName()).getInstance();
+    }
+    
+    /**
+     * Shutdown all closeable instances.
+     */
+    public void shutdown() {
+        reloadableItems.values().stream().map(Reloadable::getInstance).forEach(each -> {
+            if (each instanceof Closeable) {
+                try {
+                    ((Closeable) each).close();
+                } catch (IOException ignored) {
+                }
+            }
+        });
+    }
+}

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -62,6 +63,7 @@ public final class ElasticJobExecutorTest {
     @Before
     public void setUp() {
         jobConfig = createJobConfiguration();
+        when(jobFacade.loadJobConfiguration(anyBoolean())).thenReturn(jobConfig);
         elasticJobExecutor = new ElasticJobExecutor(fooJob, jobConfig, jobFacade);
         setJobItemExecutor();
     }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
 
+import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -64,6 +66,11 @@ public final class ExecutorServiceReloadable implements Reloadable<ExecutorServi
     @Override
     public ExecutorService getInstance() {
         return executorService;
+    }
+    
+    @Override
+    public void close() {
+        Optional.ofNullable(executorService).ifPresent(ExecutorService::shutdown);
     }
     
     @Override

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.concurrent;
+
+import com.google.common.base.Strings;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
+import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Executor service reloadable.
+ */
+public final class ExecutorServiceReloadable implements Reloadable<ExecutorService> {
+    
+    private String jobExecutorServiceHandlerType;
+    
+    private ExecutorService executorService;
+    
+    @Override
+    public synchronized void reloadIfNecessary(final JobConfiguration jobConfig) {
+        if (null == executorService) {
+            init(jobConfig.getJobExecutorServiceHandlerType(), jobConfig.getJobName());
+            return;
+        }
+        String newJobExecutorServiceHandlerType = Strings.isNullOrEmpty(jobConfig.getJobExecutorServiceHandlerType())
+                ? JobExecutorServiceHandlerFactory.DEFAULT_HANDLER : jobConfig.getJobExecutorServiceHandlerType();
+        if (newJobExecutorServiceHandlerType.equals(jobExecutorServiceHandlerType)) {
+            return;
+        }
+        reload(newJobExecutorServiceHandlerType, jobConfig.getJobName());
+    }
+    
+    private void init(final String jobExecutorServiceHandlerType, final String jobName) {
+        this.jobExecutorServiceHandlerType = Strings.isNullOrEmpty(jobExecutorServiceHandlerType) ? JobExecutorServiceHandlerFactory.DEFAULT_HANDLER : jobExecutorServiceHandlerType;
+        executorService = JobExecutorServiceHandlerFactory.getHandler(jobExecutorServiceHandlerType).createExecutorService(jobName);
+    }
+    
+    private void reload(final String jobExecutorServiceHandlerType, final String jobName) {
+        executorService.shutdown();
+        this.jobExecutorServiceHandlerType = jobExecutorServiceHandlerType;
+        executorService = JobExecutorServiceHandlerFactory.getHandler(jobExecutorServiceHandlerType).createExecutorService(jobName);
+    }
+    
+    @Override
+    public ExecutorService getInstance() {
+        return executorService;
+    }
+    
+    @Override
+    public String getType() {
+        return ExecutorService.class.getName();
+    }
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.concurrent;
 
 import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
@@ -27,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * Executor service reloadable.
  */
+@Slf4j
 public final class ExecutorServiceReloadable implements Reloadable<ExecutorService> {
     
     private String jobExecutorServiceHandlerType;
@@ -44,6 +46,7 @@ public final class ExecutorServiceReloadable implements Reloadable<ExecutorServi
         if (newJobExecutorServiceHandlerType.equals(jobExecutorServiceHandlerType)) {
             return;
         }
+        log.debug("JobExecutorServiceHandler reload occurred in the job '{}'. Change from '{}' to '{}'.", jobConfig.getJobName(), jobExecutorServiceHandlerType, newJobExecutorServiceHandlerType);
         reload(newJobExecutorServiceHandlerType, jobConfig.getJobName());
     }
     

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadable.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.context.Reloadable;
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/Reloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/Reloadable.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,27 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.error.handler;
+package org.apache.shardingsphere.elasticjob.infra.context;
 
-import org.apache.shardingsphere.elasticjob.infra.spi.SPIPostProcessor;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.spi.TypedSPI;
 
-import java.io.Closeable;
-
 /**
- * Job error handler.
+ * Reloadable.
+ *
+ * @param <T> reload target
  */
-public interface JobErrorHandler extends TypedSPI, SPIPostProcessor, Closeable {
+public interface Reloadable<T> extends TypedSPI {
     
     /**
-     * Handle exception.
-     * 
-     * @param jobName job name
-     * @param cause failure cause
+     * Reload if necessary.
+     *
+     * @param jobConfiguration job configuration
      */
-    void handleException(String jobName, Throwable cause);
+    void reloadIfNecessary(JobConfiguration jobConfiguration);
     
-    @Override
-    default void close() {
-    }
+    /**
+     * Get target instance.
+     *
+     * @return instance
+     */
+    T getInstance();
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/Reloadable.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/Reloadable.java
@@ -20,12 +20,14 @@ package org.apache.shardingsphere.elasticjob.infra.context;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.spi.TypedSPI;
 
+import java.io.Closeable;
+
 /**
  * Reloadable.
  *
  * @param <T> reload target
  */
-public interface Reloadable<T> extends TypedSPI {
+public interface Reloadable<T> extends TypedSPI, Closeable {
     
     /**
      * Reload if necessary.

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/ReloadablePostProcessor.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/context/ReloadablePostProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.context;
+
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+
+/**
+ * Reloadable post processor.
+ */
+public interface ReloadablePostProcessor {
+    
+    /**
+     * Initialize reloadable.
+     *
+     * @param jobConfig job configuration
+     */
+    void init(JobConfiguration jobConfig);
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactory.java
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JobExecutorServiceHandlerFactory {
     
-    private static final String DEFAULT_HANDLER = "CPU";
+    public static final String DEFAULT_HANDLER = "CPU";
     
     static {
         ElasticJobServiceLoader.registerTypedService(JobExecutorServiceHandler.class);

--- a/elasticjob-infra/elasticjob-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.context.Reloadable
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.elasticjob.infra.context.Reloadable
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.elasticjob.infra.concurrent.ExecutorServiceReloadable

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
@@ -27,7 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.infra.concurrent;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ExecutorServiceReloadableTest {
+    
+    @Mock
+    private ExecutorService mockExecutorService;
+    
+    @Test
+    public void assertInitialize() {
+        ExecutorServiceReloadable executorServiceReloadable = new ExecutorServiceReloadable();
+        String jobExecutorServiceHandlerType = "SINGLE_THREAD";
+        JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobExecutorServiceHandlerType(jobExecutorServiceHandlerType).build();
+        assertNull(executorServiceReloadable.getInstance());
+        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        ExecutorService actual = executorServiceReloadable.getInstance();
+        assertNotNull(actual);
+        assertFalse(actual.isShutdown());
+        assertFalse(actual.isTerminated());
+        actual.shutdown();
+    }
+    
+    @Test
+    public void assertReload() {
+        ExecutorServiceReloadable executorServiceReloadable = new ExecutorServiceReloadable();
+        setField(executorServiceReloadable, "jobExecutorServiceHandlerType", "mock");
+        setField(executorServiceReloadable, "executorService", mockExecutorService);
+        JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).build();
+        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        verify(mockExecutorService).shutdown();
+        ExecutorService actual = executorServiceReloadable.getInstance();
+        assertFalse(actual.isShutdown());
+        assertFalse(actual.isTerminated());
+        actual.shutdown();
+    }
+    
+    @Test
+    public void assertUnnecessaryToReload() {
+        ExecutorServiceReloadable executorServiceReloadable = new ExecutorServiceReloadable();
+        JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).build();
+        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        ExecutorService expected = executorServiceReloadable.getInstance();
+        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        ExecutorService actual = executorServiceReloadable.getInstance();
+        assertThat(actual, is(expected));
+        actual.shutdown();
+    }
+    
+    @Test
+    public void assertShutdown() {
+        ExecutorServiceReloadable executorServiceReloadable = new ExecutorServiceReloadable();
+        setField(executorServiceReloadable, "executorService", mockExecutorService);
+        executorServiceReloadable.close();
+        verify(mockExecutorService).shutdown();
+    }
+    
+    @SneakyThrows
+    private void setField(final Object target, final String fieldName, final Object value) {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        boolean originAccessible = field.isAccessible();
+        if (!originAccessible) {
+            field.setAccessible(true);
+        }
+        field.set(target, value);
+        field.setAccessible(originAccessible);
+    }
+}

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
@@ -46,7 +46,7 @@ public final class ExecutorServiceReloadableTest {
         String jobExecutorServiceHandlerType = "SINGLE_THREAD";
         JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).jobExecutorServiceHandlerType(jobExecutorServiceHandlerType).build();
         assertNull(executorServiceReloadable.getInstance());
-        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        executorServiceReloadable.init(jobConfig);
         ExecutorService actual = executorServiceReloadable.getInstance();
         assertNotNull(actual);
         assertFalse(actual.isShutdown());
@@ -72,7 +72,7 @@ public final class ExecutorServiceReloadableTest {
     public void assertUnnecessaryToReload() {
         ExecutorServiceReloadable executorServiceReloadable = new ExecutorServiceReloadable();
         JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).build();
-        executorServiceReloadable.reloadIfNecessary(jobConfig);
+        executorServiceReloadable.init(jobConfig);
         ExecutorService expected = executorServiceReloadable.getInstance();
         executorServiceReloadable.reloadIfNecessary(jobConfig);
         ExecutorService actual = executorServiceReloadable.getInstance();


### PR DESCRIPTION
Fixes #1544 

Changes proposed in this pull request:
- Extract `JobErrorHandler`, `ExecutorService` from ElasticJobExecutor into `ExecutorContext`.
- Add interface `Reloadable` and implements `JobErrorHandlerReloadable`, `ExecutorServiceReloadable`.
- Add testcase for implementations of Reloadable.
