### PR TITLE
Remove state pollution caused by test GsonFactoryTest.assertRegisterTypeAdapter to avoid order-dependent flaky tests

### DIFF
--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactory.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactory.java
@@ -31,9 +31,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class GsonFactory {
     
-    private static final GsonBuilder GSON_BUILDER = new GsonBuilder();
+    private static GsonBuilder gsonBuilder = new GsonBuilder();
     
-    private static volatile Gson gson = GSON_BUILDER.create();
+    private static volatile Gson gson = gsonBuilder.create();
     
     private static final JsonParser JSON_PARSER = new JsonParser();
     
@@ -44,8 +44,8 @@ public final class GsonFactory {
      * @param typeAdapter Gson type adapter
      */
     public static synchronized void registerTypeAdapter(final Type type, final TypeAdapter typeAdapter) {
-        GSON_BUILDER.registerTypeAdapter(type, typeAdapter);
-        gson = GSON_BUILDER.create();
+        gsonBuilder.registerTypeAdapter(type, typeAdapter);
+        gson = gsonBuilder.create();
     }
     
     /**
@@ -64,5 +64,13 @@ public final class GsonFactory {
      */
     public static JsonParser getJsonParser() {
         return JSON_PARSER;
+    }
+
+    /**
+     * Re-initialize the GsonBuilder.
+     */
+    public static synchronized void clean() {
+        gsonBuilder = new GsonBuilder();
+        gson = gsonBuilder.create();
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactoryTest.java
@@ -52,6 +52,7 @@ public final class GsonFactoryTest {
         });
         assertThat(beforeRegisterGson.toJson(new GsonFactoryTest()), is("{}"));
         assertThat(GsonFactory.getGson().toJson(new GsonFactoryTest()), is("test"));
+        GsonFactory.clean();
     }
     
     @Test


### PR DESCRIPTION
Fixes #1900.

Changes proposed in this pull request:
- Remove the `final` keyword for the `GsonBuilder` field in `GsonFactory` class.
- Add `clean` method in `GsonFactory` class, which re-initializes the `GsonBuilder`.
- Invoke the `clean` method in `GsonFactory` when the test `GsonFactoryTest.assertRegisterTypeAdapter` finishes.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Note: this PR is a follow-up of #1774.