### PR TITLE
Update ServerStatisticsAPIImpl.java

### DIFF
--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ServerStatisticsAPIImpl.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ServerStatisticsAPIImpl.java
@@ -68,10 +68,12 @@ public final class ServerStatisticsAPIImpl implements ServerStatisticsAPI {
             List<String> instances = regCenter.getChildrenKeys(jobNodePath.getInstancesNodePath());
             for (String each : instances) {
                 JobInstance jobInstance = YamlEngine.unmarshal(regCenter.get(jobNodePath.getInstanceNodePath(each)), JobInstance.class);
-                ServerBriefInfo serverInfo = servers.get(jobInstance.getServerIp());
-                if (null != serverInfo) {
-                    serverInfo.getInstances().add(each);
-                    serverInfo.setInstancesNum(serverInfo.getInstances().size());
+                if (null != jobInstance) {
+                    ServerBriefInfo serverInfo = servers.get(jobInstance.getServerIp());
+                    if (null != serverInfo) {
+                        serverInfo.getInstances().add(each);
+                        serverInfo.setInstancesNum(serverInfo.getInstances().size());
+                    }
                 }
             }
         }


### PR DESCRIPTION
jobInstance from unmarshalled can be null. And thereafter it throws NPE error like the following one:

Fixes #ISSUSE_ID.
```
[ERROR] 16:04:12.281 [http-nio-8088-exec-10] o.a.s.e.l.u.w.h.RestExceptionHandler - null
java.lang.NullPointerException: null
        at org.apache.shardingsphere.elasticjob.lite.lifecycle.internal.statistics.ServerStatisticsAPIImpl.getAllServersBriefInfo(ServerStatisticsAPIImpl.java:71)
        at org.apache.shardingsphere.elasticjob.lite.ui.web.controller.ServerOperationController.getAllServersBriefInfo(ServerOperationController.java:70)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
```

Changes proposed in this pull request:
- add null check for `serverInfo` before it is used. 
-
-
