### PR TITLE
enableEventTrace Separate configuration

### DIFF
--- a/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/api/JobConfiguration.java
+++ b/elasticjob-api/src/main/java/org/apache/shardingsphere/elasticjob/api/JobConfiguration.java
@@ -80,6 +80,8 @@ public final class JobConfiguration {
     private final String label;
     
     private final boolean staticSharding;
+
+    private final boolean enableEventTrace;
     
     /**
      * Create ElasticJob configuration builder.
@@ -138,6 +140,8 @@ public final class JobConfiguration {
         private String label;
         
         private boolean staticSharding;
+
+        private boolean enableEventTrace;
     
         /**
          * Cron expression.
@@ -412,6 +416,17 @@ public final class JobConfiguration {
             this.staticSharding = staticSharding;
             return this;
         }
+
+        /**
+         * Set static enableEventTrace.
+         *
+         * @param enableEventTrace static enableEventTrace
+         * @return ElasticJob configuration builder
+         */
+        public Builder enableEventTrace(final boolean enableEventTrace) {
+            this.enableEventTrace = enableEventTrace;
+            return this;
+        }
         
         /**
          * Build ElasticJob configuration.
@@ -424,7 +439,7 @@ public final class JobConfiguration {
             return new JobConfiguration(jobName, cron, timeZone, shardingTotalCount, shardingItemParameters, jobParameter,
                     monitorExecution, failover, misfire, maxTimeDiffSeconds, reconcileIntervalMinutes,
                     jobShardingStrategyType, jobExecutorServiceHandlerType, jobErrorHandlerType, jobListenerTypes,
-                    extraConfigurations, description, props, disabled, overwrite, label, staticSharding);
+                    extraConfigurations, description, props, disabled, overwrite, label, staticSharding, enableEventTrace);
         }
     }
 }

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/facade/CloudJobFacadeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/facade/CloudJobFacadeTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,94 +43,94 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class CloudJobFacadeTest {
-    
+
     private ShardingContexts shardingContexts;
-    
+
     @Mock
     private JobTracingEventBus jobTracingEventBus;
-    
+
     private JobFacade jobFacade;
-    
+
     @Before
     public void setUp() {
         shardingContexts = getShardingContexts();
         jobFacade = new CloudJobFacade(shardingContexts, getJobConfiguration(), jobTracingEventBus);
     }
-    
+
     private ShardingContexts getShardingContexts() {
         Map<Integer, String> shardingItemParameters = new HashMap<>(1, 1);
         shardingItemParameters.put(0, "A");
         return new ShardingContexts("fake_task_id", "test_job", 3, "", shardingItemParameters);
     }
-    
+
     private JobConfiguration getJobConfiguration() {
         return JobConfiguration.newBuilder("test_job", 1).setProperty(DataflowJobProperties.STREAM_PROCESS_KEY, Boolean.FALSE.toString()).build();
     }
-    
+
     @Test
     public void assertCheckJobExecutionEnvironment() throws JobExecutionEnvironmentException {
         jobFacade.checkJobExecutionEnvironment();
     }
-    
+
     @Test
     public void assertFailoverIfNecessary() {
         jobFacade.failoverIfNecessary();
     }
-    
+
     @Test
     public void assertRegisterJobBegin() {
         jobFacade.registerJobBegin(null);
     }
-    
+
     @Test
     public void assertRegisterJobCompleted() {
         jobFacade.registerJobCompleted(null);
     }
-    
+
     @Test
     public void assertGetShardingContext() {
         assertThat(jobFacade.getShardingContexts(), is(shardingContexts));
     }
-    
+
     @Test
     public void assertMisfireIfNecessary() {
         jobFacade.misfireIfRunning(null);
     }
-    
+
     @Test
     public void assertClearMisfire() {
         jobFacade.clearMisfire(null);
     }
-    
+
     @Test
     public void assertIsExecuteMisfired() {
         assertFalse(jobFacade.isExecuteMisfired(null));
     }
-    
+
     @Test
     public void assertIsNeedSharding() {
         assertFalse(jobFacade.isNeedSharding());
     }
-    
+
     @Test
     public void assertBeforeJobExecuted() {
         jobFacade.beforeJobExecuted(null);
     }
-    
+
     @Test
     public void assertAfterJobExecuted() {
         jobFacade.afterJobExecuted(null);
     }
-    
+
     @Test
     public void assertPostJobExecutionEvent() {
-        JobExecutionEvent jobExecutionEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent jobExecutionEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         jobFacade.postJobExecutionEvent(jobExecutionEvent);
         verify(jobTracingEventBus).post(jobExecutionEvent);
     }
-    
+
     @Test
     public void assertPostJobStatusTraceEvent() {
-        jobFacade.postJobStatusTraceEvent(String.format("%s@-@0@-@%s@-@fake_slave_id@-@0", "test_job", ExecutionType.READY), State.TASK_RUNNING, "message is empty.");
+        jobFacade.postJobStatusTraceEvent(String.format("%s@-@0@-@%s@-@fake_slave_id@-@0", "test_job", ExecutionType.READY), State.TASK_RUNNING, "message is empty.", true);
     }
 }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearch.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/main/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearch.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,17 +44,17 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public final class JobEventRdbSearch {
-    
+
     private static final String TABLE_JOB_EXECUTION_LOG = "JOB_EXECUTION_LOG";
-    
+
     private static final String TABLE_JOB_STATUS_TRACE_LOG = "JOB_STATUS_TRACE_LOG";
-    
-    private static final List<String> FIELDS_JOB_EXECUTION_LOG = 
+
+    private static final List<String> FIELDS_JOB_EXECUTION_LOG =
             Arrays.asList("id", "hostname", "ip", "task_id", "job_name", "execution_source", "sharding_item", "start_time", "complete_time", "is_success", "failure_cause");
-    
-    private static final List<String> FIELDS_JOB_STATUS_TRACE_LOG = 
+
+    private static final List<String> FIELDS_JOB_STATUS_TRACE_LOG =
             Arrays.asList("id", "job_name", "original_task_id", "task_id", "slave_id", "source", "execution_type", "sharding_item", "state", "message", "creation_time");
-    
+
     private final DataSource dataSource;
 
     /**
@@ -76,19 +76,19 @@ public final class JobEventRdbSearch {
     public Result<JobStatusTraceEvent> findJobStatusTraceEvents(final Condition condition) {
         return new Result<>(getEventCount(TABLE_JOB_STATUS_TRACE_LOG, FIELDS_JOB_STATUS_TRACE_LOG, condition), getJobStatusTraceEvents(condition));
     }
-    
+
     private List<JobExecutionEvent> getJobExecutionEvents(final Condition condition) {
         List<JobExecutionEvent> result = new LinkedList<>();
         try (
                 Connection conn = dataSource.getConnection();
                 PreparedStatement preparedStatement = createDataPreparedStatement(conn, TABLE_JOB_EXECUTION_LOG, FIELDS_JOB_EXECUTION_LOG, condition);
                 ResultSet resultSet = preparedStatement.executeQuery()
-                ) {
+        ) {
             while (resultSet.next()) {
                 JobExecutionEvent jobExecutionEvent = new JobExecutionEvent(resultSet.getString(1), resultSet.getString(2), resultSet.getString(3), resultSet.getString(4),
-                        resultSet.getString(5), JobExecutionEvent.ExecutionSource.valueOf(resultSet.getString(6)), Integer.parseInt(resultSet.getString(7)), 
-                        new Date(resultSet.getTimestamp(8).getTime()), resultSet.getTimestamp(9) == null ? null : new Date(resultSet.getTimestamp(9).getTime()), 
-                        resultSet.getBoolean(10), resultSet.getString(11));
+                        resultSet.getString(5), JobExecutionEvent.ExecutionSource.valueOf(resultSet.getString(6)), Integer.parseInt(resultSet.getString(7)),
+                        new Date(resultSet.getTimestamp(8).getTime()), resultSet.getTimestamp(9) == null ? null : new Date(resultSet.getTimestamp(9).getTime()),
+                        resultSet.getBoolean(10), resultSet.getString(11), true);
                 result.add(jobExecutionEvent);
             }
         } catch (final SQLException ex) {
@@ -97,14 +97,14 @@ public final class JobEventRdbSearch {
         }
         return result;
     }
-    
+
     private List<JobStatusTraceEvent> getJobStatusTraceEvents(final Condition condition) {
         List<JobStatusTraceEvent> result = new LinkedList<>();
         try (
                 Connection conn = dataSource.getConnection();
                 PreparedStatement preparedStatement = createDataPreparedStatement(conn, TABLE_JOB_STATUS_TRACE_LOG, FIELDS_JOB_STATUS_TRACE_LOG, condition);
                 ResultSet resultSet = preparedStatement.executeQuery()
-                ) {
+        ) {
             while (resultSet.next()) {
                 JobStatusTraceEvent jobStatusTraceEvent = new JobStatusTraceEvent(resultSet.getString(1), resultSet.getString(2), resultSet.getString(3), resultSet.getString(4),
                         resultSet.getString(5), JobStatusTraceEvent.Source.valueOf(resultSet.getString(6)), resultSet.getString(7), resultSet.getString(8),
@@ -117,14 +117,14 @@ public final class JobEventRdbSearch {
         }
         return result;
     }
-    
+
     private int getEventCount(final String tableName, final Collection<String> tableFields, final Condition condition) {
         int result = 0;
         try (
                 Connection conn = dataSource.getConnection();
                 PreparedStatement preparedStatement = createCountPreparedStatement(conn, tableName, tableFields, condition);
                 ResultSet resultSet = preparedStatement.executeQuery()
-                ) {
+        ) {
             resultSet.next();
             result = resultSet.getInt(1);
         } catch (final SQLException ex) {
@@ -133,21 +133,21 @@ public final class JobEventRdbSearch {
         }
         return result;
     }
-    
+
     private PreparedStatement createDataPreparedStatement(final Connection conn, final String tableName, final Collection<String> tableFields, final Condition condition) throws SQLException {
         String sql = buildDataSql(tableName, tableFields, condition);
         PreparedStatement result = conn.prepareStatement(sql);
         setBindValue(result, tableFields, condition);
         return result;
     }
-    
+
     private PreparedStatement createCountPreparedStatement(final Connection conn, final String tableName, final Collection<String> tableFields, final Condition condition) throws SQLException {
         String sql = buildCountSql(tableName, tableFields, condition);
         PreparedStatement result = conn.prepareStatement(sql);
         setBindValue(result, tableFields, condition);
         return result;
     }
-    
+
     private String buildDataSql(final String tableName, final Collection<String> tableFields, final Condition condition) {
         StringBuilder sqlBuilder = new StringBuilder();
         String selectSql = buildSelect(tableName, tableFields);
@@ -157,7 +157,7 @@ public final class JobEventRdbSearch {
         sqlBuilder.append(selectSql).append(whereSql).append(orderSql).append(limitSql);
         return sqlBuilder.toString();
     }
-    
+
     private String buildCountSql(final String tableName, final Collection<String> tableFields, final Condition condition) {
         StringBuilder sqlBuilder = new StringBuilder();
         String selectSql = buildSelectCount(tableName);
@@ -165,11 +165,11 @@ public final class JobEventRdbSearch {
         sqlBuilder.append(selectSql).append(whereSql);
         return sqlBuilder.toString();
     }
-    
+
     private String buildSelectCount(final String tableName) {
         return String.format("SELECT COUNT(1) FROM %s", tableName);
     }
-    
+
     private String buildSelect(final String tableName, final Collection<String> tableFields) {
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append("SELECT ");
@@ -180,7 +180,7 @@ public final class JobEventRdbSearch {
         sqlBuilder.append(" FROM ").append(tableName);
         return sqlBuilder.toString();
     }
-    
+
     private String buildWhere(final String tableName, final Collection<String> tableFields, final Condition condition) {
         StringBuilder sqlBuilder = new StringBuilder();
         sqlBuilder.append(" WHERE 1=1");
@@ -200,7 +200,7 @@ public final class JobEventRdbSearch {
         }
         return sqlBuilder.toString();
     }
-    
+
     private void setBindValue(final PreparedStatement preparedStatement, final Collection<String> tableFields, final Condition condition) throws SQLException {
         int index = 1;
         if (null != condition.getFields() && !condition.getFields().isEmpty()) {
@@ -218,7 +218,7 @@ public final class JobEventRdbSearch {
             preparedStatement.setTimestamp(index, new Timestamp(condition.getEndTime().getTime()));
         }
     }
-    
+
     private String getTableTimeField(final String tableName) {
         String result = "";
         if (TABLE_JOB_EXECUTION_LOG.equals(tableName)) {
@@ -228,7 +228,7 @@ public final class JobEventRdbSearch {
         }
         return result;
     }
-    
+
     private String buildOrder(final Collection<String> tableFields, final String sortName, final String sortOrder) {
         if (Strings.isNullOrEmpty(sortName)) {
             return "";
@@ -246,7 +246,7 @@ public final class JobEventRdbSearch {
         }
         return sqlBuilder.toString();
     }
-    
+
     private String buildLimit(final int page, final int perPage) {
         StringBuilder sqlBuilder = new StringBuilder();
         if (page > 0 && perPage > 0) {
@@ -263,30 +263,30 @@ public final class JobEventRdbSearch {
     @RequiredArgsConstructor
     @Getter
     public static class Condition {
-        
+
         private static final int DEFAULT_PAGE_SIZE = 10;
-        
+
         private final int perPage;
-        
+
         private final int page;
-        
+
         private final String sort;
-        
+
         private final String order;
-        
+
         private final Date startTime;
-        
+
         private final Date endTime;
-        
+
         private final Map<String, Object> fields;
     }
-    
+
     @RequiredArgsConstructor
     @Getter
     public static class Result<T> {
-        
+
         private final Integer total;
-        
+
         private final List<T> rows;
     }
 }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/JobFacade.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/JobFacade.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,48 +29,48 @@ import java.util.Collection;
  * Job facade.
  */
 public interface JobFacade {
-    
+
     /**
      * Load job configuration.
-     * 
+     *
      * @param fromCache load from cache or not
      * @return job configuration
      */
     JobConfiguration loadJobConfiguration(boolean fromCache);
-    
+
     /**
      * Check job execution environment.
-     * 
+     *
      * @throws JobExecutionEnvironmentException job execution environment exception
      */
     void checkJobExecutionEnvironment() throws JobExecutionEnvironmentException;
-    
+
     /**
      * Failover If necessary.
      */
     void failoverIfNecessary();
-    
+
     /**
      * Register job begin.
      *
      * @param shardingContexts sharding contexts
      */
     void registerJobBegin(ShardingContexts shardingContexts);
-    
+
     /**
      * Register job completed.
      *
      * @param shardingContexts sharding contexts
      */
     void registerJobCompleted(ShardingContexts shardingContexts);
-    
+
     /**
      * Get sharding contexts.
      *
      * @return sharding contexts
      */
     ShardingContexts getShardingContexts();
-    
+
     /**
      * Set task misfire flag.
      *
@@ -78,56 +78,57 @@ public interface JobFacade {
      * @return whether satisfy misfire condition
      */
     boolean misfireIfRunning(Collection<Integer> shardingItems);
-    
+
     /**
      * Clear misfire flag.
      *
      * @param shardingItems sharding items to be cleared misfire flag
      */
     void clearMisfire(Collection<Integer> shardingItems);
-    
+
     /**
      * Judge job whether need to execute misfire tasks.
-     * 
+     *
      * @param shardingItems sharding items
      * @return whether need to execute misfire tasks
      */
     boolean isExecuteMisfired(Collection<Integer> shardingItems);
-    
+
     /**
      * Judge job whether need resharding.
      *
      * @return whether need resharding
      */
     boolean isNeedSharding();
-    
+
     /**
      * Call before job executed.
      *
      * @param shardingContexts sharding contexts
      */
     void beforeJobExecuted(ShardingContexts shardingContexts);
-    
+
     /**
      * Call after job executed.
      *
      * @param shardingContexts sharding contexts
      */
     void afterJobExecuted(ShardingContexts shardingContexts);
-    
+
     /**
      * Post job execution event.
      *
      * @param jobExecutionEvent job execution event
      */
     void postJobExecutionEvent(JobExecutionEvent jobExecutionEvent);
-    
+
     /**
      * Post job status trace event.
      *
-     * @param taskId task Id
-     * @param state job state
-     * @param message job message
+     * @param enableEventTrace enableEventTrace
+     * @param taskId           task Id
+     * @param state            job state
+     * @param message          job message
      */
-    void postJobStatusTraceEvent(String taskId, State state, String message);
+    void postJobStatusTraceEvent(String taskId, State state, String message, boolean enableEventTrace);
 }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,20 +46,20 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class ElasticJobExecutorTest {
-    
+
     @Mock
     private FooJob fooJob;
-    
+
     private JobConfiguration jobConfig;
-    
+
     @Mock
     private JobFacade jobFacade;
-    
+
     @Mock
     private ClassedFooJobExecutor jobItemExecutor;
-    
+
     private ElasticJobExecutor elasticJobExecutor;
-    
+
     @Before
     public void setUp() {
         jobConfig = createJobConfiguration();
@@ -67,19 +67,19 @@ public final class ElasticJobExecutorTest {
         elasticJobExecutor = new ElasticJobExecutor(fooJob, jobConfig, jobFacade);
         setJobItemExecutor();
     }
-    
+
     private JobConfiguration createJobConfiguration() {
         return JobConfiguration.newBuilder("test_job", 3)
                 .cron("0/1 * * * * ?").shardingItemParameters("0=A,1=B,2=C").jobParameter("param").failover(true).misfire(false).jobErrorHandlerType("THROW").description("desc").build();
     }
-    
+
     @SneakyThrows
     private void setJobItemExecutor() {
         Field field = ElasticJobExecutor.class.getDeclaredField("jobItemExecutor");
         field.setAccessible(true);
         field.set(elasticJobExecutor, jobItemExecutor);
     }
-    
+
     @Test(expected = JobSystemException.class)
     public void assertExecuteWhenCheckMaxTimeDiffSecondsIntolerable() throws JobExecutionEnvironmentException {
         doThrow(JobExecutionEnvironmentException.class).when(jobFacade).checkJobExecutionEnvironment();
@@ -89,79 +89,79 @@ public final class ElasticJobExecutorTest {
             verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         }
     }
-    
+
     @Test
     public void assertExecuteWhenPreviousJobStillRunning() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 3, "", Collections.emptyMap());
         when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
         when(jobFacade.misfireIfRunning(shardingContexts.getShardingItemParameters().keySet())).thenReturn(true);
         elasticJobExecutor.execute();
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, 
-                "Previous job 'test_job' - shardingItems '[]' is still running, misfired job will start after previous job completed.");
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED,
+                "Previous job 'test_job' - shardingItems '[]' is still running, misfired job will start after previous job completed.", true);
         verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
     }
