### PR TITLE
Each job has its own listener event notify thread instead of the only one curator thread

### DIFF
--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/main/java/org/apache/shardingsphere/elasticjob/reg/base/CoordinatorRegistryCenter.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/main/java/org/apache/shardingsphere/elasticjob/reg/base/CoordinatorRegistryCenter.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.elasticjob.reg.listener.ConnectionStateChangedE
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Coordinator registry center.
@@ -111,8 +112,9 @@ public interface CoordinatorRegistryCenter extends RegistryCenter {
      *
      * @param key key to be watched
      * @param listener data listener
+     * @param executor event notify executor
      */
-    void watch(String key, DataChangedEventListener listener);
+    void watch(String key, DataChangedEventListener listener, Executor executor);
     
     /**
      * Add connection state changed event listener to registry center.

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -408,20 +409,28 @@ public final class ZookeeperRegistryCenter implements CoordinatorRegistryCenter 
     }
     
     @Override
-    public void watch(final String key, final DataChangedEventListener listener) {
+    public void watch(final String key, final DataChangedEventListener listener, final Executor executor) {
         CuratorCache cache = caches.get(key + "/");
-        cache.listenable().addListener((curatorType, oldData, newData) -> {
-            if (null == newData && null == oldData) {
-                return;
+        CuratorCacheListener cacheListener = new CuratorCacheListener() {
+            @Override
+            public void event(final Type curatorType, final ChildData oldData, final ChildData newData) {
+                if (null == newData && null == oldData) {
+                    return;
+                }
+                DataChangedEvent.Type type = getTypeFromCuratorType(curatorType);
+                String path = DataChangedEvent.Type.DELETED == type ? oldData.getPath() : newData.getPath();
+                if (path.isEmpty() || DataChangedEvent.Type.IGNORED == type) {
+                    return;
+                }
+                byte[] data = DataChangedEvent.Type.DELETED == type ? oldData.getData() : newData.getData();
+                listener.onChange(new DataChangedEvent(type, path, null == data ? "" : new String(data, StandardCharsets.UTF_8)));
             }
-            Type type = getTypeFromCuratorType(curatorType);
-            String path = Type.DELETED == type ? oldData.getPath() : newData.getPath();
-            if (path.isEmpty() || Type.IGNORED == type) {
-                return;
-            }
-            byte[] data = Type.DELETED == type ? oldData.getData() : newData.getData();
-            listener.onChange(new DataChangedEvent(type, path, null == data ? "" : new String(data, StandardCharsets.UTF_8)));
-        });
+        };
+        if (executor != null) {
+            cache.listenable().addListener(cacheListener, executor);
+        } else {
+            cache.listenable().addListener(cacheListener);
+        }
     }
     
     private Type getTypeFromCuratorType(final CuratorCacheListener.Type curatorType) {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistry.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistry.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.elasticjob.lite.api.registry;
 
 import lombok.RequiredArgsConstructor;
+
+import org.apache.curator.utils.ThreadUtils;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
@@ -31,6 +33,9 @@ import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
 
 import java.util.Arrays;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -51,7 +56,9 @@ public final class JobInstanceRegistry {
      * Register.
      */
     public void register() {
-        regCenter.watch("/", new JobInstanceRegistryListener());
+        ThreadFactory threadFactory = ThreadUtils.newGenericThreadFactory("ListenerNotify-instanceRegistry");
+        Executor executor = Executors.newSingleThreadExecutor(threadFactory);
+        regCenter.watch("/", new JobInstanceRegistryListener(), executor);
     }
     
     public class JobInstanceRegistryListener implements DataChangedEventListener {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerManager.java
@@ -58,6 +58,7 @@ public final class ListenerManager {
     
     public ListenerManager(final CoordinatorRegistryCenter regCenter, final String jobName, final Collection<ElasticJobListener> elasticJobListeners) {
         jobNodeStorage = new JobNodeStorage(regCenter, jobName);
+        ListenerNotifierManager.getInstance().registerJobNotifyExecutor(jobName);
         electionListenerManager = new ElectionListenerManager(regCenter, jobName);
         shardingListenerManager = new ShardingListenerManager(regCenter, jobName);
         failoverListenerManager = new FailoverListenerManager(regCenter, jobName);

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManager.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.elasticjob.lite.internal.listener;
 
 import org.apache.curator.utils.ThreadUtils;

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManager.java
@@ -1,0 +1,62 @@
+package org.apache.shardingsphere.elasticjob.lite.internal.listener;
+
+import org.apache.curator.utils.ThreadUtils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Manage listener's notify executor,
+ * each job has its own listener notify executor.
+ */
+public final class ListenerNotifierManager {
+
+    private static volatile ListenerNotifierManager instance;
+
+    private final Map<String, Executor> listenerNotifyExecutors = new ConcurrentHashMap<>();
+
+    private ListenerNotifierManager() { }
+
+    /**
+     * Get singleton instance of ListenerNotifierManager.
+     * @return singleton instance of ListenerNotifierManager.
+     */
+    public static ListenerNotifierManager getInstance() {
+        if (null == instance) {
+            synchronized (ListenerNotifierManager.class) {
+                if (null == instance) {
+                    instance = new ListenerNotifierManager();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Register a listener notify executor for the job specified.
+     * @param jobName The job's name.
+     */
+    public void registerJobNotifyExecutor(final String jobName) {
+        if (!listenerNotifyExecutors.containsKey(jobName)) {
+            synchronized (this) {
+                if (!listenerNotifyExecutors.containsKey(jobName)) {
+                    ThreadFactory threadFactory = ThreadUtils.newGenericThreadFactory("ListenerNotify-" + jobName);
+                    Executor notifyExecutor = Executors.newSingleThreadExecutor(threadFactory);
+                    listenerNotifyExecutors.put(jobName, notifyExecutor);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the listener notify executor for the specified job.
+     * @param jobName The job's name.
+     * @return The job listener's notify executor.
+     */
+    public Executor getJobNotifyExecutor(final String jobName) {
+        return listenerNotifyExecutors.get(jobName);
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.storage;
 
+import org.apache.shardingsphere.elasticjob.lite.internal.listener.ListenerNotifierManager;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.base.LeaderExecutionCallback;
 import org.apache.shardingsphere.elasticjob.reg.base.transaction.TransactionOperation;
@@ -26,6 +27,7 @@ import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListene
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Job node storage.
@@ -218,7 +220,8 @@ public final class JobNodeStorage {
      * @param listener data listener
      */
     public void addDataListener(final DataChangedEventListener listener) {
-        regCenter.watch("/" + jobName, listener);
+        Executor executor = ListenerNotifierManager.getInstance().getJobNotifyExecutor(jobName);
+        regCenter.watch("/" + jobName, listener, executor);
     }
     
     /**

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.lite.internal.listener;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListenerNotifierManagerTest {
+
+    @Test
+    public void assertRegisterAndGetJobNotifyExecutor() {
+        String jobName = "test_job";
+        ListenerNotifierManager.getInstance().registerJobNotifyExecutor(jobName);
+        assertThat(ListenerNotifierManager.getInstance().getJobNotifyExecutor(jobName), notNullValue(Executor.class));
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.storage;
 
+import org.apache.shardingsphere.elasticjob.lite.internal.listener.ListenerNotifierManager;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.base.transaction.TransactionOperation;
@@ -32,6 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -176,8 +178,11 @@ public final class JobNodeStorageTest {
     @Test
     public void assertAddDataListener() {
         DataChangedEventListener listener = mock(DataChangedEventListener.class);
+        String jobName = "test_job";
+        ListenerNotifierManager.getInstance().registerJobNotifyExecutor(jobName);
+        Executor executor = ListenerNotifierManager.getInstance().getJobNotifyExecutor(jobName);
         jobNodeStorage.addDataListener(listener);
-        verify(regCenter).watch("/test_job", listener);
+        verify(regCenter).watch("/test_job", listener, executor);
     }
     
     @Test


### PR DESCRIPTION
Fixes #2038.

Changes proposed in this pull request:
- Add ListenerNotifierManager to manage job listener's notify thread executor. The thread executor is created for the job when 
ListenerManager is constructed.
- Change CoordinatorRegistryCenter's watch method:
  old: watch(String key, DataChangedEventListener listener) ;
  new: watch(String key, DataChangedEventListener listener, Executor executor);

Each job now has its own event notify thread, thus no influence would occur between different jobs. 
