### PR TITLE
support jdk11 compile

### DIFF
--- a/.github/workflows/maven-macos-jdk-11.yml
+++ b/.github/workflows/maven-macos-jdk-11.yml
@@ -39,5 +39,5 @@ jobs:
           java-version: 11
       - name: Build with Maven
         run: |
-          mvn --batch-mode --no-transfer-progress clean install cobertura:cobertura -Dmaven.javadoc.skip=true
+          mvn --batch-mode --no-transfer-progress clean install -Dmaven.javadoc.skip=true
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/maven-macos-jdk-11.yml
+++ b/.github/workflows/maven-macos-jdk-11.yml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven on macOS (JDK11)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: |
+          mvn --batch-mode --no-transfer-progress clean install cobertura:cobertura -Dmaven.javadoc.skip=true
+          bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/maven-windows-jdk-11.yml
+++ b/.github/workflows/maven-windows-jdk-11.yml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This workflow will build a Java project with Maven in Windows environment
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven on Windows (JDK11)
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global core.longpaths true
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: |
+          mvn --batch-mode --no-transfer-progress clean install cobertura:cobertura -D"maven.javadoc.skip=true"

--- a/.github/workflows/maven-windows-jdk-11.yml
+++ b/.github/workflows/maven-windows-jdk-11.yml
@@ -38,4 +38,4 @@ jobs:
           java-version: 11
       - name: Build with Maven
         run: |