-    
+
     @Test
     public void assertExecuteWhenShardingItemsIsEmpty() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 3, "", Collections.emptyMap());
         prepareForIsNotMisfire(jobFacade, shardingContexts);
         elasticJobExecutor.execute();
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, "Sharding item for job 'test_job' is empty.");
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, "Sharding item for job 'test_job' is empty.", true);
         verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
     }
-    
+
     @Test(expected = JobSystemException.class)
     public void assertExecuteFailureWhenThrowExceptionForSingleShardingItem() {
         assertExecuteFailureWhenThrowException(createSingleShardingContexts());
     }
-    
+
     @Test
     public void assertExecuteFailureWhenThrowExceptionForMultipleShardingItems() {
         assertExecuteFailureWhenThrowException(createMultipleShardingContexts());
     }
-    
+
     private void assertExecuteFailureWhenThrowException(final ShardingContexts shardingContexts) {
         prepareForIsNotMisfire(jobFacade, shardingContexts);
         doThrow(RuntimeException.class).when(jobItemExecutor).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         try {
             elasticJobExecutor.execute();
         } finally {
-            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
-            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_RUNNING, "");
-            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_ERROR, getErrorMessage(shardingContexts));
+            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
+            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_RUNNING, "", true);
+            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_ERROR, getErrorMessage(shardingContexts), true);
             verify(jobFacade).registerJobBegin(shardingContexts);
             verify(jobItemExecutor, times(shardingContexts.getShardingTotalCount())).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
             verify(jobFacade).registerJobCompleted(shardingContexts);
         }
     }
