### PR TITLE
Avoid possible NPE in LegacyCrashedRunningItemListener

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManager.java
@@ -154,7 +154,7 @@ public final class FailoverListenerManager extends AbstractListenerManager {
         }
         
         private boolean isCurrentInstanceOnline(final DataChangedEvent event) {
-            return Type.ADDED == event.getType() && event.getKey().endsWith(instanceNode.getLocalInstancePath());
+            return Type.ADDED == event.getType() && !JobRegistry.getInstance().isShutdown(jobName) && event.getKey().endsWith(instanceNode.getLocalInstancePath());
         }
         
         private boolean isTheOnlyInstance(final Set<JobInstance> availableJobInstances) {

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -187,6 +188,7 @@ public final class FailoverListenerManagerTest {
     @Test
     public void assertLegacyCrashedRunningItemListenerWhenRunningItemsArePresent() {
         JobInstance jobInstance = new JobInstance("127.0.0.1@-@1");
+        JobRegistry.getInstance().registerJob("test_job", mock(JobScheduleController.class));
         JobRegistry.getInstance().addJobInstance("test_job", jobInstance);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").failover(true).build());
         when(instanceNode.getLocalInstancePath()).thenReturn("instances/127.0.0.1@-@1");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.Map;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -202,5 +204,11 @@ public final class FailoverListenerManagerTest {
         verify(failoverService).setCrashedFailoverFlag(0);
         verify(executionService).clearRunningInfo(Collections.singletonList(0));
         verify(failoverService).failoverIfNecessary();
+    }
+    
+    @Test
+    public void assertLegacyCrashedRunningItemListenerWhenJobInstanceAbsent() {
+        failoverListenerManager.new LegacyCrashedRunningItemListener().onChange(new DataChangedEvent(Type.ADDED, "", ""));
+        verifyNoInteractions(instanceNode);
     }
 }


### PR DESCRIPTION
When shutting down job, NPE may occur because job instance was removed.