### PR TITLE
Do not create tracingDatasource when elasticjob.tracing.type is not RDB

### DIFF
--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <optional>true</optional>
         </dependency>
         
         <dependency>
@@ -74,14 +75,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/ElasticJobTracingConfiguration.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/ElasticJobTracingConfiguration.java
@@ -20,11 +20,13 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
 
 import javax.sql.DataSource;
@@ -35,39 +37,43 @@ import javax.sql.DataSource;
 @EnableConfigurationProperties(TracingProperties.class)
 public class ElasticJobTracingConfiguration {
 
-    /**
-     * Create a bean of tracing DataSource.
-     *
-     * @param tracingProperties tracing Properties
-     * @return tracing DataSource
-     */
-    @Bean("tracingDataSource")
-    public DataSource tracingDataSource(final TracingProperties tracingProperties) {
-        DataSourceProperties dataSource = tracingProperties.getDataSource();
-        if (dataSource == null) {
-            return null;
-        }
-        HikariDataSource tracingDataSource = new HikariDataSource();
-        tracingDataSource.setJdbcUrl(dataSource.getUrl());
-        BeanUtils.copyProperties(dataSource, tracingDataSource);
-        return tracingDataSource;
-    }
-
-    /**
-     * Create a bean of tracing configuration.
-     *
-     * @param dataSource required by constructor
-     * @param tracingDataSource tracing ataSource
-     * @return a bean of tracing configuration
-     */
-    @Bean
-    @ConditionalOnBean(DataSource.class)
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(name = "elasticjob.tracing.type", havingValue = "RDB")
-    public TracingConfiguration<DataSource> tracingConfiguration(final DataSource dataSource, @Nullable final DataSource tracingDataSource) {
-        DataSource ds = tracingDataSource;
-        if (ds == null) {
-            ds = dataSource;
+    static class RDBTracingConfiguration {
+        /**
+         * Create a bean of tracing DataSource.
+         *
+         * @param tracingProperties tracing Properties
+         * @return tracing DataSource
+         */
+        @Bean("tracingDataSource")
+        public DataSource tracingDataSource(final TracingProperties tracingProperties) {
+            DataSourceProperties dataSource = tracingProperties.getDataSource();
+            if (dataSource == null) {
+                return null;
+            }
+            HikariDataSource tracingDataSource = new HikariDataSource();
+            tracingDataSource.setJdbcUrl(dataSource.getUrl());
+            BeanUtils.copyProperties(dataSource, tracingDataSource);
+            return tracingDataSource;
         }
-        return new TracingConfiguration<>("RDB", ds);
+
+        /**
+         * Create a bean of tracing configuration.
+         *
+         * @param dataSource required by constructor
+         * @param tracingDataSource tracing ataSource
+         * @return a bean of tracing configuration
+         */
+        @Bean
+        @ConditionalOnBean(name = "tracingDataSource")
+        public TracingConfiguration<DataSource> tracingConfiguration(@Qualifier("tracingDataSource") final DataSource dataSource,
+                                                                     @Nullable final DataSource tracingDataSource) {
+            DataSource ds = tracingDataSource;
+            if (ds == null) {
+                ds = dataSource;
+            }
+            return new TracingConfiguration<>("RDB", ds);
+        }
     }
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/ElasticJobTracingConfiguration.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/ElasticJobTracingConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -34,6 +33,7 @@ import javax.sql.DataSource;
 /**
  * ElasticJob tracing auto configuration.
  */
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(TracingProperties.class)
 public class ElasticJobTracingConfiguration {
 
@@ -66,8 +66,8 @@ public class ElasticJobTracingConfiguration {
          * @return a bean of tracing configuration
          */
         @Bean
-        @ConditionalOnBean(name = "tracingDataSource")
-        public TracingConfiguration<DataSource> tracingConfiguration(@Qualifier("tracingDataSource") final DataSource dataSource,
+        @ConditionalOnBean(DataSource.class)
+        public TracingConfiguration<DataSource> tracingConfiguration(final DataSource dataSource,
                                                                      @Nullable final DataSource tracingDataSource) {
             DataSource ds = tracingDataSource;
             if (ds == null) {

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
@@ -1,11 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing;
 
+import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.ResolvableType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 import javax.sql.DataSource;
@@ -16,7 +36,13 @@ import static org.junit.Assert.assertNull;
 
 @SpringBootTest
 @SpringBootApplication
+@ActiveProfiles("tracing")
 public class TracingConfigurationTest extends AbstractJUnit4SpringContextTests {
+
+    @BeforeClass
+    public static void init() {
+        EmbedTestingServer.start();
+    }
 
     @Test
     public void assertNotRDBConfiguration() {

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
@@ -1,0 +1,28 @@
+package org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing;
+
+import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
+import org.junit.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ResolvableType;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+import javax.sql.DataSource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+@SpringBootTest
+@SpringBootApplication
+public class TracingConfigurationTest extends AbstractJUnit4SpringContextTests {
+
+    @Test
+    public void assertNotRDBConfiguration() {
+        assertNotNull(applicationContext);
+        assertFalse(applicationContext.containsBean("tracingDataSource"));
+        ObjectProvider<Object> provider = applicationContext.getBeanProvider(ResolvableType.forClassWithGenerics(TracingConfiguration.class, DataSource.class));
+        assertNull(provider.getIfAvailable());
+    }
+}

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/resources/application-tracing.yml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/resources/application-tracing.yml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+elasticjob:
+  regCenter:
+    serverLists: localhost:18181
+    namespace: elasticjob-lite-spring-boot-starter


### PR DESCRIPTION
Fixes #2253.
