### PR TITLE
Fix NPE in InstanceService.getAvailableJobInstances

### DIFF
--- a/elasticjob-infra/elasticjob-registry-center/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
+++ b/elasticjob-infra/elasticjob-registry-center/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
@@ -137,10 +137,7 @@ public final class ZookeeperRegistryCenter implements CoordinatorRegistryCenter 
             return getDirectly(key);
         }
         Optional<ChildData> resultInCache = cache.get(key);
-        if (resultInCache.isPresent()) {
-            return null == resultInCache.get().getData() ? null : new String(resultInCache.get().getData(), StandardCharsets.UTF_8);
-        }
-        return getDirectly(key);
+        return resultInCache.map(v -> null == v.getData() ? null : new String(v.getData(), StandardCharsets.UTF_8)).orElse(getDirectly(key));
     }
     
     private CuratorCache findCuratorCache(final String key) {

--- a/elasticjob-infra/elasticjob-registry-center/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
+++ b/elasticjob-infra/elasticjob-registry-center/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
@@ -137,7 +137,7 @@ public final class ZookeeperRegistryCenter implements CoordinatorRegistryCenter 
             return getDirectly(key);
         }
         Optional<ChildData> resultInCache = cache.get(key);
-        return resultInCache.map(v -> null == v.getData() ? null : new String(v.getData(), StandardCharsets.UTF_8)).orElse(getDirectly(key));
+        return resultInCache.map(v -> null == v.getData() ? null : new String(v.getData(), StandardCharsets.UTF_8)).orElseGet(() -> getDirectly(key));
     }
     
     private CuratorCache findCuratorCache(final String key) {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java
@@ -70,7 +70,7 @@ public final class InstanceService {
         List<JobInstance> result = new LinkedList<>();
         for (String each : jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT)) {
             JobInstance jobInstance = YamlEngine.unmarshal(jobNodeStorage.getJobNodeData(instanceNode.getInstancePath(each)), JobInstance.class);
-            if (serverService.isEnableServer(jobInstance.getServerIp())) {
+            if (null != jobInstance && serverService.isEnableServer(jobInstance.getServerIp())) {
                 result.add(new JobInstance(each));
             }
         }


### PR DESCRIPTION
Fixes #1950.

I think the root reason is that:
https://github.com/apache/shardingsphere-elasticjob/blob/054571c6d7caca455418e0f83056a0182315bd75/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceService.java#L69-L78
jobNodeStorage.getJobNodeChildrenKeys(InstanceNode.ROOT) and jobNodeStorage.getJobNodeData(instanceNode.getInstancePath(each)) is not an atomic op.
jobNodeStorage.getJobNodeData(instanceNode.getInstancePath(each)) may return null then for some others delete op or network error.


Changes proposed in this pull request:
- Add null check for JobInstance.
- Use Optional map instead of Optional.isPresent.