-    
+
     private String getErrorMessage(final ShardingContexts shardingContexts) {
         return 1 == shardingContexts.getShardingItemParameters().size()
                 ? "{0=java.lang.RuntimeException" + System.lineSeparator() + "}"
                 : "{0=java.lang.RuntimeException" + System.lineSeparator() + ", 1=java.lang.RuntimeException" + System.lineSeparator() + "}";
     }
-    
+
     @Test
     public void assertExecuteSuccessForSingleShardingItems() {
         assertExecuteSuccess(createSingleShardingContexts());
     }
-    
+
     @Test
     public void assertExecuteSuccessForMultipleShardingItems() {
         assertExecuteSuccess(createMultipleShardingContexts());
     }
-    
+
     private void assertExecuteSuccess(final ShardingContexts shardingContexts) {
         prepareForIsNotMisfire(jobFacade, shardingContexts);
         elasticJobExecutor.execute();
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, "");
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, "", true);
         verifyForIsNotMisfire(jobFacade, shardingContexts);
         verify(jobItemExecutor, times(shardingContexts.getShardingTotalCount())).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
     }
-    
+
     @Test
     public void assertExecuteWithMisfireIsEmpty() {
         ShardingContexts shardingContexts = createMultipleShardingContexts();
@@ -170,7 +170,7 @@ public final class ElasticJobExecutorTest {
         verifyForIsNotMisfire(jobFacade, shardingContexts);
         verify(jobItemExecutor, times(2)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
     }
-    
+
     @Test
     public void assertExecuteWithMisfireIsNotEmptyButIsNotEligibleForJobRunning() {
         ShardingContexts shardingContexts = createMultipleShardingContexts();
@@ -180,21 +180,21 @@ public final class ElasticJobExecutorTest {
         verify(jobItemExecutor, times(2)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         verify(jobFacade, times(0)).clearMisfire(shardingContexts.getShardingItemParameters().keySet());
     }
-    
+
     @Test
     public void assertExecuteWithMisfire() {
         ShardingContexts shardingContexts = createMultipleShardingContexts();
         when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
         when(jobFacade.isExecuteMisfired(shardingContexts.getShardingItemParameters().keySet())).thenReturn(true, false);
         elasticJobExecutor.execute();
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
-        verify(jobFacade, times(2)).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_RUNNING, "");
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
+        verify(jobFacade, times(2)).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_RUNNING, "", true);
         verify(jobFacade).misfireIfRunning(shardingContexts.getShardingItemParameters().keySet());
         verify(jobFacade, times(2)).registerJobBegin(shardingContexts);
         verify(jobItemExecutor, times(4)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         verify(jobFacade, times(2)).registerJobCompleted(shardingContexts);
     }
-    
+
     @Test(expected = JobSystemException.class)
     public void assertBeforeJobExecutedFailure() {
         ShardingContexts shardingContexts = createMultipleShardingContexts();
@@ -206,7 +206,7 @@ public final class ElasticJobExecutorTest {
             verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         }
     }
-    
+
     @Test(expected = JobSystemException.class)
     public void assertAfterJobExecutedFailure() {
         ShardingContexts shardingContexts = createMultipleShardingContexts();
@@ -218,33 +218,33 @@ public final class ElasticJobExecutorTest {
             verify(jobItemExecutor, times(2)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
         }
     }
-    
+
     private ShardingContexts createSingleShardingContexts() {
         Map<Integer, String> map = new HashMap<>(1, 1);
         map.put(0, "A");
         return new ShardingContexts("fake_task_id", "test_job", 1, "", map);
     }
-    
+
     private ShardingContexts createMultipleShardingContexts() {
         Map<Integer, String> map = new HashMap<>(2, 1);
         map.put(0, "A");
         map.put(1, "B");
         return new ShardingContexts("fake_task_id", "test_job", 2, "", map);
     }
-    
+
     private void prepareForIsNotMisfire(final JobFacade jobFacade, final ShardingContexts shardingContexts) {
         when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
         when(jobFacade.misfireIfRunning(shardingContexts.getShardingItemParameters().keySet())).thenReturn(false);
         when(jobFacade.isExecuteMisfired(shardingContexts.getShardingItemParameters().keySet())).thenReturn(false);
     }
-    
+
     private void verifyForIsNotMisfire(final JobFacade jobFacade, final ShardingContexts shardingContexts) {
         try {
             verify(jobFacade).checkJobExecutionEnvironment();
         } catch (final JobExecutionEnvironmentException ex) {
             throw new RuntimeException(ex);
         }
-        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
+        verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.", true);
         verify(jobFacade).beforeJobExecuted(shardingContexts);
         verify(jobFacade).registerJobBegin(shardingContexts);
         verify(jobFacade).registerJobCompleted(shardingContexts);

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/main/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEvent.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/main/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEvent.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,63 +32,65 @@ import java.util.UUID;
 @AllArgsConstructor
 @Getter
 public final class JobExecutionEvent implements JobEvent {
-    
+
     private String id = UUID.randomUUID().toString();
-    
+
     private final String hostname;
-    
+
     private final String ip;
-    
+
     private final String taskId;
-    
+
     private final String jobName;
-    
+
     private final ExecutionSource source;
-    
+
     private final int shardingItem;
-    
+
     private Date startTime = new Date();
-    
+
     @Setter
     private Date completeTime;
-    
+
     @Setter
     private boolean success;
-    
+
     @Setter
     private String failureCause;
-    
+
+    private final boolean enableEventTrace;
+
     /**
      * Execution success.
-     * 
+     *
      * @return job execution event
      */
     public JobExecutionEvent executionSuccess() {
-        JobExecutionEvent result = new JobExecutionEvent(id, hostname, ip, taskId, jobName, source, shardingItem, startTime, completeTime, success, failureCause);
+        JobExecutionEvent result = new JobExecutionEvent(id, hostname, ip, taskId, jobName, source, shardingItem, startTime, completeTime, success, failureCause, enableEventTrace);
         result.setCompleteTime(new Date());
         result.setSuccess(true);
         return result;
     }
-    
+
     /**
      * Execution failure.
-     * 
+     *
      * @param failureCause failure cause
      * @return job execution event
      */
     public JobExecutionEvent executionFailure(final String failureCause) {
-        JobExecutionEvent result = new JobExecutionEvent(id, hostname, ip, taskId, jobName, source, shardingItem, startTime, completeTime, success, failureCause);
+        JobExecutionEvent result = new JobExecutionEvent(id, hostname, ip, taskId, jobName, source, shardingItem, startTime, completeTime, success, failureCause, enableEventTrace);
         result.setCompleteTime(new Date());
         result.setSuccess(false);
         result.setFailureCause(failureCause);
         return result;
     }
-    
+
     /**
      * Execution source.
      */
     public enum ExecutionSource {
-        
+
         NORMAL_TRIGGER, MISFIRE, FAILOVER
     }
 }

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/JobTracingEventBusTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/JobTracingEventBusTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,32 +39,32 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class JobTracingEventBusTest {
-    
+
     @Mock
     private JobEventCaller jobEventCaller;
-    
+
     @Mock
     private EventBus eventBus;
-    
+
     private JobTracingEventBus jobTracingEventBus;
-    
+
     @Test
     public void assertRegisterFailure() {
         jobTracingEventBus = new JobTracingEventBus(new TracingConfiguration<>("FAIL", null));
         assertIsRegistered(false);
     }
-    
+
     @Test
     public void assertPost() throws InterruptedException {
         jobTracingEventBus = new JobTracingEventBus(new TracingConfiguration<>("TEST", jobEventCaller));
         assertIsRegistered(true);
-        jobTracingEventBus.post(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_event_bus_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0));
+        jobTracingEventBus.post(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_event_bus_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true));
         while (!TestTracingListener.isExecutionEventCalled()) {
             Thread.sleep(100L);
         }
         verify(jobEventCaller).call();
     }
-    
+
     @Test
     public void assertPostWithoutListener() throws ReflectiveOperationException {
         jobTracingEventBus = new JobTracingEventBus();
@@ -72,10 +72,10 @@ public final class JobTracingEventBusTest {
         Field field = JobTracingEventBus.class.getDeclaredField("eventBus");
         field.setAccessible(true);
         field.set(jobTracingEventBus, eventBus);
-        jobTracingEventBus.post(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_event_bus_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0));
+        jobTracingEventBus.post(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_event_bus_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true));
         verify(eventBus, times(0)).post(ArgumentMatchers.<JobEvent>any());
     }
-    
+
     @SneakyThrows
     private void assertIsRegistered(final boolean actual) {
         Field field = JobTracingEventBus.class.getDeclaredField("isRegistered");

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEventTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEventTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,10 +27,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class JobExecutionEventTest {
-    
+
     @Test
     public void assertNewJobExecutionEvent() {
-        JobExecutionEvent actual = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent actual = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         assertThat(actual.getJobName(), is("test_job"));
         assertThat(actual.getSource(), is(JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER));
         assertThat(actual.getShardingItem(), is(0));
@@ -40,18 +40,18 @@ public final class JobExecutionEventTest {
         assertFalse(actual.isSuccess());
         assertNull(actual.getFailureCause());
     }
-    
+
     @Test
     public void assertExecutionSuccess() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         JobExecutionEvent successEvent = startEvent.executionSuccess();
         assertNotNull(successEvent.getCompleteTime());
         assertTrue(successEvent.isSuccess());
     }
-    
+
     @Test
     public void assertExecutionFailure() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         JobExecutionEvent failureEvent = startEvent.executionFailure("java.lang.RuntimeException: failure");
         assertNotNull(failureEvent.getCompleteTime());
         assertFalse(failureEvent.isSuccess());

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,14 +41,14 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class RDBTracingListenerTest {
-    
+
     private static final String JOB_NAME = "test_rdb_event_listener";
-    
+
     @Mock
     private RDBJobEventStorage repository;
-    
+
     private JobTracingEventBus jobTracingEventBus;
-    
+
     @Before
     public void setUp() throws SQLException {
         BasicDataSource dataSource = new BasicDataSource();
@@ -60,21 +60,21 @@ public final class RDBTracingListenerTest {
         setRepository(tracingListener);
         jobTracingEventBus = new JobTracingEventBus(new TracingConfiguration<DataSource>("RDB", dataSource));
     }
-    
+
     @SneakyThrows
     private void setRepository(final RDBTracingListener tracingListener) {
         Field field = RDBTracingListener.class.getDeclaredField("repository");
         field.setAccessible(true);
         field.set(tracingListener, repository);
     }
-    
+
     @Test
     public void assertPostJobExecutionEvent() {
-        JobExecutionEvent jobExecutionEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", JOB_NAME, JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent jobExecutionEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", JOB_NAME, JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         jobTracingEventBus.post(jobExecutionEvent);
         verify(repository, atMost(1)).addJobExecutionEvent(jobExecutionEvent);
     }
-    
+
     @Test
     public void assertPostJobStatusTraceEvent() {
         JobStatusTraceEvent jobStatusTraceEvent = new JobStatusTraceEvent(JOB_NAME, "fake_task_id", "fake_slave_id", Source.LITE_EXECUTOR, "READY", "0", State.TASK_RUNNING, "message is empty.");

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/storage/RDBJobEventStorageTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/storage/RDBJobEventStorageTest.java
@@ -7,7 +7,7 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,11 +37,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class RDBJobEventStorageTest {
-    
+
     private RDBJobEventStorage storage;
 
     private BasicDataSource dataSource;
-    
+
     @Before
     public void setup() throws SQLException {
         dataSource = new BasicDataSource();
@@ -51,7 +51,7 @@ public final class RDBJobEventStorageTest {
         dataSource.setPassword("");
         storage = new RDBJobEventStorage(dataSource);
     }
-    
+
     @After
     public void teardown() throws SQLException {
         dataSource.close();
@@ -59,15 +59,15 @@ public final class RDBJobEventStorageTest {
 
     @Test
     public void assertAddJobExecutionEvent() {
-        assertTrue(storage.addJobExecutionEvent(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0)));
+        assertTrue(storage.addJobExecutionEvent(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true)));
     }
-    
+
     @Test
     public void assertAddJobStatusTraceEvent() {
         assertTrue(storage.addJobStatusTraceEvent(
                 new JobStatusTraceEvent("test_job", "fake_task_id", "fake_slave_id", Source.LITE_EXECUTOR, "READY", "0", State.TASK_RUNNING, "message is empty.")));
     }
-    
+
     @Test
     public void assertAddJobStatusTraceEventWhenFailoverWithTaskStagingState() {
         JobStatusTraceEvent jobStatusTraceEvent = new JobStatusTraceEvent(
@@ -77,7 +77,7 @@ public final class RDBJobEventStorageTest {
         storage.addJobStatusTraceEvent(jobStatusTraceEvent);
         assertThat(storage.getJobStatusTraceEvents("fake_failover_task_id").size(), is(1));
     }
-    
+
     @Test
     public void assertAddJobStatusTraceEventWhenFailoverWithTaskFailedState() {
         JobStatusTraceEvent stagingJobStatusTraceEvent = new JobStatusTraceEvent(
@@ -93,45 +93,45 @@ public final class RDBJobEventStorageTest {
             assertThat(jobStatusTraceEvent.getOriginalTaskId(), is("original_fake_failed_failover_task_id"));
         }
     }
-    
+
     @Test
     public void assertUpdateJobExecutionEventWhenSuccess() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         assertTrue(storage.addJobExecutionEvent(startEvent));
         JobExecutionEvent successEvent = startEvent.executionSuccess();
         assertTrue(storage.addJobExecutionEvent(successEvent));
     }
-    
+
     @Test
     public void assertUpdateJobExecutionEventWhenFailure() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         assertTrue(storage.addJobExecutionEvent(startEvent));
         JobExecutionEvent failureEvent = startEvent.executionFailure("java.lang.RuntimeException: failure");
         assertTrue(storage.addJobExecutionEvent(failureEvent));
         assertThat(failureEvent.getFailureCause(), is("java.lang.RuntimeException: failure"));
         assertNotNull(failureEvent.getCompleteTime());
     }
-    
+
     @Test
     public void assertUpdateJobExecutionEventWhenSuccessAndConflict() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         JobExecutionEvent successEvent = startEvent.executionSuccess();
         assertTrue(storage.addJobExecutionEvent(successEvent));
         assertFalse(storage.addJobExecutionEvent(startEvent));
     }
-    
+
     @Test
     public void assertUpdateJobExecutionEventWhenFailureAndConflict() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         JobExecutionEvent failureEvent = startEvent.executionFailure("java.lang.RuntimeException: failure");
         assertTrue(storage.addJobExecutionEvent(failureEvent));
         assertThat(failureEvent.getFailureCause(), is("java.lang.RuntimeException: failure"));
         assertFalse(storage.addJobExecutionEvent(startEvent));
     }
-    
+
     @Test
     public void assertUpdateJobExecutionEventWhenFailureAndMessageExceed() {
-        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0);
+        JobExecutionEvent startEvent = new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true);
         assertTrue(storage.addJobExecutionEvent(startEvent));
         StringBuilder failureMsg = new StringBuilder();
         for (int i = 0; i < 600; i++) {
@@ -141,9 +141,9 @@ public final class RDBJobEventStorageTest {
         assertTrue(storage.addJobExecutionEvent(failEvent));
         assertThat(failEvent.getFailureCause(), startsWith("java.lang.RuntimeException: failure"));
     }
-    
+
     @Test
     public void assertFindJobExecutionEvent() {
-        storage.addJobExecutionEvent(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0));
+        storage.addJobExecutionEvent(new JobExecutionEvent("localhost", "127.0.0.1", "fake_task_id", "test_job", JobExecutionEvent.ExecutionSource.NORMAL_TRIGGER, 0, true));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/pojo/JobConfigurationPOJO.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/pojo/JobConfigurationPOJO.java
@@ -36,51 +36,53 @@ import java.util.Properties;
 @Getter
 @Setter
 public final class JobConfigurationPOJO {
-    
+
     private String jobName;
-    
+
     private String cron;
-    
+
     private String timeZone;
-    
+
     private int shardingTotalCount;
-    
+
     private String shardingItemParameters;
-    
+
     private String jobParameter;
-    
+
     private boolean monitorExecution;
-    
+
     private boolean failover;
-    
+
     private boolean misfire;
-    
+
     private int maxTimeDiffSeconds = -1;
-    
+
     private int reconcileIntervalMinutes;
-    
+
     private String jobShardingStrategyType;
-    
+
     private String jobExecutorServiceHandlerType;
-    
+
     private String jobErrorHandlerType;
-    
+
     private Collection<String> jobListenerTypes = new ArrayList<>();
-    
+
     private Collection<YamlConfiguration<JobExtraConfiguration>> jobExtraConfigurations = new LinkedList<>();
-    
+
     private String description;
-    
+
     private Properties props = new Properties();
-    
+
     private boolean disabled;
-    
+
     private boolean overwrite;
-    
+
     private String label;
-    
+
     private boolean staticSharding;
-    
+
+    private boolean enableEventTrace;
+
     /**
      * Convert to job configuration.
      *
@@ -93,14 +95,14 @@ public final class JobConfigurationPOJO {
                 .maxTimeDiffSeconds(maxTimeDiffSeconds).reconcileIntervalMinutes(reconcileIntervalMinutes)
                 .jobShardingStrategyType(jobShardingStrategyType).jobExecutorServiceHandlerType(jobExecutorServiceHandlerType)
                 .jobErrorHandlerType(jobErrorHandlerType).jobListenerTypes(jobListenerTypes.toArray(new String[]{})).description(description)
-                .disabled(disabled).overwrite(overwrite).label(label).staticSharding(staticSharding).build();
+                .disabled(disabled).overwrite(overwrite).label(label).staticSharding(staticSharding).enableEventTrace(enableEventTrace).build();
         jobExtraConfigurations.stream().map(YamlConfiguration::toConfiguration).forEach(result.getExtraConfigurations()::add);
         for (Object each : props.keySet()) {
             result.getProps().setProperty(each.toString(), props.get(each.toString()).toString());
         }
         return result;
     }
-    
+
     /**
      * Convert from job configuration.
      *
@@ -133,6 +135,7 @@ public final class JobConfigurationPOJO {
         result.setOverwrite(jobConfiguration.isOverwrite());
         result.setLabel(jobConfiguration.getLabel());
         result.setStaticSharding(jobConfiguration.isStaticSharding());
+        result.setEnableEventTrace(jobConfiguration.isEnableEventTrace());
         return result;
     }
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationProperties.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationProperties.java
@@ -32,49 +32,51 @@ import java.util.Properties;
 @Getter
 @Setter
 public final class ElasticJobConfigurationProperties {
-    
+
     private Class<? extends ElasticJob> elasticJobClass;
-    
+
     private String elasticJobType;
-    
+
     private String cron;
-    
+
     private String timeZone;
-    
+
     private String jobBootstrapBeanName;
-    
+
     private int shardingTotalCount;
-    
+
     private String shardingItemParameters;
-    
+
     private String jobParameter;
-    
+
     private boolean monitorExecution;
-    
+
     private boolean failover;
-    
+
     private boolean misfire;
-    
+
     private int maxTimeDiffSeconds = -1;
-    
+
     private int reconcileIntervalMinutes;
-    
+
     private String jobShardingStrategyType;
-    
+
     private String jobExecutorServiceHandlerType;
-    
+
     private String jobErrorHandlerType;
-    
+
     private Collection<String> jobListenerTypes = new LinkedList<>();
-    
+
     private String description;
-    
+
     private Properties props = new Properties();
-    
+
     private boolean disabled;
-    
+
     private boolean overwrite;
-    
+
+    private boolean enableEventTrace;
+
     /**
      * Convert to job configuration.
      *
@@ -87,7 +89,7 @@ public final class ElasticJobConfigurationProperties {
                 .monitorExecution(monitorExecution).failover(failover).misfire(misfire)
                 .maxTimeDiffSeconds(maxTimeDiffSeconds).reconcileIntervalMinutes(reconcileIntervalMinutes)
                 .jobShardingStrategyType(jobShardingStrategyType).jobExecutorServiceHandlerType(jobExecutorServiceHandlerType).jobErrorHandlerType(jobErrorHandlerType)
-                .jobListenerTypes(jobListenerTypes.toArray(new String[0])).description(description).disabled(disabled).overwrite(overwrite).build();
+                .jobListenerTypes(jobListenerTypes.toArray(new String[0])).description(description).disabled(disabled).overwrite(overwrite).enableEventTrace(enableEventTrace).build();
         props.stringPropertyNames().forEach(each -> result.getProps().setProperty(each, props.getProperty(each)));
         return result;
     }

--- a/examples/elasticjob-example-lite-springboot/pom.xml
+++ b/examples/elasticjob-example-lite-springboot/pom.xml
@@ -96,5 +96,10 @@
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/examples/elasticjob-example-lite-springboot/src/main/java/org/apache/shardingsphere/elasticjob/lite/example/controller/OneOffJobController.java
+++ b/examples/elasticjob-example-lite-springboot/src/main/java/org/apache/shardingsphere/elasticjob/lite/example/controller/OneOffJobController.java
@@ -26,9 +26,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class OneOffJobController {
-    
+
     private static final String RES_TEXT = "{\"msg\":\"OK\"}";
-    
+
     @Resource(name = "manualScriptJobBean")
     private OneOffJobBootstrap manualScriptJob;
 
@@ -43,25 +43,25 @@ public class OneOffJobController {
     @Autowired
     @Qualifier(value = "occurErrorNoticeEmailBean")
     private OneOffJobBootstrap occurErrorNoticeEmailJob;
-    
+
     @GetMapping("/execute/manualScriptJob")
     public String executeManualScriptJob() {
         manualScriptJob.execute();
         return RES_TEXT;
     }
-    
+
     @GetMapping("/execute/occurErrorNoticeDingtalkJob")
     public String executeOneOffJob() {
         occurErrorNoticeDingtalkJob.execute();
         return RES_TEXT;
     }
-    
+
     @GetMapping("/execute/occurErrorNoticeWechatJob")
     public String executeOccurErrorNoticeWechatJob() {
         occurErrorNoticeWechatJob.execute();
         return RES_TEXT;
     }
-    
+
     @GetMapping("/execute/occurErrorNoticeEmailJob")
     public String executeOccurErrorNoticeEmailJob() {
         occurErrorNoticeEmailJob.execute();

--- a/examples/elasticjob-example-lite-springboot/src/main/resources/application.yml
+++ b/examples/elasticjob-example-lite-springboot/src/main/resources/application.yml
@@ -14,6 +14,8 @@ elasticjob:
       cron: 0/5 * * * * ?
       shardingTotalCount: 3
       shardingItemParameters: 0=Beijing,1=Shanghai,2=Guangzhou
+      enableEventTrace: true
+      overwrite: true
     dataflowJob:
       elasticJobClass: org.apache.shardingsphere.elasticjob.lite.example.job.SpringBootDataflowJob
       cron: 0/5 * * * * ?

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,7 +38,7 @@
     </modules>
     
     <properties>
-        <revision>3.0.0-RC1</revision>
+        <revision>3.1.0-SNAPSHOT</revision>
         <java.version>1.8</java.version>
         <curator.version>5.1.0</curator.version>
         <springframework.version>4.3.4.RELEASE</springframework.version>


### PR DESCRIPTION
Fixes #ISSUSE_ID.
https://github.com/apache/shardingsphere-elasticjob/issues/1958

Changes proposed in this pull request:
- Added enableEventTrace attribute in ElasticJobConfigurationProperties,JobConfigurationPOJO,JobConfiguration,JobExecutionEvent
- The modified method may cause some inconsistencies between the implementation and naming of the postJobExecutionEvent and postJobStatusTraceEvent methods in the JobFacade, but this should be done with minimal changes
- Adding the enableeventtrace attribute will cause an error on the task list page in elasticjob-3.0.0-lite-ui:
Unable to find property 'enableEventTrace' on class: org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO
