### PR TITLE
Fix issue #2116 : add executor remove where job shutdown

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobRegistry.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobRegistry.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
+import org.apache.shardingsphere.elasticjob.lite.internal.listener.ListenerNotifierManager;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 
 import java.util.Map;
@@ -169,6 +170,7 @@ public final class JobRegistry {
     public void shutdown(final String jobName) {
         Optional.ofNullable(schedulerMap.remove(jobName)).ifPresent(JobScheduleController::shutdown);
         Optional.ofNullable(regCenterMap.remove(jobName)).ifPresent(regCenter -> regCenter.evictCacheData("/" + jobName));
+        ListenerNotifierManager.getInstance().removeJobNotifyExecutor(jobName);
         jobInstanceMap.remove(jobName);
         jobRunningMap.remove(jobName);
         currentShardingTotalCountMap.remove(jobName);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
@@ -35,4 +35,11 @@ public class ListenerNotifierManagerTest {
         ListenerNotifierManager.getInstance().registerJobNotifyExecutor(jobName);
         assertThat(ListenerNotifierManager.getInstance().getJobNotifyExecutor(jobName), notNullValue(Executor.class));
     }
+
+    @Test
+    public void assertRemoveAndShutDownJobNotifyExecutor() {
+        String jobName = "test_job";
+        ListenerNotifierManager.getInstance().registerJobNotifyExecutor(jobName);
+        ListenerNotifierManager.getInstance().removeJobNotifyExecutor(jobName);
+    }
 }


### PR DESCRIPTION
Fixes #2116 .

Changes proposed in this pull request:

when job shutdown, add remove method from listenerNotifyManager map
-
-
-