-          mvn --batch-mode --no-transfer-progress clean install cobertura:cobertura -D"maven.javadoc.skip=true"
+          mvn --batch-mode --no-transfer-progress clean install -D"maven.javadoc.skip=true"

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudAppController.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudAppController.java
@@ -82,7 +82,7 @@ public final class CloudAppController implements RestfulController {
      * Register app config.
      *
      * @param appConfig cloud app config
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST)
     public boolean register(@RequestBody final CloudAppConfigurationPOJO appConfig) {
@@ -98,7 +98,7 @@ public final class CloudAppController implements RestfulController {
      * Update app config.
      *
      * @param appConfig cloud app config
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.PUT)
     public boolean update(@RequestBody final CloudAppConfigurationPOJO appConfig) {
@@ -143,7 +143,7 @@ public final class CloudAppController implements RestfulController {
      * Disable app config.
      *
      * @param appName app name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/{appName}/disable")
     public boolean disable(@Param(name = "appName", source = ParamSource.PATH) final String appName) {
@@ -162,7 +162,7 @@ public final class CloudAppController implements RestfulController {
      * Enable app.
      *
      * @param appName app name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/{appName}/enable")
     public boolean enable(@Param(name = "appName", source = ParamSource.PATH) final String appName) {
@@ -181,7 +181,7 @@ public final class CloudAppController implements RestfulController {
      * Deregister app.
      *
      * @param appName app name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.DELETE, path = "/{appName}")
     public boolean deregister(@Param(name = "appName", source = ParamSource.PATH) final String appName) {

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudJobController.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudJobController.java
@@ -107,7 +107,7 @@ public final class CloudJobController implements RestfulController {
      * Register cloud job.
      *
      * @param cloudJobConfig cloud job configuration
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/register")
     public boolean register(@RequestBody final CloudJobConfigurationPOJO cloudJobConfig) {
@@ -119,7 +119,7 @@ public final class CloudJobController implements RestfulController {
      * Update cloud job.
      *
      * @param cloudJobConfig cloud job configuration
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.PUT, path = "/update")
     public boolean update(@RequestBody final CloudJobConfigurationPOJO cloudJobConfig) {
@@ -131,7 +131,7 @@ public final class CloudJobController implements RestfulController {
      * Deregister cloud job.
      *
      * @param jobName job name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.DELETE, path = "/{jobName}/deregister")
     public boolean deregister(@Param(name = "jobName", source = ParamSource.PATH) final String jobName) {
@@ -154,7 +154,7 @@ public final class CloudJobController implements RestfulController {
      * Enable cloud job.
      *
      * @param jobName job name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/{jobName}/enable")
     public boolean enable(@Param(name = "jobName", source = ParamSource.PATH) final String jobName) {
@@ -170,7 +170,7 @@ public final class CloudJobController implements RestfulController {
      * Disable cloud job.
      *
      * @param jobName job name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/{jobName}/disable")
     public boolean disable(@Param(name = "jobName", source = ParamSource.PATH) final String jobName) {
@@ -185,7 +185,7 @@ public final class CloudJobController implements RestfulController {
      * Trigger job once.
      *
      * @param jobName job name
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/trigger")
     public boolean trigger(@RequestBody final String jobName) {

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudOperationController.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudOperationController.java
@@ -63,7 +63,7 @@ public final class CloudOperationController implements RestfulController {
     /**
      * Explicit reconcile service.
      *
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/reconcile/explicit")
     public boolean explicitReconcile() {
@@ -75,7 +75,7 @@ public final class CloudOperationController implements RestfulController {
     /**
      * Implicit reconcile service.
      *
-     * @return <tt>true</tt> for operation finished.
+     * @return <em>true</em> for operation finished.
      */
     @Mapping(method = Http.POST, path = "/reconcile/implicit")
     public boolean implicitReconcile() {

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/fixture/listener/SimpleOnceListener.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/fixture/listener/SimpleOnceListener.java
@@ -20,15 +20,14 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.liste
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.lite.api.listener.AbstractDistributeOnceElasticJobListener;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.service.FooService;
-
-import javax.annotation.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class SimpleOnceListener extends AbstractDistributeOnceElasticJobListener {
     
-    @Resource
+    @Autowired
     private FooService fooService;
     
     private final long startedTimeoutMilliseconds;

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
@@ -27,8 +27,7 @@ import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.annotation.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertTrue;
 
@@ -39,7 +38,7 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     
     private final String throughputDataflowJobName;
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
     
     @Before

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
@@ -28,8 +28,7 @@ import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.annotation.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +39,7 @@ public abstract class AbstractOneOffJobSpringIntegrateTest extends AbstractZooke
     
     private final String throughputDataflowJobName;
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
     
     @Before

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
@@ -25,9 +25,8 @@ import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-
-import javax.annotation.Resource;
 
 import static org.junit.Assert.assertTrue;
 
@@ -36,7 +35,7 @@ public final class JobSpringNamespaceWithRefTest extends AbstractZookeeperJUnit4
     
     private final String simpleJobName = "simpleElasticJob_job_ref";
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
     
     @Before

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import static org.junit.Assert.assertTrue;
-import javax.annotation.Resource;
 import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
@@ -27,6 +26,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -35,7 +35,7 @@ public final class JobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnit
     
     private final String scriptJobName = "scriptElasticJob_job_type";
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
     
     private Scheduler scheduler;

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
@@ -26,9 +26,8 @@ import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-
-import javax.annotation.Resource;
 
 import static org.junit.Assert.assertTrue;
 
@@ -37,7 +36,7 @@ public final class OneOffJobSpringNamespaceWithRefTest extends AbstractZookeeper
     
     private final String oneOffSimpleJobName = "oneOffSimpleElasticJobRef";
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
 
     @Before

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -24,9 +24,8 @@ import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZ
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-
-import javax.annotation.Resource;
 
 import static org.junit.Assert.assertTrue;
 
@@ -35,7 +34,7 @@ public final class OneOffJobSpringNamespaceWithTypeTest extends AbstractZookeepe
     
     private final String scriptJobName = "oneOffScriptElasticJob_job_type";
     
-    @Resource
+    @Autowired
     private CoordinatorRegistryCenter regCenter;
     
     @After

--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -34,8 +34,8 @@
     </modules>
 
     <properties>
-        <springboot.version>2.3.1.RELEASE</springboot.version>
-        <springframework.version>[3.1.0.RELEASE,5.2.7.RELEASE]</springframework.version>
+        <springboot.version>2.5.3</springboot.version>
+        <springframework.version>[3.1.0.RELEASE,5.3.9]</springframework.version>
     </properties>
 
     <dependencyManagement>

--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -34,8 +34,8 @@
     </modules>
 
     <properties>
-        <springboot.version>2.5.3</springboot.version>
-        <springframework.version>[3.1.0.RELEASE,5.3.9]</springframework.version>
+        <springboot.version>2.3.12.RELEASE</springboot.version>
+        <springframework.version>[3.1.0.RELEASE,5.2.16.RELEASE]</springframework.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
         <h2.version>1.4.184</h2.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>2.7.21</mockito.version>
+        <mockito.version>3.11.2</mockito.version>
         
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
@@ -87,7 +87,7 @@
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven-enforcer-plugin.version>1.4</maven-enforcer-plugin.version>
         <maven-project-info-reports-plugin.version>2.8</maven-project-info-reports-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
@@ -100,8 +100,6 @@
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
-
-        <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
     </properties>
     
     <dependencyManagement>
@@ -486,6 +484,7 @@
                 </executions>
                 <configuration>
                     <aggregate>true</aggregate>
+                    <source>${java.version}</source>
                     <charset>${project.build.sourceEncoding}</charset>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <docencoding>${project.build.sourceEncoding}</docencoding>


### PR DESCRIPTION
Fixes #1947.

Changes proposed in this pull request:
- remove `javadocExecutable` 
- modify  `<tt>` to `<em>` (maven-javadoc-plugin no find `<tt>` label)
- modify  `@Resource` to `@Autowired` (jdk11 remove `javax.annotation`)
- update version `mockito.version` is `2.7` to `3.11` ( '2.7'  not support jdk11)
- update version `maven-compiler-plugin.version` is `3.3` to `3.8` ( '3.3'  not support jdk11)
- update version `maven-javadoc-plugin.version` is `2.10` to `3.3` ('2.10' not support jdk11)
- add  jdk11 build in github-workflows (remove `cobertura:cobertura`, cobertura-maven-plugin can‘t support jdk11 )