### PR TITLE
Use  a auto increment unique identity to Mysql InnoDB PRIMARY KEY

### DIFF
--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/main/resources/META-INF/sql/MySQL.properties
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/main/resources/META-INF/sql/MySQL.properties
@@ -15,7 +15,23 @@
 # limitations under the License.
 #
 
-JOB_EXECUTION_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_EXECUTION_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, task_id VARCHAR(255) NOT NULL, hostname VARCHAR(255) NOT NULL, ip VARCHAR(50) NOT NULL, sharding_item INT NOT NULL, execution_source VARCHAR(20) NOT NULL, failure_cause VARCHAR(4000) NULL, is_success INT NOT NULL, start_time TIMESTAMP NULL, complete_time TIMESTAMP NULL, PRIMARY KEY (id))
+JOB_EXECUTION_LOG.TABLE.CREATE = CREATE TABLE \
+    IF NOT EXISTS JOB_EXECUTION_LOG (   \
+        auto_id int NOT NULL AUTO_INCREMENT,    \
+        id VARCHAR (40) NOT NULL,               \
+        job_name VARCHAR (100) NOT NULL,        \
+        task_id VARCHAR (255) NOT NULL,         \
+        hostname VARCHAR (255) NOT NULL,        \
+        ip VARCHAR (50) NOT NULL,               \
+        sharding_item INT NOT NULL,             \
+        execution_source VARCHAR (20) NOT NULL, \
+        failure_cause VARCHAR (4000) NULL,      \
+        is_success INT NOT NULL,                \
+        start_time TIMESTAMP NULL,              \
+        complete_time TIMESTAMP NULL,           \
+        PRIMARY KEY (auto_id),                  \
+        UNIQUE KEY `id` (`id`)                  \
+    ) ENGINE=InnoDB
 
 JOB_EXECUTION_LOG.INSERT=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 JOB_EXECUTION_LOG.INSERT_COMPLETE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, task_id, hostname, ip, sharding_item, execution_source, is_success, start_time, complete_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -23,9 +39,25 @@ JOB_EXECUTION_LOG.INSERT_FAILURE=INSERT INTO JOB_EXECUTION_LOG (id, job_name, ta
 JOB_EXECUTION_LOG.UPDATE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ? WHERE id = ?
 JOB_EXECUTION_LOG.UPDATE_FAILURE=UPDATE JOB_EXECUTION_LOG SET is_success = ?, complete_time = ?, failure_cause = ? WHERE id = ?
 
-JOB_STATUS_TRACE_LOG.TABLE.CREATE=CREATE TABLE IF NOT EXISTS JOB_STATUS_TRACE_LOG (id VARCHAR(40) NOT NULL, job_name VARCHAR(100) NOT NULL, original_task_id VARCHAR(255) NOT NULL, task_id VARCHAR(255) NOT NULL, slave_id VARCHAR(50) NOT NULL, source VARCHAR(50) NOT NULL, execution_type VARCHAR(20) NOT NULL, sharding_item VARCHAR(100) NOT NULL, state VARCHAR(20) NOT NULL, message VARCHAR(4000) NULL, creation_time TIMESTAMP NULL, PRIMARY KEY (id))
+JOB_STATUS_TRACE_LOG.TABLE.CREATE= CREATE TABLE \
+    IF NOT EXISTS JOB_STATUS_TRACE_LOG ( \
+        auto_id int NOT NULL AUTO_INCREMENT,     \
+        id VARCHAR (40) NOT NULL,                \
+        job_name VARCHAR (100) NOT NULL,         \
+        original_task_id VARCHAR (255) NOT NULL, \
+        task_id VARCHAR (255) NOT NULL,          \
+        slave_id VARCHAR (50) NOT NULL,          \
+        source VARCHAR (50) NOT NULL,            \
+        execution_type VARCHAR (20) NOT NULL,    \
+        sharding_item VARCHAR (100) NOT NULL,    \
+        state VARCHAR (20) NOT NULL,             \
+        message VARCHAR (4000) NULL,             \
+        creation_time TIMESTAMP NULL,            \
+        PRIMARY KEY (auto_id)                    \
+    ) ENGINE=InnoDB
+
 TASK_ID_STATE_INDEX.INDEX.CREATE=CREATE INDEX TASK_ID_STATE_INDEX ON JOB_STATUS_TRACE_LOG (task_id(128), state)
 
 JOB_STATUS_TRACE_LOG.INSERT=INSERT INTO JOB_STATUS_TRACE_LOG (id, job_name, original_task_id, task_id, slave_id, source, execution_type, sharding_item, state, message, creation_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-JOB_STATUS_TRACE_LOG.SELECT=SELECT * FROM JOB_STATUS_TRACE_LOG WHERE task_id = ?
+JOB_STATUS_TRACE_LOG.SELECT=SELECT id, job_name, original_task_id, task_id, slave_id, source, execution_type, sharding_item, state, message, creation_time FROM JOB_STATUS_TRACE_LOG WHERE task_id = ?
 JOB_STATUS_TRACE_LOG.SELECT_ORIGINAL_TASK_ID=SELECT original_task_id FROM JOB_STATUS_TRACE_LOG WHERE task_id = ? and state= 'TASK_STAGING' LIMIT 1


### PR DESCRIPTION
Fixes #1818.

Changes proposed in this pull request:
-  Use  a auto increment unique identity to Mysql InnoDB PRIMARY KEY.
-  fix the JOB_STATUS_TRACE_LOG.SELECT SQL. (If columns' order changed, those logic may be impacted)