### PR TITLE
[ISSUE #2142]add distributed lock to avoid onceListener invoke multi times

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
@@ -61,18 +61,7 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
             BlockUtils.waitingShortTime();
         }
         if (guaranteeService.isAllStarted()) {
-            if (!guaranteeService.lockAllStarted()) {
-                return;
-            }
-            try {
-                if (!guaranteeService.isAllStarted()) {
-                    return;
-                }
-                doBeforeJobExecutedAtLastStarted(shardingContexts);
-            } finally {
-                guaranteeService.unlockAllStarted();
-                guaranteeService.clearAllStartedInfo();
-            }
+            guaranteeService.executeInLeaderForLastStarted(this, shardingContexts);
             return;
         }
         long before = timeService.getCurrentMillis();
@@ -100,18 +89,7 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
             BlockUtils.waitingShortTime();
         }
         if (guaranteeService.isAllCompleted()) {
-            if (!guaranteeService.lockAllCompleted()) {
-                return;
-            }
-            try {
-                if (!guaranteeService.isAllCompleted()) {
-                    return;
-                }
-                doAfterJobExecutedAtLastCompleted(shardingContexts);
-            } finally {
-                guaranteeService.unlockAllCompleted();
-                guaranteeService.clearAllCompletedInfo();
-            }
+            guaranteeService.executeInLeaderForLastCompleted(this, shardingContexts);
             return;
         }
         long before = timeService.getCurrentMillis();

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/api/listener/AbstractDistributeOnceElasticJobListener.java
@@ -61,8 +61,18 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
             BlockUtils.waitingShortTime();
         }
         if (guaranteeService.isAllStarted()) {
-            doBeforeJobExecutedAtLastStarted(shardingContexts);
-            guaranteeService.clearAllStartedInfo();
+            if (!guaranteeService.lockAllStarted()) {
+                return;
+            }
+            try {
+                if (!guaranteeService.isAllStarted()) {
+                    return;
+                }
+                doBeforeJobExecutedAtLastStarted(shardingContexts);
+            } finally {
+                guaranteeService.unlockAllStarted();
+                guaranteeService.clearAllStartedInfo();
+            }
             return;
         }
         long before = timeService.getCurrentMillis();
