### PR TITLE
add annotation define  to discuss

### DIFF
--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/ElasticJobProp.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/ElasticJobProp.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * The annotation that specify elastic-job prop.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ElasticJobProp {
+    
+    /**
+     * prop key.
+     * @return key
+     */
+    String key();
+    
+    /**
+     * prop value.
+     * @return value
+     */
+    String value() default "";
+}

--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.elasticjob.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -27,6 +28,7 @@ import java.lang.annotation.Target;
  * The annotation that specify a job of elastic.
  */
 @Documented
+@Repeatable(EnableElasticJobs.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface EnableElasticJob {

--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
@@ -49,7 +49,7 @@ public @interface EnableElasticJob {
      * Sharding total count.
      * @return shardingTotalCount
      */
-    int shardingTotalCount() default 1;
+    int shardingTotalCount();
     
     /**
      * Sharding item parameters.

--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation that specify a job of elastic.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EnableElasticJob {
+    
+    /**
+     * CRON expression, control the job trigger time.
+     * @return cron
+     */
+    String cron() default "";
+    
+    /**
+     * Job name.
+     * @return jobName
+     */
+    String jobName() default "";
+    
+    /**
+     * Sharding total count.
+     * @return shardingTotalCount
+     */
+    int shardingTotalCount() default 1;
+    
+    /**
+     * Sharding item parameters.
+     * @return shardingItemParameters
+     */
+    String shardingItemParameters() default "";
+    
+    /**
+     * Job parameter.
+     * @return jobParameter
+     */
+    String jobParameter() default "";
+    
+    /**
+     * Monitor job execution status.
+     * @return monitorExecution
+     */
+    boolean monitorExecution() default true;
+    
+    /**
+     * Enable or disable job failover.
+     * @return failover
+     */
+    boolean failover() default false;
+    
+    /**
+     * Enable or disable the missed task to re-execute.
+     * @return misfire
+     */
+    boolean misfire() default true;
+    
+    /**
+     * The maximum value for time difference between server and registry center in seconds.
+     * @return maxTimeDiffSeconds
+     */
+    int maxTimeDiffSeconds() default -1;
+    
+    /**
+     * Service scheduling interval in minutes for repairing job server inconsistent state.
+     * @return reconcileIntervalMinutes
+     */
+    int reconcileIntervalMinutes() default 10;
+    
+    /**
+     * Job sharding strategy type.
+     * @return jobShardingStrategyType
+     */
+    String jobShardingStrategyType() default "AVG_ALLOCATION";
+    
+    /**
+     * Job thread pool handler type.
+     * @return jobExecutorServiceHandlerType
+     */
+    String jobExecutorServiceHandlerType() default "CPU";
+    
+    /**
+     * Job thread pool handler type.
+     * @return jobErrorHandlerType
+     */
+    String jobErrorHandlerType() default "";
+    
+    /**
+     * Job listener types.
+     * @return jobListenerTypes
+     */
+    String[] jobListenerTypes() default {};
+    
+    /**
+     * Job description.
+     * @return description
+     */
+    String description() default "";
+    
+    /**
+     * Job properties.
+     * @return props
+     */
+    ElasticJobProp[] props() default {};
+    
+    /**
+     * Enable or disable start the job.
+     * @return disabled
+     */
+    boolean disabled() default false;
+    
+    /**
+     * Enable or disable local configuration override registry center configuration.
+     * @return overwrite
+     */
+    boolean overwrite() default false;
+}

--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJob.java
@@ -32,16 +32,16 @@ import java.lang.annotation.Target;
 public @interface EnableElasticJob {
     
     /**
+     * Job name.
+     * @return jobName
+     */
+    String jobName();
+    
+    /**
      * CRON expression, control the job trigger time.
      * @return cron
      */
     String cron() default "";
-    
-    /**
-     * Job name.
-     * @return jobName
-     */
-    String jobName() default "";
     
     /**
      * Sharding total count.

--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobs.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobs.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation that specify multiple jobs of elastic.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EnableElasticJobs {
+    
+    /**
+     * EnableElasticJob list.
+     * @return EnableElasticJob list
+     */
+    EnableElasticJob[] value();
+}

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.elasticjob.annotation;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
@@ -1,0 +1,24 @@
+package org.apache.shardingsphere.elasticjob.annotation;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.shardingsphere.elasticjob.annotation.job.impl.SimpleTestJob;
+import org.junit.Test;
+
+public class EnableElasticJobTest {
+    
+    @Test
+    public void assertAnnotationJob() {
+        EnableElasticJob annotation = SimpleTestJob.class.getAnnotation(EnableElasticJob.class);
+        assertEquals(annotation.jobName(), "SimpleTestJob");
+        assertEquals(annotation.cron(), "0/5 * * * * ?");
+        assertEquals(annotation.shardingTotalCount(), 3);
+        assertEquals(annotation.shardingItemParameters(), "0=Beijing,1=Shanghai,2=Guangzhou");
+        assertArrayEquals(annotation.jobListenerTypes(), new String[] {"NOOP", "LOG"});
+        for (ElasticJobProp prop :annotation.props()) {
+            assertEquals(prop.key(), "print.title");
+            assertEquals(prop.value(), "test title");
+        }
+    }
+}

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/EnableElasticJobTest.java
@@ -20,6 +20,9 @@ package org.apache.shardingsphere.elasticjob.annotation;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
 import org.apache.shardingsphere.elasticjob.annotation.job.impl.SimpleTestJob;
 import org.junit.Test;
 
@@ -27,15 +30,22 @@ public class EnableElasticJobTest {
     
     @Test
     public void assertAnnotationJob() {
-        EnableElasticJob annotation = SimpleTestJob.class.getAnnotation(EnableElasticJob.class);
-        assertEquals(annotation.jobName(), "SimpleTestJob");
-        assertEquals(annotation.cron(), "0/5 * * * * ?");
-        assertEquals(annotation.shardingTotalCount(), 3);
-        assertEquals(annotation.shardingItemParameters(), "0=Beijing,1=Shanghai,2=Guangzhou");
-        assertArrayEquals(annotation.jobListenerTypes(), new String[] {"NOOP", "LOG"});
-        for (ElasticJobProp prop :annotation.props()) {
-            assertEquals(prop.key(), "print.title");
-            assertEquals(prop.value(), "test title");
+        EnableElasticJobs annotations = SimpleTestJob.class.getAnnotation(EnableElasticJobs.class);
+        Queue<String> jobNames = new LinkedList<>(Arrays.asList("SimpleTestJobFirst", "SimpleTestJobSecond"));
+        
+        for (EnableElasticJob annotation :annotations.value()) {
+            assertEquals(annotation.jobName(), jobNames.poll());
+            assertEquals(annotation.cron(), "0/5 * * * * ?");
+            assertEquals(annotation.shardingTotalCount(), 3);
+            assertEquals(annotation.shardingItemParameters(), "0=Beijing,1=Shanghai,2=Guangzhou");
+            assertArrayEquals(annotation.jobListenerTypes(), new String[] {"NOOP", "LOG"});
+    
+            Queue<String> propsKey = new LinkedList<>(Arrays.asList("print.title", "print.content"));
+            Queue<String> propsValue = new LinkedList<>(Arrays.asList("test title", "test content"));
+            for (ElasticJobProp prop :annotation.props()) {
+                assertEquals(prop.key(), propsKey.poll());
+                assertEquals(prop.value(), propsValue.poll());
+            }
         }
     }
 }

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/CustomJob.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/CustomJob.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.annotation.job;
+
+import org.apache.shardingsphere.elasticjob.api.ElasticJob;
+import org.apache.shardingsphere.elasticjob.api.ShardingContext;
+
+public interface CustomJob extends ElasticJob {
+    
+    /**
+     * Execute custom job.
+     *
+     * @param shardingContext sharding context
+     */
+    void execute(ShardingContext shardingContext);
+}

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
@@ -1,0 +1,22 @@
+package org.apache.shardingsphere.elasticjob.annotation.job.impl;
+
+import org.apache.shardingsphere.elasticjob.annotation.EnableElasticJob;
+import org.apache.shardingsphere.elasticjob.annotation.ElasticJobProp;
+import org.apache.shardingsphere.elasticjob.annotation.job.CustomJob;
+import org.apache.shardingsphere.elasticjob.api.ShardingContext;
+
+@EnableElasticJob(
+        cron = "0/5 * * * * ?",
+        jobName = "SimpleTestJob",
+        shardingTotalCount = 3,
+        shardingItemParameters = "0=Beijing,1=Shanghai,2=Guangzhou",
+        jobListenerTypes = {"NOOP", "LOG"},
+        props = {@ElasticJobProp(key = "print.title", value = "test title")}
+)
+public class SimpleTestJob implements CustomJob {
+    
+    @Override
+    public void execute(final ShardingContext shardingContext) {
+    }
+    
+}

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.elasticjob.annotation.job.impl;
 
 import org.apache.shardingsphere.elasticjob.annotation.EnableElasticJob;

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/job/impl/SimpleTestJob.java
@@ -24,11 +24,25 @@ import org.apache.shardingsphere.elasticjob.api.ShardingContext;
 
 @EnableElasticJob(
         cron = "0/5 * * * * ?",
-        jobName = "SimpleTestJob",
+        jobName = "SimpleTestJobFirst",
         shardingTotalCount = 3,
         shardingItemParameters = "0=Beijing,1=Shanghai,2=Guangzhou",
         jobListenerTypes = {"NOOP", "LOG"},
-        props = {@ElasticJobProp(key = "print.title", value = "test title")}
+        props = {
+                @ElasticJobProp(key = "print.title", value = "test title"),
+                @ElasticJobProp(key = "print.content", value = "test content")
+        }
+)
+@EnableElasticJob(
+        cron = "0/5 * * * * ?",
+        jobName = "SimpleTestJobSecond",
+        shardingTotalCount = 3,
+        shardingItemParameters = "0=Beijing,1=Shanghai,2=Guangzhou",
+        jobListenerTypes = {"NOOP", "LOG"},
+        props = {
+                @ElasticJobProp(key = "print.title", value = "test title"),
+                @ElasticJobProp(key = "print.content", value = "test content")
+        }
 )
 public class SimpleTestJob implements CustomJob {
     

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/core/annotation/ElasticJobScan.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/core/annotation/ElasticJobScan.java
@@ -15,25 +15,35 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.annotation;
+package org.apache.shardingsphere.elasticjob.lite.spring.core.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The Container annotation that aggregates several {@link EnableElasticJob} annotations.
+ * Use this annotation to register Elastic Job interfaces when using Java Config.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface EnableElasticJobs {
+@Repeatable(ElasticJobScans.class)
+public @interface ElasticJobScan {
     
     /**
-     * EnableElasticJob list.
-     * @return EnableElasticJob list
+     * Alias for the {@link #basePackages()} attribute.
+     *
+     * @return base package names
      */
-    EnableElasticJob[] value();
+    String[] value() default {};
+    
+    /**
+     * Base packages to scan for Elastic Job interfaces.
+     *
+     * @return base package names for scanning Elastic Job interface
+     */
+    String[] basePackages() default {};
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/core/annotation/ElasticJobScans.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/core/annotation/ElasticJobScans.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.annotation;
+package org.apache.shardingsphere.elasticjob.lite.spring.core.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -24,16 +24,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The Container annotation that aggregates several {@link EnableElasticJob} annotations.
+ * The Container annotation that aggregates several {@link ElasticJobScan} annotations.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface EnableElasticJobs {
+public @interface ElasticJobScans {
     
     /**
-     * EnableElasticJob list.
-     * @return EnableElasticJob list
+     * ElasticJobScan list.
+     * @return ElasticJobScan list
      */
-    EnableElasticJob[] value();
+    ElasticJobScan[] value();
 }


### PR DESCRIPTION
Fixes #1445 

annotation define design to discuss.  

1. define annotation `EnableElasticJob` , like this:

```
@EnableElasticJob(
        cron = "0/5 * * * * ?",
        jobName = "SimpleTestJobFirst",
        shardingTotalCount = 3,
        shardingItemParameters = "0=Beijing,1=Shanghai,2=Guangzhou",
        jobListenerTypes = {"NOOP", "LOG"},
        props = {
                @ElasticJobProp(key = "print.title", value = "test title"),
                @ElasticJobProp(key = "print.content", value = "test content")
        }
)
@EnableElasticJob(
        cron = "0/5 * * * * ?",
        jobName = "SimpleTestJobSecond",
        shardingTotalCount = 3,
        shardingItemParameters = "0=Beijing,1=Shanghai,2=Guangzhou",
        jobListenerTypes = {"NOOP", "LOG"},
        props = {
                @ElasticJobProp(key = "print.title", value = "test title"),
                @ElasticJobProp(key = "print.content", value = "test content")
        }
)
public class SimpleTestJob implements CustomJob {
    
    @Override
    public void execute(final ShardingContext shardingContext) {
    }
    
}
```

2. define annotation `ElasticJobScan` , like this:

```
@Configuration
@ElasticJobScan("org.apache.shardingsphere.elasticjob.lite.example.job.simple")
public class ElasticConfig {
   @Bean
   public CoordinatorRegistryCenter registryCenter() {
     return new ZookeeperRegistryCenter(new ZookeeperConfiguration());
   }
}
```


Changes proposed in this pull request:
- add annotation `EnableElasticJob`, `EnableElasticJobs` define
- add annotation `ElasticJobScan`, `ElasticJobScans` define


