### PR TITLE
Adjust JobScheduler init sequence  to avoid use wrong ElasticJobListener

### DIFF
--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduler.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduler.java
@@ -91,15 +91,10 @@ public final class JobScheduler {
         jobScheduleController = createJobScheduleController();
     }
 
-    private JobConfiguration setUpJobConfiguration(CoordinatorRegistryCenter regCenter, final String jobClassName, JobConfiguration jobConfig) {
-        ConfigurationService configService = new ConfigurationService(regCenter, jobConfig.getJobName());
-        return configService.setUpJobConfiguration(jobClassName, jobConfig);
-    }
-
     public JobScheduler(final CoordinatorRegistryCenter regCenter, final String elasticJobType, final JobConfiguration jobConfig) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(elasticJobType), "Elastic job type cannot be null or empty.");
         this.regCenter = regCenter;
-        this.jobConfig = setUpJobConfiguration(regCenter,elasticJobType, jobConfig);
+        this.jobConfig = setUpJobConfiguration(regCenter, elasticJobType, jobConfig);
         Collection<ElasticJobListener> jobListeners = getElasticJobListeners(this.jobConfig);
         setUpFacade = new SetUpFacade(regCenter, this.jobConfig.getJobName(), jobListeners);
         schedulerFacade = new SchedulerFacade(regCenter, this.jobConfig.getJobName());
@@ -109,7 +104,12 @@ public final class JobScheduler {
         setGuaranteeServiceForElasticJobListeners(regCenter, jobListeners);
         jobScheduleController = createJobScheduleController();
     }
-    
+
+    private JobConfiguration setUpJobConfiguration(final CoordinatorRegistryCenter regCenter, final String jobClassName, final JobConfiguration jobConfig) {
+        ConfigurationService configService = new ConfigurationService(regCenter, jobConfig.getJobName());
+        return configService.setUpJobConfiguration(jobClassName, jobConfig);
+    }
+
     private Collection<ElasticJobListener> getElasticJobListeners(final JobConfiguration jobConfig) {
         return jobConfig.getJobListenerTypes().stream()
                 .map(type -> ElasticJobListenerFactory.createListener(type).orElseThrow(() -> new IllegalArgumentException(String.format("Can not find job listener type '%s'.", type))))

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacade.java
@@ -17,9 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.setup;
 
-import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener;
-import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationService;
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
 import org.apache.shardingsphere.elasticjob.lite.internal.instance.InstanceService;
 import org.apache.shardingsphere.elasticjob.lite.internal.listener.ListenerManager;
@@ -34,8 +32,6 @@ import java.util.Collection;
  */
 public final class SetUpFacade {
     
-    private final ConfigurationService configService;
-    
     private final LeaderService leaderService;
     
     private final ServerService serverService;
@@ -47,23 +43,11 @@ public final class SetUpFacade {
     private final ListenerManager listenerManager;
     
     public SetUpFacade(final CoordinatorRegistryCenter regCenter, final String jobName, final Collection<ElasticJobListener> elasticJobListeners) {
-        configService = new ConfigurationService(regCenter, jobName);
         leaderService = new LeaderService(regCenter, jobName);
         serverService = new ServerService(regCenter, jobName);
         instanceService = new InstanceService(regCenter, jobName);
         reconcileService = new ReconcileService(regCenter, jobName);
         listenerManager = new ListenerManager(regCenter, jobName, elasticJobListeners);
-    }
-    
-    /**
-     * Set up job configuration.
-     *
-     * @param jobClassName job class name
-     * @param jobConfig job configuration to be updated
-     * @return accepted job configuration
-     */
-    public JobConfiguration setUpJobConfiguration(final String jobClassName, final JobConfiguration jobConfig) {
-        return configService.setUpJobConfiguration(jobClassName, jobConfig);
     }
     
     /**

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
@@ -17,10 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.setup;
 
-import org.apache.shardingsphere.elasticjob.api.ElasticJob;
-import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
-import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationService;
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
 import org.apache.shardingsphere.elasticjob.lite.internal.instance.InstanceService;
 import org.apache.shardingsphere.elasticjob.lite.internal.listener.ListenerManager;
@@ -36,16 +33,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class SetUpFacadeTest {
-    
-    @Mock
-    private ConfigurationService configService;
     
     @Mock
     private LeaderService leaderService;
@@ -68,23 +60,13 @@ public final class SetUpFacadeTest {
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         setUpFacade = new SetUpFacade(null, "test_job", Collections.emptyList());
-        ReflectionUtils.setFieldValue(setUpFacade, "configService", configService);
         ReflectionUtils.setFieldValue(setUpFacade, "leaderService", leaderService);
         ReflectionUtils.setFieldValue(setUpFacade, "serverService", serverService);
         ReflectionUtils.setFieldValue(setUpFacade, "instanceService", instanceService);
         ReflectionUtils.setFieldValue(setUpFacade, "reconcileService", reconcileService);
         ReflectionUtils.setFieldValue(setUpFacade, "listenerManager", listenerManager);
     }
-    
-    @Test
-    public void assertSetUpJobConfiguration() {
-        JobConfiguration jobConfig = JobConfiguration.newBuilder("test_job", 3)
-                .cron("0/1 * * * * ?").setProperty("streaming.process", Boolean.TRUE.toString()).build();
-        when(configService.setUpJobConfiguration(ElasticJob.class.getName(), jobConfig)).thenReturn(jobConfig);
-        assertThat(setUpFacade.setUpJobConfiguration(ElasticJob.class.getName(), jobConfig), is(jobConfig));
-        verify(configService).setUpJobConfiguration(ElasticJob.class.getName(), jobConfig);
-    }
-    
+
     @Test
     public void assertRegisterStartUpInfo() {
         setUpFacade.registerStartUpInfo(true);


### PR DESCRIPTION
…ner when the config overwrite is false

Fixes #2188 

Adjust JobScheduler init sequence  to avoid use wrong ElasticJobListener when the  overwrite is false
