### PR TITLE
Add support for filter chain in Restful module

### DIFF
--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/Filter.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/Filter.java
@@ -42,6 +42,6 @@ public interface Filter {
      * @return HTTP response
      */
     default FullHttpResponse doResponse(final FullHttpRequest httpRequest) {
-        throw new UnsupportedOperationException("The filter [%s] is doing response but didn't override method Filter#doResponse.");
+        throw new UnsupportedOperationException(String.format("The filter [%s] is doing response but didn't override method Filter#doResponse.", getClass().getSimpleName()));
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/Filter.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/Filter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import org.apache.shardingsphere.elasticjob.restful.filter.FilterChain;
+
+/**
+ * HTTP request filter.
+ */
+public interface Filter {
+    
+    /**
+     * Do filter.
+     *
+     * @param httpRequest HTTP request
+     * @param filterChain filter chain
+     * @return pass the filter if true, else do response
+     */
+    boolean doFilter(FullHttpRequest httpRequest, FilterChain filterChain);
+    
+    /**
+     * Do response.
+     *
+     * @param httpRequest HTTP request
+     * @return HTTP response
+     */
+    default FullHttpResponse doResponse(final FullHttpRequest httpRequest) {
+        throw new UnsupportedOperationException("The filter [%s] is doing response but didn't override method Filter#doResponse.");
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/NettyRestfulServiceConfiguration.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/NettyRestfulServiceConfiguration.java
@@ -47,9 +47,20 @@ public final class NettyRestfulServiceConfiguration {
     @Setter
     private boolean trailingSlashSensitive;
     
+    private final List<Filter> filterInstances = new LinkedList<>();
+    
     private final List<RestfulController> controllerInstances = new LinkedList<>();
     
     private final Map<Class<? extends Throwable>, ExceptionHandler<? extends Throwable>> exceptionHandlers = new HashMap<>();
+    
+    /**
+     * Add instances of {@link Filter}.
+     *
+     * @param instances instances of Filter
+     */
+    public void addFilterInstances(final Filter... instances) {
+        filterInstances.addAll(Arrays.asList(instances));
+    }
     
     /**
      * Add instances of RestfulController.

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChain.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChain.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.filter;
+
+import com.google.common.base.Preconditions;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.util.ReferenceCountUtil;
+import org.apache.shardingsphere.elasticjob.restful.Filter;
+
+import java.util.List;
+
+/**
+ * Default filter chain.
+ */
+public final class DefaultFilterChain implements FilterChain {
+    
+    private final ChannelHandlerContext ctx;
+    
+    private final Filter[] filters;
+    
+    private int current;
+    
+    private boolean finished;
+    
+    public DefaultFilterChain(final ChannelHandlerContext ctx, final List<Filter> filterInstances) {
+        this.ctx = ctx;
+        filters = filterInstances.toArray(new Filter[0]);
+    }
+    
+    @Override
+    public void next(final FullHttpRequest httpRequest) {
+        Preconditions.checkState(!finished, "FilterChain has already finished.");
+        if (current < filters.length) {
+            Filter currentFilter = filters[current++];
+            boolean pass = currentFilter.doFilter(httpRequest, this);
+            if (!pass) {
+                finished = true;
+                doResponse(httpRequest, currentFilter);
+            }
+            return;
+        }
+        finished = true;
+        ctx.fireChannelRead(httpRequest);
+    }
+    
+    private void doResponse(final FullHttpRequest httpRequest, final Filter currentFilter) {
+        try {
+            FullHttpResponse httpResponse = currentFilter.doResponse(httpRequest);
+            Preconditions.checkNotNull(httpResponse, "Returning null is not allowed in method Filter#doResponse.");
+            ctx.writeAndFlush(httpResponse);
+        } finally {
+            ReferenceCountUtil.release(httpRequest);
+        }
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/filter/FilterChain.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/filter/FilterChain.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.filter;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+
+/**
+ * Filter chain for {@link org.apache.shardingsphere.elasticjob.restful.Filter}.
+ */
+public interface FilterChain {
+    
+    /**
+     * Next filter.
+     *
+     * @param httpRequest HTTP request
+     */
+    void next(FullHttpRequest httpRequest);
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandler.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.FullHttpRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.elasticjob.restful.Filter;
+import org.apache.shardingsphere.elasticjob.restful.filter.DefaultFilterChain;
+import org.apache.shardingsphere.elasticjob.restful.filter.FilterChain;
+
+import java.util.List;
+
+/**
+ * Filter chain inbound handler.
+ */
+@Slf4j
+@Sharable
+@RequiredArgsConstructor
+public final class FilterChainInboundHandler extends ChannelInboundHandlerAdapter {
+    
+    private final List<Filter> filterInstances;
+    
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        if (filterInstances.isEmpty()) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+        FullHttpRequest request = (FullHttpRequest) msg;
+        FilterChain filterChain = new DefaultFilterChain(ctx, filterInstances);
+        filterChain.next(request);
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
@@ -29,6 +29,8 @@ import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfigura
  */
 public final class RestfulServiceChannelInitializer extends ChannelInitializer<Channel> {
     
+    private final FilterChainInboundHandler filterChainInboundHandler;
+    
     private final HttpRequestDispatcher httpRequestDispatcher;
     
     private final HandlerParameterDecoder handlerParameterDecoder;
@@ -38,6 +40,7 @@ public final class RestfulServiceChannelInitializer extends ChannelInitializer<C
     private final ExceptionHandling exceptionHandling;
     
     public RestfulServiceChannelInitializer(final NettyRestfulServiceConfiguration configuration) {
+        filterChainInboundHandler = new FilterChainInboundHandler(configuration.getFilterInstances());
         httpRequestDispatcher = new HttpRequestDispatcher(configuration.getControllerInstances(), configuration.isTrailingSlashSensitive());
         handlerParameterDecoder = new HandlerParameterDecoder();
         handleMethodExecutor = new HandleMethodExecutor();
@@ -49,6 +52,7 @@ public final class RestfulServiceChannelInitializer extends ChannelInitializer<C
         ChannelPipeline pipeline = channel.pipeline();
         pipeline.addLast("codec", new HttpServerCodec());
         pipeline.addLast("aggregator", new HttpObjectAggregator(1024 * 1024));
+        pipeline.addLast("filterChain", filterChainInboundHandler);
         pipeline.addLast("dispatcher", httpRequestDispatcher);
         pipeline.addLast("handlerParameterDecoder", handlerParameterDecoder);
         pipeline.addLast("handleMethodExecutor", handleMethodExecutor);

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChainTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChainTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.filter;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.elasticjob.restful.Filter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DefaultFilterChainTest {
+    
+    @Mock
+    private ChannelHandlerContext ctx;
+    
+    @Mock
+    private FullHttpRequest httpRequest;
+    
+    @Mock
+    private FullHttpResponse httpResponse;
+    
+    @Mock
+    private Filter firstFilter;
+    
+    @Mock
+    private Filter secondFilter;
+    
+    @Mock
+    private Filter thirdFilter;
+    
+    @Test
+    public void assertNoFilter() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Collections.emptyList());
+        filterChain.next(httpRequest);
+        verify(ctx, never()).writeAndFlush(httpResponse);
+        verify(ctx).fireChannelRead(httpRequest);
+    }
+    
+    @Test
+    public void assertWithSingleFilterPassed() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Collections.singletonList(firstFilter));
+        when(firstFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(firstFilter).doFilter(httpRequest, filterChain);
+        verify(firstFilter, never()).doResponse(httpRequest);
+        filterChain.next(httpRequest);
+        verify(ctx).fireChannelRead(httpRequest);
+        verify(ctx, never()).writeAndFlush(httpResponse);
+    }
+    
+    @Test
+    public void assertWithSingleFilterDoResponse() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Collections.singletonList(firstFilter));
+        when(firstFilter.doResponse(httpRequest)).thenReturn(httpResponse);
+        filterChain.next(httpRequest);
+        verify(firstFilter).doFilter(httpRequest, filterChain);
+        verify(firstFilter).doResponse(httpRequest);
+        verify(ctx, never()).fireChannelRead(any(FullHttpRequest.class));
+        verify(ctx).writeAndFlush(httpResponse);
+    }
+    
+    @Test
+    public void assertWithThreeFiltersPassed() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Arrays.asList(firstFilter, secondFilter, thirdFilter));
+        when(firstFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(firstFilter).doFilter(httpRequest, filterChain);
+        when(secondFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(secondFilter).doFilter(httpRequest, filterChain);
+        when(thirdFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(thirdFilter).doFilter(httpRequest, filterChain);
+        filterChain.next(httpRequest);
+        verify(ctx).fireChannelRead(httpRequest);
+        verify(ctx, never()).writeAndFlush(any(FullHttpResponse.class));
+    }
+    
+    @Test
+    public void assertWithThreeFiltersDoResponseByTheSecond() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Arrays.asList(firstFilter, secondFilter, thirdFilter));
+        when(firstFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(firstFilter).doFilter(httpRequest, filterChain);
+        when(secondFilter.doFilter(httpRequest, filterChain)).thenReturn(false);
+        when(secondFilter.doResponse(httpRequest)).thenReturn(httpResponse);
+        assertFalse(isFinished(filterChain));
+        filterChain.next(httpRequest);
+        verify(secondFilter).doFilter(httpRequest, filterChain);
+        verify(secondFilter).doResponse(httpRequest);
+        assertTrue(isFinished(filterChain));
+        verify(thirdFilter, never()).doFilter(httpRequest, filterChain);
+        verify(ctx, never()).fireChannelRead(any(FullHttpRequest.class));
+        verify(ctx).writeAndFlush(httpResponse);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void assertInvokeFinishedFilterChainWithoutFilter() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Collections.emptyList());
+        filterChain.next(httpRequest);
+        filterChain.next(httpRequest);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void assertInvokeFinishedFilterChainWithTwoFilters() {
+        DefaultFilterChain filterChain = new DefaultFilterChain(ctx, Arrays.asList(firstFilter, secondFilter));
+        when(firstFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(firstFilter).doFilter(httpRequest, filterChain);
+        when(secondFilter.doFilter(httpRequest, filterChain)).thenReturn(true);
+        filterChain.next(httpRequest);
+        verify(secondFilter).doFilter(httpRequest, filterChain);
+        filterChain.next(httpRequest);
+        verify(ctx).fireChannelRead(httpRequest);
+        filterChain.next(httpRequest);
+    }
+    
+    @SneakyThrows
+    private boolean isFinished(final DefaultFilterChain filterChain) {
+        Field field = DefaultFilterChain.class.getDeclaredField("finished");
+        field.setAccessible(true);
+        return (boolean) field.get(filterChain);
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandlerTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.elasticjob.restful.Filter;
+import org.apache.shardingsphere.elasticjob.restful.filter.FilterChain;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class FilterChainInboundHandlerTest {
+    
+    @Mock
+    private Filter mockFilter;
+    
+    @Test
+    @SneakyThrows
+    public void assertFilterPassed() {
+        EmbeddedChannel channel = new EmbeddedChannel(new FilterChainInboundHandler(Collections.singletonList(mockFilter)));
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        when(mockFilter.doFilter(eq(httpRequest), any(FilterChain.class))).thenReturn(true);
+        channel.writeOneInbound(httpRequest);
+        verify(mockFilter).doFilter(eq(httpRequest), any(FilterChain.class));
+        verify(mockFilter, never()).doResponse(any(FullHttpRequest.class));
+    }
+    
+    @Test
+    public void assertFilterDoResponse() {
+        EmbeddedChannel channel = new EmbeddedChannel(new FilterChainInboundHandler(Collections.singletonList(mockFilter)));
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        channel.writeOneInbound(httpRequest);
+        verify(mockFilter).doFilter(eq(httpRequest), any(FilterChain.class));
+        verify(mockFilter).doResponse(any(FullHttpRequest.class));
+    }
+}


### PR DESCRIPTION
Fixes #1757.

Changes proposed in this pull request:
- Create new interface `Filter`.
- Testcases for Filter.