@@ -90,8 +100,18 @@ public abstract class AbstractDistributeOnceElasticJobListener implements Elasti
             BlockUtils.waitingShortTime();
         }
         if (guaranteeService.isAllCompleted()) {
-            doAfterJobExecutedAtLastCompleted(shardingContexts);
-            guaranteeService.clearAllCompletedInfo();
+            if (!guaranteeService.lockAllCompleted()) {
+                return;
+            }
+            try {
+                if (!guaranteeService.isAllCompleted()) {
+                    return;
+                }
+                doAfterJobExecutedAtLastCompleted(shardingContexts);
+            } finally {
+                guaranteeService.unlockAllCompleted();
+                guaranteeService.clearAllCompletedInfo();
+            }
             return;
         }
         long before = timeService.getCurrentMillis();

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNode.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNode.java
@@ -30,9 +30,9 @@ public final class GuaranteeNode {
     
     static final String COMPLETED_ROOT = ROOT + "/completed";
 
-    static final String STARTED_LOCK_ROOT = ROOT + "/started/lock";
+    static final String STARTED_LATCH_ROOT = ROOT + "/started-latch";
 
-    static final String COMPLETED_LOCK_ROOT = ROOT + "/completed/lock";
+    static final String COMPLETED_LATCH_ROOT = ROOT + "/completed-latch";
     
     private final JobNodePath jobNodePath;
     
@@ -54,21 +54,5 @@ public final class GuaranteeNode {
     
     boolean isCompletedRootNode(final String path) {
         return jobNodePath.getFullPath(COMPLETED_ROOT).equals(path);
-    }
-
-    /**
-     * get full path of started lock.
-     * @return full path of lock
-     */
-    String getStartedLockPath() {
-        return jobNodePath.getFullPath(STARTED_LOCK_ROOT);
-    }
-
-    /**
-     * get full path of completed lock.
-     * @return full path of lock
-     */
-    String getCompletedLockPath() {
-        return jobNodePath.getFullPath(COMPLETED_LOCK_ROOT);
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNode.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNode.java
@@ -29,6 +29,10 @@ public final class GuaranteeNode {
     static final String STARTED_ROOT = ROOT + "/started";
     
     static final String COMPLETED_ROOT = ROOT + "/completed";
+
+    static final String STARTED_LOCK_ROOT = ROOT + "/started/lock";
+
+    static final String COMPLETED_LOCK_ROOT = ROOT + "/completed/lock";
     
     private final JobNodePath jobNodePath;
     
@@ -50,5 +54,21 @@ public final class GuaranteeNode {
     
     boolean isCompletedRootNode(final String path) {
         return jobNodePath.getFullPath(COMPLETED_ROOT).equals(path);
+    }
+
+    /**
+     * get full path of started lock.
+     * @return full path of lock
+     */
+    String getStartedLockPath() {
+        return jobNodePath.getFullPath(STARTED_LOCK_ROOT);
+    }
+
+    /**
+     * get full path of completed lock.
+     * @return full path of lock
+     */
+    String getCompletedLockPath() {
+        return jobNodePath.getFullPath(COMPLETED_LOCK_ROOT);
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeService.java
@@ -117,8 +117,7 @@ public final class GuaranteeService {
      */
     public boolean isAllCompleted() {
         return jobNodeStorage.isJobNodeExisted(GuaranteeNode.COMPLETED_ROOT)
-                && configService.load(false).getShardingTotalCount()
-                <= jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_ROOT).size();
+                && configService.load(false).getShardingTotalCount() <= jobNodeStorage.getJobNodeChildrenKeys(GuaranteeNode.COMPLETED_ROOT).size();
     }
 
     /**

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
@@ -128,7 +128,7 @@ public final class ShardingService {
     
     private void blockUntilShardingCompleted() {
         while (!leaderService.isLeaderUntilBlock() && (jobNodeStorage.isJobNodeExisted(ShardingNode.NECESSARY) || jobNodeStorage.isJobNodeExisted(ShardingNode.PROCESSING))) {
-            log.debug("Job '{}' sleep shortAbstractDistributeOnceElasticJobListener time until sharding completed.", jobName);
+            log.debug("Job '{}' sleep short time until sharding completed.", jobName);
             BlockUtils.waitingShortTime();
         }
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingService.java
@@ -128,7 +128,7 @@ public final class ShardingService {
     
     private void blockUntilShardingCompleted() {
         while (!leaderService.isLeaderUntilBlock() && (jobNodeStorage.isJobNodeExisted(ShardingNode.NECESSARY) || jobNodeStorage.isJobNodeExisted(ShardingNode.PROCESSING))) {
-            log.debug("Job '{}' sleep short time until sharding completed.", jobName);
+            log.debug("Job '{}' sleep shortAbstractDistributeOnceElasticJobListener time until sharding completed.", jobName);
             BlockUtils.waitingShortTime();
         }
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,12 +70,9 @@ public final class DistributeOnceElasticJobListenerTest {
     public void assertBeforeJobExecutedWhenIsAllStarted() {
         when(guaranteeService.isRegisterStartSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
         when(guaranteeService.isAllStarted()).thenReturn(true);
-        when(guaranteeService.lockAllStarted()).thenReturn(true);
         distributeOnceElasticJobListener.beforeJobExecuted(shardingContexts);
         verify(guaranteeService).registerStart(Sets.newHashSet(0, 1));
-        verify(elasticJobListenerCaller).before();
-        verify(guaranteeService).clearAllStartedInfo();
-        verify(guaranteeService).unlockAllStarted();
+        verify(guaranteeService).executeInLeaderForLastStarted(distributeOnceElasticJobListener, shardingContexts);
     }
     
     @Test
@@ -103,12 +99,9 @@ public final class DistributeOnceElasticJobListenerTest {
     public void assertAfterJobExecutedWhenIsAllCompleted() {
         when(guaranteeService.isRegisterCompleteSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
         when(guaranteeService.isAllCompleted()).thenReturn(true);
-        when(guaranteeService.lockAllCompleted()).thenReturn(true);
         distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
         verify(guaranteeService).registerComplete(Sets.newHashSet(0, 1));
-        verify(elasticJobListenerCaller).after();
-        verify(guaranteeService).clearAllCompletedInfo();
-        verify(guaranteeService).unlockAllCompleted();
+        verify(guaranteeService).executeInLeaderForLastCompleted(distributeOnceElasticJobListener, shardingContexts);
     }
     
     @Test
@@ -129,29 +122,5 @@ public final class DistributeOnceElasticJobListenerTest {
         distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
         verify(guaranteeService).registerComplete(Arrays.asList(0, 1));
         verify(guaranteeService, times(0)).clearAllCompletedInfo();
-    }
-
-    @Test
-    public void assertBeforeJobExecutedWhenIsAllStartedAndNotGetLock() {
-        when(guaranteeService.isRegisterStartSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
-        when(guaranteeService.isAllStarted()).thenReturn(true);
-        when(guaranteeService.lockAllStarted()).thenReturn(false);
-        distributeOnceElasticJobListener.beforeJobExecuted(shardingContexts);
-        verify(guaranteeService).registerStart(Sets.newHashSet(0, 1));
-        verify(elasticJobListenerCaller, never()).before();
-        verify(guaranteeService, never()).clearAllStartedInfo();
-        verify(guaranteeService, never()).unlockAllStarted();
-    }
-
-    @Test
-    public void assertAfterJobExecutedWhenIsAllCompletedAndNotGetLock() {
-        when(guaranteeService.isRegisterCompleteSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
-        when(guaranteeService.isAllCompleted()).thenReturn(true);
-        when(guaranteeService.lockAllCompleted()).thenReturn(false);
-        distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
-        verify(guaranteeService).registerComplete(Sets.newHashSet(0, 1));
-        verify(elasticJobListenerCaller, never()).after();
-        verify(guaranteeService, never()).clearAllCompletedInfo();
-        verify(guaranteeService, never()).unlockAllCompleted();
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
@@ -153,6 +153,7 @@ public final class GuaranteeServiceTest {
         verify(jobNodeStorage).removeJobNodeIfExisted("guarantee/completed");
     }
 
+    @Test
     public void assertExecuteInLeaderForLastCompleted() {
         when(jobNodeStorage.isJobNodeExisted("guarantee/completed")).thenReturn(true);
         when(configService.load(false)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").build());
@@ -161,12 +162,14 @@ public final class GuaranteeServiceTest {
         verify(listener).doAfterJobExecutedAtLastCompleted(shardingContexts);
     }
 
+    @Test
     public void assertExecuteInLeaderForNotLastCompleted() {
         when(jobNodeStorage.isJobNodeExisted("guarantee/completed")).thenReturn(false);
         guaranteeService.new LeaderExecutionCallbackForLastCompleted(listener, shardingContexts).execute();
         verify(listener, never()).doAfterJobExecutedAtLastCompleted(shardingContexts);
     }
 
+    @Test
     public void assertExecuteInLeaderForLastStarted() {
         when(jobNodeStorage.isJobNodeExisted("guarantee/started")).thenReturn(true);
         when(configService.load(false)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").build());
@@ -175,6 +178,7 @@ public final class GuaranteeServiceTest {
         verify(listener).doBeforeJobExecutedAtLastStarted(shardingContexts);
     }
 
+    @Test
     public void assertExecuteInLeaderForNotLastStarted() {
         when(jobNodeStorage.isJobNodeExisted("guarantee/started")).thenReturn(false);
         guaranteeService.new LeaderExecutionCallbackForLastStarted(listener, shardingContexts).execute();

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/EmbedTestingServer.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/EmbedTestingServer.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.curator.test.TestingServer;
+import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
 
 import java.io.File;
@@ -45,6 +46,9 @@ public final class EmbedTestingServer {
      * Start the server.
      */
     public static void start() {
+        // sleep some time to avoid testServer intended stop.
+        long sleepTime = 1000L;
+        BlockUtils.sleep(sleepTime);
         if (null != testingServer) {
             return;
         }
@@ -57,7 +61,7 @@ public final class EmbedTestingServer {
         } finally {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(sleepTime);
                     testingServer.close();
                 } catch (final IOException | InterruptedException ex) {
                     RegExceptionHandler.handleException(ex);


### PR DESCRIPTION
Fixes #2142 .

Changes proposed in this pull request:

one job, multi instances completed on concurrency, can cause once listener execute some times, my current system use redis lock to avoid, but source code should add a distributed lock to avoid this, use curator InterProcessMutex now, please help review and give some advice.
