### PR TITLE
兼容4.0.1版本curator的elasticjob

### DIFF
--- a/elasticjob-api/pom.xml
+++ b/elasticjob-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-api/pom.xml
+++ b/elasticjob-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-api/pom.xml
+++ b/elasticjob-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-common/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-common/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-common/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-cloud</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationListenerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener;
 import org.apache.mesos.Protos;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job.CloudJobConfigurationListenerTest;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationListenerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.config.CloudJobExecutionType;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJsonConstants;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/CloudAppDisableListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/CloudAppDisableListenerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.app;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job.CloudJobConfigurationListenerTest;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job.CloudJobConfigurationService;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/CloudJobDisableListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/CloudJobDisableListenerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.job;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job.CloudJobConfigurationListenerTest;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.EmbedTestingServer;

--- a/elasticjob-cloud/pom.xml
+++ b/elasticjob-cloud/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-cloud/pom.xml
+++ b/elasticjob-cloud/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-cloud/pom.xml
+++ b/elasticjob-cloud/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud-executor-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-executor-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-executor-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-executor-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-cloud-scheduler-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-lite-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-src-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-src-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-src-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-src-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-src-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-src-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/elasticjob-src-distribution/pom.xml
+++ b/elasticjob-distribution/elasticjob-src-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-distribution</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-src-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/pom.xml
+++ b/elasticjob-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/pom.xml
+++ b/elasticjob-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-distribution/pom.xml
+++ b/elasticjob-distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-distribution</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-spi</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-spi</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-spi</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-dingtalk</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-dingtalk</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-dingtalk</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-email</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-email</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-email</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-general</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-general</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-general</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-wechat</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-wechat</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-wechat</artifactId>
     

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-error-handler</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-error-handler</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-error-handler</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-executor-kernel</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor-kernel</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor-kernel</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-dataflow-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-dataflow-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-dataflow-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-http-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-http-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-http-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-script-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-script-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-script-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-simple-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-simple-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor-type</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-simple-executor</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-executor</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-executor-type</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-executor</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-executor</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-tracing-api</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-tracing-rdb</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing-rdb</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-tracing</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing-rdb</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-ecosystem/elasticjob-tracing/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-tracing</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-tracing/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/elasticjob-tracing/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-ecosystem</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-tracing</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/pom.xml
+++ b/elasticjob-ecosystem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-ecosystem</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/pom.xml
+++ b/elasticjob-ecosystem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-ecosystem</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-ecosystem/pom.xml
+++ b/elasticjob-ecosystem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-ecosystem</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-infra/elasticjob-infra-common/pom.xml
+++ b/elasticjob-infra/elasticjob-infra-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-infra-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-infra-common/pom.xml
+++ b/elasticjob-infra/elasticjob-infra-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-infra-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-infra-common/pom.xml
+++ b/elasticjob-infra/elasticjob-infra-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-infra-common</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/CuratorCacheListener.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/listener/CuratorCacheListener.java
@@ -15,29 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.elasticjob.lite.internal.listener;
-
-import org.apache.curator.framework.recipes.cache.TreeCacheListener;
-import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+package org.apache.shardingsphere.elasticjob.infra.listener;
 
 /**
- * Listener manager.
+ * Cache Listener.
  */
