### PR TITLE
Bug: Bad attempt to compute absolute value of signed 32-bit hashcode

### DIFF
--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RoundRobinByNameJobShardingStrategy.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RoundRobinByNameJobShardingStrategy.java
@@ -38,7 +38,13 @@ public final class RoundRobinByNameJobShardingStrategy implements JobShardingStr
     
     private List<JobInstance> rotateServerList(final List<JobInstance> shardingUnits, final String jobName) {
         int shardingUnitsSize = shardingUnits.size();
-        int offset = Math.abs(jobName.hashCode()) % shardingUnitsSize;
+        int jobHashCode = jobName.hashCode();
+        int offset = 0;
+        if(jobHashCode != Integer.MIN_VALUE) {
+            offset = Math.abs(jobHashCode) % shardingUnitsSize;
+        } else {
+            offset = Integer.MIN_VALUE % shardingUnitsSize;
+        }
         if (0 == offset) {
             return shardingUnits;
         }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-此代码产生的哈希码，然后计算该哈希码的绝对值。如果哈希码是Integer.MIN_VALUE的，那么结果将是负面的，以及（因为Math.abs（Integer.MIN_VALUE的）==Integer.MIN_VALUE的）。 
-
