### PR TITLE
fix(sec): upgrade io.netty:netty-codec to 4.1.68.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <httpcore.version>4.4.13</httpcore.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <gson.version>2.6.1</gson.version>
-        <netty.version>4.1.59.Final</netty.version>
+        <netty.version>4.1.68.Final</netty.version>
         <mesos.version>1.1.0</mesos.version>
         <fenzo.version>0.11.1</fenzo.version>
         


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec 4.1.59.Final
- [CVE-2021-37136](https://www.oscs1024.com/hd/CVE-2021-37136)


### What did I do？
Upgrade io.netty:netty-codec from 4.1.59.Final to 4.1.68.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS