### PR TITLE
SingleSharding process keep pace with MultipleSharding process

### DIFF
--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
@@ -27,16 +27,21 @@ import org.apache.shardingsphere.elasticjob.executor.item.JobItemExecutorFactory
 import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
 import org.apache.shardingsphere.elasticjob.infra.exception.ExceptionUtils;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobExecutionEnvironmentException;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent.ExecutionSource;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.State;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /**
  * ElasticJob executor.

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -117,7 +117,7 @@ public final class ElasticJobExecutorTest {
         assertExecuteFailureWhenThrowException(createSingleShardingContexts());
     }
     
-    @Test
+    @Test(expected = JobSystemException.class)
     public void assertExecuteFailureWhenThrowExceptionForMultipleShardingItems() {
         assertExecuteFailureWhenThrowException(createMultipleShardingContexts());
     }


### PR DESCRIPTION
Fixes #1910.

Changes proposed in this pull request:
- remove SingleSharding process run in currentThread
- catch ExecutionException and throw the JobSystemException of executorService.submit
-  `assertExecuteFailureWhenThrowExceptionForMultipleShardingItems`  test is JobSystemException
