### PR TITLE
Do failover only if target items were running

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
@@ -147,6 +147,7 @@ public final class FailoverListenerManager extends AbstractListenerManager {
                     failoverService.clearFailoveringItem(entry.getKey());
                 }
             }
+            failoverService.failoverIfNecessary();
         }
         
         private boolean isCurrentInstanceOnline(final DataChangedEvent event) {

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
@@ -135,16 +135,19 @@ public final class FailoverListenerManager extends AbstractListenerManager {
             if (allRunningItems.isEmpty() && allFailoveringItems.isEmpty()) {
                 return;
             }
+            for (Entry<Integer, JobInstance> entry : allFailoveringItems.entrySet()) {
+                if (!availableJobInstances.contains(entry.getValue())) {
+                    int item = entry.getKey();
+                    failoverService.setCrashedFailoverFlagDirectly(item);
+                    failoverService.clearFailoveringItem(item);
+                    executionService.clearRunningInfo(Collections.singletonList(item));
+                    allRunningItems.remove(item);
+                }
+            }
             for (Entry<Integer, JobInstance> entry : allRunningItems.entrySet()) {
                 if (!availableJobInstances.contains(entry.getValue())) {
                     failoverService.setCrashedFailoverFlag(entry.getKey());
                     executionService.clearRunningInfo(Collections.singletonList(entry.getKey()));
-                }
-            }
-            for (Entry<Integer, JobInstance> entry : allFailoveringItems.entrySet()) {
-                if (!availableJobInstances.contains(entry.getValue())) {
-                    failoverService.setCrashedFailoverFlagDirectly(entry.getKey());
-                    failoverService.clearFailoveringItem(entry.getKey());
                 }
             }
             failoverService.failoverIfNecessary();

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverService.java
@@ -23,8 +23,8 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleCo
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingNode;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
-import org.apache.shardingsphere.elasticjob.reg.base.LeaderExecutionCallback;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.reg.base.LeaderExecutionCallback;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,6 +57,7 @@ public final class FailoverService {
     public void setCrashedFailoverFlag(final int item) {
         if (!isFailoverAssigned(item)) {
             jobNodeStorage.createJobNodeIfNeeded(FailoverNode.getItemsNode(item));
+            jobNodeStorage.removeJobNodeIfExisted(ShardingNode.getRunningNode(item));
         }
     }
 

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
@@ -17,7 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.sharding;
 
+import com.google.common.base.Strings;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationService;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
@@ -26,7 +28,9 @@ import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Execution service.
@@ -131,6 +135,23 @@ public final class ExecutionService {
         List<Integer> result = new ArrayList<>(shardingTotalCount);
         for (int i = 0; i < shardingTotalCount; i++) {
             result.add(i);
+        }
+        return result;
+    }
+    
+    /**
+     * Get all running items with instance.
+     *
+     * @return running items with instance.
+     */
+    public Map<Integer, JobInstance> getAllRunningItems() {
+        int shardingTotalCount = configService.load(true).getShardingTotalCount();
+        Map<Integer, JobInstance> result = new LinkedHashMap<>(shardingTotalCount, 1);
+        for (int i = 0; i < shardingTotalCount; i++) {
+            String data = jobNodeStorage.getJobNodeData(ShardingNode.getRunningNode(i));
+            if (!Strings.isNullOrEmpty(data)) {
+                result.put(i, new JobInstance(data));
+            }
         }
         return result;
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
@@ -52,11 +52,16 @@ public final class ExecutionService {
      */
     public void registerJobBegin(final ShardingContexts shardingContexts) {
         JobRegistry.getInstance().setJobRunning(jobName, true);
-        if (!configService.load(true).isMonitorExecution()) {
+        JobConfiguration jobConfiguration = configService.load(true);
+        if (!jobConfiguration.isMonitorExecution()) {
             return;
         }
         for (int each : shardingContexts.getShardingItemParameters().keySet()) {
-            jobNodeStorage.fillEphemeralJobNode(ShardingNode.getRunningNode(each), "");
+            if (jobConfiguration.isFailover()) {
+                jobNodeStorage.fillJobNode(ShardingNode.getRunningNode(each), "");
+            } else {
+                jobNodeStorage.fillEphemeralJobNode(ShardingNode.getRunningNode(each), "");
+            }
         }
     }
     

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionService.java
@@ -60,11 +60,12 @@ public final class ExecutionService {
         if (!jobConfiguration.isMonitorExecution()) {
             return;
         }
+        String jobInstanceId = JobRegistry.getInstance().getJobInstance(jobName).getJobInstanceId();
         for (int each : shardingContexts.getShardingItemParameters().keySet()) {
             if (jobConfiguration.isFailover()) {
-                jobNodeStorage.fillJobNode(ShardingNode.getRunningNode(each), "");
+                jobNodeStorage.fillJobNode(ShardingNode.getRunningNode(each), jobInstanceId);
             } else {
-                jobNodeStorage.fillEphemeralJobNode(ShardingNode.getRunningNode(each), "");
+                jobNodeStorage.fillEphemeralJobNode(ShardingNode.getRunningNode(each), jobInstanceId);
             }
         }
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
@@ -202,11 +202,15 @@ public final class ShardingService {
         List<Integer> result = new LinkedList<>();
         int shardingTotalCount = configService.load(true).getShardingTotalCount();
         for (int i = 0; i < shardingTotalCount; i++) {
-            if (jobInstanceId.equals(jobNodeStorage.getJobNodeData(ShardingNode.getInstanceNode(i)))) {
+            if (isRunningItem(i) && jobInstanceId.equals(jobNodeStorage.getJobNodeData(ShardingNode.getInstanceNode(i)))) {
                 result.add(i);
             }
         }
         return result;
+    }
+    
+    private boolean isRunningItem(final int item) {
+        return jobNodeStorage.isJobNodeExisted(ShardingNode.getRunningNode(item));
     }
     
     /**

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -74,7 +74,7 @@ public final class FailoverListenerManagerTest {
     @Test
     public void assertStart() {
         failoverListenerManager.start();
-        verify(jobNodeStorage, times(2)).addDataListener(ArgumentMatchers.any(DataChangedEventListener.class));
+        verify(jobNodeStorage, times(3)).addDataListener(ArgumentMatchers.any(DataChangedEventListener.class));
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -136,6 +136,8 @@ public final class FailoverListenerManagerTest {
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").failover(true).build());
         when(shardingService.getCrashedShardingItems("127.0.0.1@-@1")).thenReturn(Arrays.asList(0, 2));
+        when(instanceNode.isInstancePath("/test_job/instances/127.0.0.1@-@1")).thenReturn(true);
+        when(instanceNode.getInstanceFullPath()).thenReturn("/test_job/instances");
         failoverListenerManager.new JobCrashedJobListener().onChange(new DataChangedEvent(Type.DELETED, "/test_job/instances/127.0.0.1@-@1", ""));
         verify(failoverService).setCrashedFailoverFlag(0);
         verify(failoverService).setCrashedFailoverFlag(2);
@@ -149,6 +151,8 @@ public final class FailoverListenerManagerTest {
         JobRegistry.getInstance().registerJob("test_job", jobScheduleController);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").failover(true).build());
         when(failoverService.getFailoveringItems("127.0.0.1@-@1")).thenReturn(Collections.singletonList(1));
+        when(instanceNode.isInstancePath("/test_job/instances/127.0.0.1@-@1")).thenReturn(true);
+        when(instanceNode.getInstanceFullPath()).thenReturn("/test_job/instances");
         failoverListenerManager.new JobCrashedJobListener().onChange(new DataChangedEvent(Type.DELETED, "/test_job/instances/127.0.0.1@-@1", ""));
         verify(failoverService).setCrashedFailoverFlagDirectly(1);
         verify(failoverService).failoverIfNecessary();

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.sharding;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationService;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
@@ -76,11 +77,13 @@ public final class ExecutionServiceTest {
     
     @Test
     public void assertRegisterJobBeginWithMonitorExecution() {
+        String jobInstanceId = "127.0.0.1@-@1";
+        JobRegistry.getInstance().addJobInstance("test_job", new JobInstance(jobInstanceId));
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").monitorExecution(true).build());
         executionService.registerJobBegin(getShardingContext());
-        verify(jobNodeStorage).fillEphemeralJobNode("sharding/0/running", "");
-        verify(jobNodeStorage).fillEphemeralJobNode("sharding/1/running", "");
-        verify(jobNodeStorage).fillEphemeralJobNode("sharding/2/running", "");
+        verify(jobNodeStorage).fillEphemeralJobNode("sharding/0/running", jobInstanceId);
+        verify(jobNodeStorage).fillEphemeralJobNode("sharding/1/running", jobInstanceId);
+        verify(jobNodeStorage).fillEphemeralJobNode("sharding/2/running", jobInstanceId);
         assertTrue(JobRegistry.getInstance().isJobRunning("test_job"));
     }
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingServiceTest.java
@@ -250,8 +250,9 @@ public final class ShardingServiceTest {
         when(serverService.isEnableServer("127.0.0.1")).thenReturn(true);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").build());
         when(jobNodeStorage.getJobNodeData("sharding/0/instance")).thenReturn("127.0.0.1@-@0");
-        when(jobNodeStorage.getJobNodeData("sharding/1/instance")).thenReturn("127.0.0.1@-@1");
+        when(jobNodeStorage.isJobNodeExisted("sharding/0/running")).thenReturn(true);
         when(jobNodeStorage.getJobNodeData("sharding/2/instance")).thenReturn("127.0.0.1@-@0");
+        when(jobNodeStorage.isJobNodeExisted("sharding/2/running")).thenReturn(true);
         assertThat(shardingService.getCrashedShardingItems("127.0.0.1@-@0"), is(Arrays.asList(0, 2)));
         JobRegistry.getInstance().shutdown("test_job");
     }


### PR DESCRIPTION
Fixes #2090.

Changes proposed in this pull request:
- Make running node persistence if failover enabled.
- Check if any running node existed and instance of running node not available.
