### PR TITLE
Fix CVE dependency issue#1993

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <httpcore.version>4.4.13</httpcore.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <gson.version>2.6.1</gson.version>
-        <netty.version>4.1.45.Final</netty.version>
+        <netty.version>4.1.59.Final</netty.version>
         <mesos.version>1.1.0</mesos.version>
         <fenzo.version>0.11.1</fenzo.version>
         


### PR DESCRIPTION
Fix issue #1993 by update dependency io.netty:netty-common to 4.1.59.
