### PR TITLE
Bind HTTP response lifecycle to request scope in Restful module

### DIFF
--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/handler/HandleContext.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/handler/HandleContext.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.elasticjob.restful.handler;
 
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -35,7 +36,9 @@ public final class HandleContext<T> {
     
     private final FullHttpRequest httpRequest;
     
-    private final MappingContext<T> mappingContext;
+    private final FullHttpResponse httpResponse;
+    
+    private MappingContext<T> mappingContext;
     
     private Object[] args = new Object[0];
 }

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/ContextInitializationInboundHandler.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/ContextInitializationInboundHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.restful.pipeline;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
+import org.apache.shardingsphere.elasticjob.restful.handler.Handler;
+
+
+/**
+ * Create an instance of {@link FullHttpResponse} and initialize {@link HandleContext}.
+ */
+@Slf4j
+@Sharable
+public final class ContextInitializationInboundHandler extends ChannelInboundHandlerAdapter {
+    
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        log.debug("{}", msg);
+        FullHttpRequest httpRequest = (FullHttpRequest) msg;
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(httpRequest.protocolVersion(), HttpResponseStatus.NOT_FOUND, ctx.alloc().buffer());
+        ctx.fireChannelRead(new HandleContext<Handler>(httpRequest, httpResponse));
+    }
+}

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandleMethodExecutor.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandleMethodExecutor.java
@@ -17,16 +17,13 @@
 
 package org.apache.shardingsphere.elasticjob.restful.pipeline;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
 import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
 import org.apache.shardingsphere.elasticjob.restful.handler.Handler;
@@ -42,6 +39,7 @@ import java.lang.reflect.InvocationTargetException;
 @Sharable
 public final class HandleMethodExecutor extends ChannelInboundHandlerAdapter {
     
+    @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
         HandleContext<Handler> handleContext = (HandleContext<Handler>) msg;
@@ -49,28 +47,28 @@ public final class HandleMethodExecutor extends ChannelInboundHandlerAdapter {
             Handler handler = handleContext.getMappingContext().payload();
             Object[] args = handleContext.getArgs();
             Object handleResult = handler.execute(args);
-            FullHttpResponse response;
+            FullHttpResponse httpResponse = handleContext.getHttpResponse();
             if (null != handleResult) {
                 String mimeType = HttpUtil.getMimeType(handler.getProducing()).toString();
                 ResponseBodySerializer serializer = ResponseBodySerializerFactory.getResponseBodySerializer(mimeType);
                 byte[] bodyBytes = serializer.serialize(handleResult);
-                response = createHttpResponse(handler.getProducing(), bodyBytes, handler.getHttpStatusCode());
+                populateHttpResponse(httpResponse, handler.getProducing(), bodyBytes, handler.getHttpStatusCode());
             } else {
-                response = createHttpResponse(handler.getProducing(), new byte[0], handler.getHttpStatusCode());
+                populateHttpResponse(httpResponse, handler.getProducing(), new byte[0], handler.getHttpStatusCode());
             }
-            ctx.writeAndFlush(response);
+            ctx.writeAndFlush(httpResponse);
         } finally {
             ReferenceCountUtil.release(handleContext.getHttpRequest());
         }
     }
     
-    private FullHttpResponse createHttpResponse(final String producingContentType, final byte[] bodyBytes, final int statusCode) {
+    private void populateHttpResponse(final FullHttpResponse httpResponse, final String producingContentType, final byte[] bodyBytes, final int statusCode) {
         HttpResponseStatus httpResponseStatus = HttpResponseStatus.valueOf(statusCode);
-        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, httpResponseStatus, Unpooled.wrappedBuffer(bodyBytes));
-        response.headers().set(HttpHeaderNames.CONTENT_TYPE, producingContentType);
-        HttpUtil.setContentLength(response, bodyBytes.length);
-        HttpUtil.setKeepAlive(response, true);
-        return response;
+        httpResponse.setStatus(httpResponseStatus);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, producingContentType);
+        httpResponse.content().writeBytes(bodyBytes);
+        HttpUtil.setContentLength(httpResponse, httpResponse.content().readableBytes());
+        HttpUtil.setKeepAlive(httpResponse, true);
     }
     
     @Override

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoder.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoder.java
@@ -53,6 +53,7 @@ public final class HandlerParameterDecoder extends ChannelInboundHandlerAdapter 
     
     private final PathMatcher pathMatcher = new RegexPathMatcher();
     
