### PR TITLE
Revert "Bug: Bad attempt to compute absolute value of signed 32-bit hashcode"

### DIFF
--- a/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RoundRobinByNameJobShardingStrategy.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/main/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RoundRobinByNameJobShardingStrategy.java
@@ -38,13 +38,7 @@ public final class RoundRobinByNameJobShardingStrategy implements JobShardingStr
     
     private List<JobInstance> rotateServerList(final List<JobInstance> shardingUnits, final String jobName) {
         int shardingUnitsSize = shardingUnits.size();
-        int jobHashCode = jobName.hashCode();
-        int offset = 0;
-        if (jobHashCode != Integer.MIN_VALUE) {
-            offset = Math.abs(jobHashCode) % shardingUnitsSize;
-        } else {
-            offset = Integer.MIN_VALUE % shardingUnitsSize;
-        }
+        int offset = Math.abs(jobName.hashCode()) % shardingUnitsSize;
         if (0 == offset) {
             return shardingUnits;
         }


### PR DESCRIPTION
Reverts apache/shardingsphere-elasticjob#2151

Sorry for my fault. Result of Integer.MIN_VALUE % shardingUnitSize is still negative, which can still cause out of boundary exception.