### PR TITLE
fix(sec): upgrade org.apache.mesos:mesos to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <snakeyaml.version>1.26</snakeyaml.version>
         <gson.version>2.6.1</gson.version>
         <netty.version>4.1.59.Final</netty.version>
-        <mesos.version>1.1.0</mesos.version>
+        <mesos.version>1.7.1</mesos.version>
         <fenzo.version>0.11.1</fenzo.version>
         
         <commons-dbcp2.version>2.7.0</commons-dbcp2.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.mesos:mesos 1.1.0
- [CVE-2018-11793](https://www.oscs1024.com/hd/CVE-2018-11793)


### What did I do？
Upgrade org.apache.mesos:mesos from 1.1.0 to 1.7.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>