### PR TITLE
Fix typo in Javadoc

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
@@ -109,7 +109,7 @@ public final class JobNodeStorage {
     /**
      * Create job node if needed.
      * 
-     * <p>Do not create node if root root not existed, which means job is shutdown.</p>
+     * <p>Do not create node if root node not existed, which means job is shutdown.</p>
      * 
      * @param node node
      */


### PR DESCRIPTION
Changes proposed in this pull request:
- Change "root root" to "root node".
