### PR TITLE
Update the `Registry Center Configuration` doc

### DIFF
--- a/docs/content/user-manual/elasticjob-lite/configuration/_index.cn.md
+++ b/docs/content/user-manual/elasticjob-lite/configuration/_index.cn.md
@@ -22,8 +22,8 @@ ElasticJob-Lite 提供了 3 种配置方式，用于不同的使用场景。
 | baseSleepTimeMilliseconds     | int      | 1000    | 等待重试的间隔时间的初始毫秒数 |
 | maxSleepTimeMilliseconds      | String   | 3000    | 等待重试的间隔时间的最大毫秒数 |
 | maxRetries                    | String   | 3       | 最大重试次数                 |
-| sessionTimeoutMilliseconds    | boolean  | 60000   | 会话超时毫秒数               |
-| connectionTimeoutMilliseconds | boolean  | 15000   | 连接超时毫秒数               |
+| sessionTimeoutMilliseconds    | int      | 60000   | 会话超时毫秒数               |
+| connectionTimeoutMilliseconds | int      | 15000   | 连接超时毫秒数               |
 | digest                        | String   | 无需验证 | 连接 ZooKeeper 的权限令牌    |
 
 ### 核心配置项说明

--- a/docs/content/user-manual/elasticjob-lite/configuration/_index.en.md
+++ b/docs/content/user-manual/elasticjob-lite/configuration/_index.en.md
@@ -22,8 +22,8 @@ ElasticJob-Lite has provided 3 kinds of configuration methods for different situ
 | baseSleepTimeMilliseconds     | int           | 1000          | The initial value of milliseconds for the retry interval |
 | maxSleepTimeMilliseconds      | String        | 3000          | The maximum value of milliseconds for the retry interval |
 | maxRetries                    | String        | 3             | Maximum number of retries                                |
-| sessionTimeoutMilliseconds    | boolean       | 60000         | Session timeout in milliseconds                          |
-| connectionTimeoutMilliseconds | boolean       | 15000         | Connection timeout in milliseconds                       |
+| sessionTimeoutMilliseconds    | int           | 60000         | Session timeout in milliseconds                          |
+| connectionTimeoutMilliseconds | int           | 15000         | Connection timeout in milliseconds                       |
 | digest                        | String        | no need       | Permission token to connect to ZooKeeper                 |
 
 ### Core Configuration Description


### PR DESCRIPTION
fixed `sessionTimeoutMilliseconds` and `connectionTimeoutMilliseconds` data types

Changes proposed in this pull request:
- Fixed data types for parameters in Registry Center Configuration
