### PR TITLE
#1883 fix performance loss for the misfired configuration that is not turned on

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/LiteJobFacade.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/LiteJobFacade.java
@@ -131,7 +131,7 @@ public final class LiteJobFacade implements JobFacade {
     
     @Override
     public boolean isExecuteMisfired(final Collection<Integer> shardingItems) {
-        return !isNeedSharding() && configService.load(true).isMisfire() && !executionService.getMisfiredJobItems(shardingItems).isEmpty();
+        return configService.load(true).isMisfire() && !isNeedSharding() && !executionService.getMisfiredJobItems(shardingItems).isEmpty();
     }
     
     @Override


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere-elasticjob/issues/1883

Changes proposed in this pull request:
- Reverse order !isNeedSharding() && configService.load(true).isMisfire() -> configService.load(true).isMisfire() && !isNeedSharding(). According to the short-circuit characteristics, if the misfired configuration is not turned on, there will be no additional performance loss.
