### PR TITLE
Stop the correct instance of ReconcileService when shutdown

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduler.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduler.java
@@ -182,6 +182,7 @@ public final class JobScheduler {
      * Shutdown job.
      */
     public void shutdown() {
+        setUpFacade.tearDown();
         schedulerFacade.shutdownInstance();
         jobExecutor.shutdown();
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacade.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacade.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
-import org.apache.shardingsphere.elasticjob.lite.internal.reconcile.ReconcileService;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ExecutionService;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
@@ -36,14 +35,11 @@ public final class SchedulerFacade {
     
     private final ExecutionService executionService;
     
-    private final ReconcileService reconcileService;
-    
     public SchedulerFacade(final CoordinatorRegistryCenter regCenter, final String jobName) {
         this.jobName = jobName;
         leaderService = new LeaderService(regCenter, jobName);
         shardingService = new ShardingService(regCenter, jobName);
         executionService = new ExecutionService(regCenter, jobName);
-        reconcileService = new ReconcileService(regCenter, jobName);
     }
     
     /**
@@ -61,9 +57,6 @@ public final class SchedulerFacade {
     public void shutdownInstance() {
         if (leaderService.isLeader()) {
             leaderService.removeLeader();
-        }
-        if (reconcileService.isRunning()) {
-            reconcileService.stopAsync();
         }
         JobRegistry.getInstance().shutdown(jobName);
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
@@ -80,4 +80,10 @@ public final class SetUpFacade {
             reconcileService.startAsync();
         }
     }
+    
+    public void tearDown() {
+        if (reconcileService.isRunning()) {
+            reconcileService.stopAsync();
+        }
+    }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
@@ -81,6 +81,9 @@ public final class SetUpFacade {
         }
     }
     
+    /**
+     * Tear down.
+     */
     public void tearDown() {
         if (reconcileService.isRunning()) {
             reconcileService.stopAsync();

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacadeTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
-import org.apache.shardingsphere.elasticjob.lite.internal.reconcile.ReconcileService;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
@@ -48,9 +47,6 @@ public final class SchedulerFacadeTest {
     @Mock
     private ShardingService shardingService;
     
-    @Mock
-    private ReconcileService reconcileService;
-    
     private SchedulerFacade schedulerFacade;
     
     @Before
@@ -59,7 +55,6 @@ public final class SchedulerFacadeTest {
         schedulerFacade = new SchedulerFacade(null, "test_job");
         ReflectionUtils.setFieldValue(schedulerFacade, "leaderService", leaderService);
         ReflectionUtils.setFieldValue(schedulerFacade, "shardingService", shardingService);
-        ReflectionUtils.setFieldValue(schedulerFacade, "reconcileService", reconcileService);
     }
     
     @Test
@@ -68,19 +63,16 @@ public final class SchedulerFacadeTest {
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController);
         schedulerFacade.shutdownInstance();
         verify(leaderService, times(0)).removeLeader();
-        verify(reconcileService, times(0)).stopAsync();
         verify(jobScheduleController).shutdown();
     }
     
     @Test
     public void assertShutdownInstanceIfLeaderAndReconcileServiceIsRunning() {
         when(leaderService.isLeader()).thenReturn(true);
-        when(reconcileService.isRunning()).thenReturn(true);
         JobRegistry.getInstance().registerRegistryCenter("test_job", regCenter);
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController);
         schedulerFacade.shutdownInstance();
         verify(leaderService).removeLeader();
-        verify(reconcileService).stopAsync();
         verify(jobScheduleController).shutdown();
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
@@ -92,4 +92,11 @@ public final class SetUpFacadeTest {
         verify(leaderService).electLeader();
         verify(serverService).persistOnline(true);
     }
+    
+    @Test
+    public void assertTearDown() {
+        when(reconcileService.isRunning()).thenReturn(true);
+        setUpFacade.tearDown();
+        verify(reconcileService).stopAsync();
+    }
 }


### PR DESCRIPTION
Fixes #1853 .

Changes proposed in this pull request:
- Remove `ReconcileService` from `SchedulerFacade`.
- Add `tearDown` method in `SetupFacade`.
- Complete testcases.