+    @SuppressWarnings({"unchecked", "NullableProblems"})
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
         HandleContext<Handler> handleContext = (HandleContext<Handler>) msg;

--- a/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
+++ b/elasticjob-infra/elasticjob-restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/pipeline/RestfulServiceChannelInitializer.java
@@ -29,6 +29,8 @@ import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfigura
  */
 public final class RestfulServiceChannelInitializer extends ChannelInitializer<Channel> {
     
+    private final ContextInitializationInboundHandler contextInitializationInboundHandler;
+    
     private final HttpRequestDispatcher httpRequestDispatcher;
     
     private final HandlerParameterDecoder handlerParameterDecoder;
@@ -38,6 +40,7 @@ public final class RestfulServiceChannelInitializer extends ChannelInitializer<C
     private final ExceptionHandling exceptionHandling;
     
     public RestfulServiceChannelInitializer(final NettyRestfulServiceConfiguration configuration) {
+        contextInitializationInboundHandler = new ContextInitializationInboundHandler();
         httpRequestDispatcher = new HttpRequestDispatcher(configuration.getControllerInstances(), configuration.isTrailingSlashSensitive());
         handlerParameterDecoder = new HandlerParameterDecoder();
         handleMethodExecutor = new HandleMethodExecutor();
@@ -49,6 +52,7 @@ public final class RestfulServiceChannelInitializer extends ChannelInitializer<C
         ChannelPipeline pipeline = channel.pipeline();
         pipeline.addLast("codec", new HttpServerCodec());
         pipeline.addLast("aggregator", new HttpObjectAggregator(1024 * 1024));
+        pipeline.addLast("contextInitialization", contextInitializationInboundHandler);
         pipeline.addLast("dispatcher", httpRequestDispatcher);
         pipeline.addLast("handlerParameterDecoder", handlerParameterDecoder);
         pipeline.addLast("handleMethodExecutor", handleMethodExecutor);

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
@@ -49,10 +49,11 @@ public final class HandlerParameterDecoderTest {
     
     @Before
     public void setUp() {
+        ContextInitializationInboundHandler contextInitializationInboundHandler = new ContextInitializationInboundHandler();
         HttpRequestDispatcher httpRequestDispatcher = new HttpRequestDispatcher(Collections.singletonList(new DecoderTestController()), false);
         HandlerParameterDecoder handlerParameterDecoder = new HandlerParameterDecoder();
         HandleMethodExecutor handleMethodExecutor = new HandleMethodExecutor();
-        channel = new EmbeddedChannel(httpRequestDispatcher, handlerParameterDecoder, handleMethodExecutor);
+        channel = new EmbeddedChannel(contextInitializationInboundHandler, httpRequestDispatcher, handlerParameterDecoder, handleMethodExecutor);
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
@@ -23,8 +23,9 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import org.apache.shardingsphere.elasticjob.restful.handler.HandlerNotFoundException;
 import org.apache.shardingsphere.elasticjob.restful.controller.JobController;
+import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
+import org.apache.shardingsphere.elasticjob.restful.handler.HandlerNotFoundException;
 import org.junit.Test;
 
 public final class HttpRequestDispatcherTest {
@@ -33,6 +34,6 @@ public final class HttpRequestDispatcherTest {
     public void assertDispatcherHandlerNotFound() {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDispatcher(Lists.newArrayList(new JobController()), false));
         FullHttpRequest fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/myJob/myCron");
-        channel.writeInbound(fullHttpRequest);
+        channel.writeInbound(new HandleContext<>(fullHttpRequest, null));
     }
 }


### PR DESCRIPTION
Refactor for #1757.

Changes proposed in this pull request:
- Bind HTTP response lifecycle to request scope in Restful module.