### PR TITLE
Fix the issue #2105: NullPointerExecption caused by job configuration…

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationService.java
@@ -56,7 +56,11 @@ public final class ConfigurationService {
         } else {
             result = jobNodeStorage.getJobNodeDataDirectly(ConfigurationNode.ROOT);
         }
-        return YamlEngine.unmarshal(result, JobConfigurationPOJO.class).toJobConfiguration();
+        if (result != null) {
+            return YamlEngine.unmarshal(result, JobConfigurationPOJO.class).toJobConfiguration();
+        } else {
+            throw new JobConfigurationException("JobConfiguration was not found. It maybe has been removed or has not been configured correctly.");
+        }
     }
     
     /**


### PR DESCRIPTION
Fixes #2105.

Changes proposed in this pull request:
- When no job configuration can be loaded, throw more readable JobConfigurationExecption, not NullPointerExecption. 