### PR TITLE
FIX: The spring-boot-starter-jdbc is not optional in ElasticJob Sprin…

### DIFF
--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
…g Boot Starter

Fixes #1791
Changes proposed in this pull request:
-
-
-
