### PR TITLE
Fix an order-dependent flaky test

### DIFF
--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
@@ -121,6 +121,8 @@ public final class BootstrapEnvironmentTest {
 
     @Test
     public void assertGetFrameworkHostPort() {
+        Properties properties = new Properties();
+        ReflectionUtils.setFieldValue(bootstrapEnvironment, "properties", properties);
         assertThat(bootstrapEnvironment.getFrameworkHostPort(), is("localhost:8899"));
     }
 


### PR DESCRIPTION
This is an order-dependent flaky test. And the main reason is that it uses a static variable across different test cases.

The purpose of this case test is to verify a property value (`Hostname`). The expected value is `localhost`, but the actual value is `127.0.0.1`.

**How to reproduce:**

Run this test alone by `mvn test -Dtest=BootstrapEnvironmentTest#assertGetFrameworkHostPort`

**Explanation of this flaky test:**

1. The `properties` object basically is a hashmap with a default value for each key
2. The `properties` object is stored in a singleton [BootstrapEnvironment](https://github.com/apache/shardingsphere-elasticjob/blob/master/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironment.java#L42) (static)
3. In the `properties` object, the default value for `hostname` is `localhost`
4. When the BootstrapEnvironment singleton is initialized, the values of `properties` are populated from [elasticjob-cloud-scheduler.properties](https://github.com/apache/shardingsphere-elasticjob/blob/master/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/resources/conf/elasticjob-cloud-scheduler.properties). So the hostname becomes `127.0.0.1`
5. In some other test cases, the `properties` object will reset. It means that even though the hostname is `127.0.0.1` at the beginning, the hostname becomes `localhost` after reset. So this test case passes.
6. But we run these tests in a certain order or run this test alone, this test fails.

**Solution**:

Reset the "properties" at the beginning of assertGetFrameworkHostPort, make sure we get the default value.

**Error message:**
```
Expected: is "localhost:8899"
     but: was "127.0.0.1:8899"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.apache.shardingsphere.elasticjob.cloud.scheduler.env.BootstrapEnvironmentTest.assertGetFrameworkHostPort(BootstrapEnvironmentTest.java:126)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at edu.illinois.cs.testrunner.execution.JUnitTestRunner.runChild(JUnitTestRunner.java:333)
	at edu.illinois.cs.testrunner.execution.JUnitTestRunner.run(JUnitTestRunner.java:109)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at edu.illinois.cs.testrunner.execution.JUnitTestExecutor.execute(JUnitTestExecutor.java:292)
	at edu.illinois.cs.testrunner.execution.JUnitTestExecutor.execute(JUnitTestExecutor.java:328)
	at edu.illinois.cs.testrunner.execution.JUnitTestExecutor.executeWithJUnit4Runner(JUnitTestExecutor.java:366)
	at edu.illinois.cs.testrunner.execution.JUnitTestExecutor.runOrder(JUnitTestExecutor.java:47)
	at edu.illinois.cs.testrunner.execution.Executor$.$anonfun$run$1(Executor.scala:30)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at scala.util.Try$.apply(Try.scala:209)
	at edu.illinois.cs.testrunner.execution.Executor$.run(Executor.scala:28)
	at edu.illinois.cs.testrunner.execution.Executor$.main(Executor.scala:18)
	at edu.illinois.cs.testrunner.execution.Executor.main(Executor.scala)
```