### PR TITLE
Fix itemErrorMessages not cleared after job finished

### DIFF
--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/main/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutor.java
@@ -129,6 +129,7 @@ public final class ElasticJobExecutor {
                 jobFacade.postJobStatusTraceEvent(taskId, State.TASK_FINISHED, "");
             } else {
                 jobFacade.postJobStatusTraceEvent(taskId, State.TASK_ERROR, itemErrorMessages.toString());
+                itemErrorMessages.clear();
             }
         }
     }


### PR DESCRIPTION
It will make error message show again in next loop.

Fixes #2019.

Changes proposed in this pull request:
-
-
-