-public abstract class AbstractListenerManager {
-    
-    private final JobNodeStorage jobNodeStorage;
-    
-    protected AbstractListenerManager(final CoordinatorRegistryCenter regCenter, final String jobName) {
-        jobNodeStorage = new JobNodeStorage(regCenter, jobName);
-    }
-    
+public interface CuratorCacheListener {
+
     /**
-     * Start listener.
+     * An enumerated type that describes a change.
      */
-    public abstract void start();
-    
-    protected void addDataListener(final TreeCacheListener listener) {
-        jobNodeStorage.addDataListener(listener);
+    enum Type {
+        /**
+         * A new node was added to the cache.
+         */
+        NODE_CREATED,
+
+        /**
+         * A node already in the cache has changed.
+         */
+        NODE_CHANGED,
+
+        /**
+         * A node already in the cache was deleted.
+         */
+        NODE_DELETED;
     }
 }

--- a/elasticjob-infra/elasticjob-registry-center/pom.xml
+++ b/elasticjob-infra/elasticjob-registry-center/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-registry-center</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-registry-center/pom.xml
+++ b/elasticjob-infra/elasticjob-registry-center/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-registry-center</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-registry-center/pom.xml
+++ b/elasticjob-infra/elasticjob-registry-center/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-infra</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-registry-center</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-infra/elasticjob-registry-center/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,7 +57,7 @@ public final class ZookeeperRegistryCenterMiscellaneousTest {
     
     @Test
     public void assertGetRawCache() {
-        assertThat(zkRegCenter.getRawCache("/test"), instanceOf(CuratorCache.class));
+        assertThat(zkRegCenter.getRawCache("/test"), instanceOf(TreeCache.class));
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>elasticjob-infra</artifactId>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>elasticjob-infra</artifactId>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>elasticjob-infra</artifactId>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticjob-infra/pom.xml
+++ b/elasticjob-infra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-infra</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-infra/pom.xml
+++ b/elasticjob-infra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-infra</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-infra/pom.xml
+++ b/elasticjob-infra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-infra</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/elasticjob-lite-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistry.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistry.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.api.registry;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
@@ -51,8 +51,8 @@ public final class JobInstanceRegistry {
      * Register.
      */
     public void register() {
-        CuratorCache cache = (CuratorCache) regCenter.getRawCache("/");
-        cache.listenable().addListener(new JobInstanceRegistryListener());
+        TreeCache cache = (TreeCache) regCenter.getRawCache("/");
+        cache.getListenable().addListener(new JobInstanceRegistryListener());
     }
     
     public class JobInstanceRegistryListener extends AbstractJobListener {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/AbstractJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/AbstractJobListener.java
@@ -41,8 +41,6 @@ public abstract class AbstractJobListener implements TreeCacheListener, CuratorC
             case NODE_UPDATED:
                 event(Type.NODE_CHANGED, null, event.getData());
                 break;
-            case INITIALIZED:
-                break;
             default:
                 break;
         }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotService.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.elasticjob.lite.internal.snapshot;
 import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.shardingsphere.elasticjob.lite.internal.util.SensitiveInfoUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 
@@ -112,9 +112,9 @@ public final class SnapshotService {
             String zkValue = Optional.ofNullable(regCenter.get(zkPath)).orElse("");
             String cachePath = zkPath;
             String cacheValue = zkValue;
-            CuratorCache cache = (CuratorCache) regCenter.getRawCache("/" + jobName);
+            TreeCache cache = (TreeCache) regCenter.getRawCache("/" + jobName);
             if (null != cache) {
-                Optional<ChildData> cacheData = cache.get(zkPath);
+                Optional<ChildData> cacheData = Optional.ofNullable(cache.getCurrentData(zkPath));
                 cachePath = cacheData.map(ChildData::getPath).orElse("");
                 cacheValue = cacheData.map(ChildData::getData).map(String::new).orElse("");
             }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorage.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.elasticjob.lite.internal.storage;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorOp;
 import org.apache.curator.framework.api.transaction.TransactionOp;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
@@ -243,9 +243,9 @@ public final class JobNodeStorage {
      * 
      * @param listener data listener
      */
-    public void addDataListener(final CuratorCacheListener listener) {
-        CuratorCache cache = (CuratorCache) regCenter.getRawCache("/" + jobName);
-        cache.listenable().addListener(listener);
+    public void addDataListener(final TreeCacheListener listener) {
+        TreeCache cache = (TreeCache) regCenter.getRawCache("/" + jobName);
+        cache.getListenable().addListener(listener);
     }
     
     /**

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistryTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistryTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.api.registry;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/RescheduleListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/RescheduleListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.config;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.lite.fixture.LiteYamlConstants;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.election;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.failover;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.LiteYamlConstants;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.guarantee;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener;
 import org.apache.shardingsphere.elasticjob.lite.api.listener.AbstractDistributeOnceElasticJobListener;
 import org.apache.shardingsphere.elasticjob.lite.internal.listener.AbstractJobListener;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.instance;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/MonitorExecutionListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/MonitorExecutionListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.sharding;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.lite.fixture.LiteYamlConstants;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingListenerManagerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.sharding;
 
 import com.google.common.collect.Lists;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.fixture.LiteYamlConstants;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
@@ -24,8 +24,8 @@ import org.apache.curator.framework.api.transaction.TransactionCheckBuilder;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder;
 import org.apache.curator.framework.api.transaction.TransactionOp;
 import org.apache.curator.framework.listen.Listenable;
-import org.apache.curator.framework.recipes.cache.CuratorCache;
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import org.apache.curator.framework.recipes.cache.TreeCache;
+import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
@@ -237,11 +237,11 @@ public final class JobNodeStorageTest {
     
     @Test
     public void assertAddDataListener() {
-        CuratorCache cache = mock(CuratorCache.class);
+        TreeCache cache = mock(TreeCache.class);
         @SuppressWarnings("unchecked")
-        Listenable<CuratorCacheListener> listeners = mock(Listenable.class);
-        CuratorCacheListener listener = mock(CuratorCacheListener.class);
-        when(cache.listenable()).thenReturn(listeners);
+        Listenable<TreeCacheListener> listeners = mock(Listenable.class);
+        TreeCacheListener listener = mock(TreeCacheListener.class);
+        when(cache.getListenable()).thenReturn(listeners);
         when(regCenter.getRawCache("/test_job")).thenReturn(cache);
         jobNodeStorage.addDataListener(listener);
         verify(listeners).addListener(listener);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/trigger/TriggerListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/trigger/TriggerListenerManagerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.trigger;
 
-import org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type;
+import org.apache.shardingsphere.elasticjob.infra.listener.CuratorCacheListener.Type;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;

--- a/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-lifecycle</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-lifecycle</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-lifecycle</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-spring-boot-starter</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-boot-starter</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-boot-starter</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-spring-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-core</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-namespace</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-spring-namespace</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite-spring</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring-namespace</artifactId>
     <name>${project.artifactId}</name>

--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite-spring</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/elasticjob-lite-spring/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob-lite</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite-spring</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/pom.xml
+++ b/elasticjob-lite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.0.1</version>
     </parent>
     <artifactId>elasticjob-lite</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/pom.xml
+++ b/elasticjob-lite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite</artifactId>
     <packaging>pom</packaging>

--- a/elasticjob-lite/pom.xml
+++ b/elasticjob-lite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.shardingsphere.elasticjob</groupId>
         <artifactId>elasticjob</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>elasticjob-lite</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.apache.shardingsphere.elasticjob</groupId>
     <artifactId>elasticjob</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.0.1</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
@@ -737,7 +737,7 @@
         <connection>scm:git:https://github.com/apache/shardingsphere-elasticjob.git</connection>
         <developerConnection>scm:git:https://github.com/apache/shardingsphere-elasticjob.git</developerConnection>
         <url>https://github.com/apache/shardingsphere-elasticjob.git</url>
-        <tag>HEAD</tag>
+        <tag>3.0.1</tag>
     </scm>
     
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <guava.version>29.0-jre</guava.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <quartz.version>2.3.2</quartz.version>
-        <curator.version>5.1.0</curator.version>
+        <curator.version>4.0.1</curator.version>
         <lombok.version>1.18.12</lombok.version>
         <aspectj.version>1.9.1</aspectj.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.apache.shardingsphere.elasticjob</groupId>
     <artifactId>elasticjob</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
@@ -49,7 +49,7 @@
         <guava.version>29.0-jre</guava.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <quartz.version>2.3.2</quartz.version>
-        <curator.version>4.0.1</curator.version>
+        <curator.version>4.2.0</curator.version>
         <lombok.version>1.18.12</lombok.version>
         <aspectj.version>1.9.1</aspectj.version>
         <slf4j.version>1.7.7</slf4j.version>
@@ -748,4 +748,5 @@
             <unsubscribe>dev-unsubscribe@shardingsphere.apache.org</unsubscribe>
         </mailingList>
     </mailingLists>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <guava.version>29.0-jre</guava.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <quartz.version>2.3.2</quartz.version>
-        <curator.version>4.2.0</curator.version>
+        <curator.version>4.0.1</curator.version>
         <lombok.version>1.18.12</lombok.version>
         <aspectj.version>1.9.1</aspectj.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.apache.shardingsphere.elasticjob</groupId>
     <artifactId>elasticjob</artifactId>
-    <version>3.0.1</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
@@ -737,7 +737,7 @@
         <connection>scm:git:https://github.com/apache/shardingsphere-elasticjob.git</connection>
         <developerConnection>scm:git:https://github.com/apache/shardingsphere-elasticjob.git</developerConnection>
         <url>https://github.com/apache/shardingsphere-elasticjob.git</url>
-        <tag>3.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <mailingLists>


### PR DESCRIPTION
因为elasticjob使用的curator版本5.1.0和RPC使用的curator版本不兼容，造成elasticjob启动失败。
1、修改elasticjob使用的curator版本为4.0.1
2、修复[因版本修改的BUG