### PR TITLE
Use Awaitility instead of BlockUtils in unit tests

### DIFF
--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/pom.xml
@@ -58,5 +58,10 @@
             <optional>true</optional>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/fixture/InternalController.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/fixture/InternalController.java
@@ -18,14 +18,18 @@
 package org.apache.shardingsphere.elasticjob.http.executor.fixture;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.restful.Http;
 import org.apache.shardingsphere.elasticjob.restful.RestfulController;
 import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
 import org.apache.shardingsphere.elasticjob.restful.annotation.Param;
 import org.apache.shardingsphere.elasticjob.restful.annotation.ParamSource;
+import org.awaitility.Awaitility;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @Slf4j
 public final class InternalController implements RestfulController {
@@ -71,7 +75,9 @@ public final class InternalController implements RestfulController {
      */
     @Mapping(method = Http.POST, path = "/postWithTimeout")
     public String postWithTimeout() {
-        BlockUtils.waitingShortTime();
+        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(Boolean.TRUE, is(Boolean.TRUE))
+        );
         return "ejob";
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/pom.xml
+++ b/elasticjob-infra/elasticjob-infra-common/pom.xml
@@ -87,5 +87,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.elasticjob.infra.concurrent;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -38,15 +40,17 @@ public final class ElasticJobExecutorServiceTest {
         assertFalse(executorServiceObject.isShutdown());
         ExecutorService executorService = executorServiceObject.createExecutorService();
         executorService.submit(new FooTask());
-        BlockUtils.waitingShortTime();
-        assertThat(executorServiceObject.getActiveThreadCount(), is(1));
-        assertThat(executorServiceObject.getWorkQueueSize(), is(0));
-        assertFalse(executorServiceObject.isShutdown());
+        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThat(executorServiceObject.getActiveThreadCount(), is(1));
+            assertThat(executorServiceObject.getWorkQueueSize(), is(0));
+            assertFalse(executorServiceObject.isShutdown());
+        });
         executorService.submit(new FooTask());
-        BlockUtils.waitingShortTime();
-        assertThat(executorServiceObject.getActiveThreadCount(), is(1));
-        assertThat(executorServiceObject.getWorkQueueSize(), is(1));
-        assertFalse(executorServiceObject.isShutdown());
+        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertThat(executorServiceObject.getActiveThreadCount(), is(1));
+            assertThat(executorServiceObject.getWorkQueueSize(), is(1));
+            assertFalse(executorServiceObject.isShutdown());
+        });
         executorService.shutdownNow();
         assertThat(executorServiceObject.getWorkQueueSize(), is(0));
         assertTrue(executorServiceObject.isShutdown());
@@ -54,13 +58,11 @@ public final class ElasticJobExecutorServiceTest {
     }
     
     static class FooTask implements Runnable {
-        
+
         @Override
         public void run() {
-            BlockUtils.sleep(1000L);
-            while (!hasExecuted) {
-                Thread.yield();
-            }
+            Awaitility.await().atMost(1L, TimeUnit.MINUTES)
+                    .untilAsserted(() -> assertThat(hasExecuted, is(true)));
         }
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-core/pom.xml
@@ -125,5 +125,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/OneOffDisabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/OneOffDisabledJobIntegrateTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.elasticjob.lite.integrate.disable;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.junit.Test;
 
 public final class OneOffDisabledJobIntegrateTest extends DisabledJobIntegrateTest {
@@ -35,7 +34,6 @@ public final class OneOffDisabledJobIntegrateTest extends DisabledJobIntegrateTe
     
     @Test
     public void assertJobRunning() {
-        BlockUtils.waitingShortTime();
         assertDisabledRegCenterInfo();
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/ScheduleDisabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/ScheduleDisabledJobIntegrateTest.java
@@ -21,9 +21,13 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class ScheduleDisabledJobIntegrateTest extends DisabledJobIntegrateTest {
@@ -40,12 +44,11 @@ public final class ScheduleDisabledJobIntegrateTest extends DisabledJobIntegrate
     
     @Test
     public void assertJobRunning() {
-        BlockUtils.waitingShortTime();
         assertDisabledRegCenterInfo();
         setJobEnable();
-        while (!((DetailedFooJob) getElasticJob()).isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(10L, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(((DetailedFooJob) getElasticJob()).isCompleted(), is(true))
+        );
         assertEnabledRegCenterInfo();
     }
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/OneOffEnabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/OneOffEnabledJobIntegrateTest.java
@@ -19,9 +19,13 @@ package org.apache.shardingsphere.elasticjob.lite.integrate.enable;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class OneOffEnabledJobIntegrateTest extends EnabledJobIntegrateTest {
@@ -38,9 +42,9 @@ public final class OneOffEnabledJobIntegrateTest extends EnabledJobIntegrateTest
     
     @Test
     public void assertJobInit() {
-        while (!((DetailedFooJob) getElasticJob()).isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(((DetailedFooJob) getElasticJob()).isCompleted(), is(true))
+        );
         assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/ScheduleEnabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/ScheduleEnabledJobIntegrateTest.java
@@ -19,9 +19,13 @@ package org.apache.shardingsphere.elasticjob.lite.integrate.enable;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class ScheduleEnabledJobIntegrateTest extends EnabledJobIntegrateTest {
@@ -35,12 +39,12 @@ public final class ScheduleEnabledJobIntegrateTest extends EnabledJobIntegrateTe
         return JobConfiguration.newBuilder(jobName, 3).cron("0/1 * * * * ?").shardingItemParameters("0=A,1=B,2=C")
                 .jobListenerTypes("INTEGRATE-TEST", "INTEGRATE-DISTRIBUTE").overwrite(true).build();
     }
-    
+
     @Test
     public void assertJobInit() {
-        while (!((DetailedFooJob) getElasticJob()).isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(10L, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(((DetailedFooJob) getElasticJob()).isCompleted(), is(true))
+        );
         assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/OneOffEnabledJobTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/OneOffEnabledJobTest.java
@@ -17,21 +17,23 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.annotation.integrate;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.AnnotationUnShardingJob;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class OneOffEnabledJobTest extends BaseAnnotationTest {
     
@@ -55,9 +57,9 @@ public final class OneOffEnabledJobTest extends BaseAnnotationTest {
     
     @Test
     public void assertJobInit() {
-        while (!((AnnotationUnShardingJob) getElasticJob()).isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(((AnnotationUnShardingJob) getElasticJob()).isCompleted(), is(true))
+        );
         assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
     }
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/ScheduleEnabledJobTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/ScheduleEnabledJobTest.java
@@ -17,21 +17,23 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.annotation.integrate;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.AnnotationSimpleJob;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class ScheduleEnabledJobTest extends BaseAnnotationTest {
     
@@ -57,9 +59,9 @@ public final class ScheduleEnabledJobTest extends BaseAnnotationTest {
     
     @Test
     public void assertJobInit() {
-        while (!((AnnotationSimpleJob) getElasticJob()).isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(((AnnotationSimpleJob) getElasticJob()).isCompleted(), is(true))
+        );
         assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
     }
     

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/pom.xml
@@ -87,5 +87,10 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootScannerTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootScannerTest.java
@@ -17,18 +17,22 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.boot.job;
 
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.job.impl.AnnotationCustomJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.core.scanner.ElasticJobScan;
+import org.awaitility.Awaitility;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @SpringBootTest
@@ -44,9 +48,9 @@ public class ElasticJobSpringBootScannerTest extends AbstractJUnit4SpringContext
     
     @Test
     public void assertDefaultBeanNameWithTypeJob() {
-        while (!AnnotationCustomJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(AnnotationCustomJob.isCompleted(), is(true))
+        );
         assertTrue(AnnotationCustomJob.isCompleted());
         assertNotNull(applicationContext);
         assertNotNull(applicationContext.getBean("annotationCustomJobSchedule", ScheduleJobBootstrap.class));

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.job;
 
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobExtraConfiguration;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.JobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
@@ -30,6 +29,7 @@ import org.apache.shardingsphere.elasticjob.lite.spring.boot.reg.ZookeeperProper
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing.TracingProperties;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
+import org.awaitility.Awaitility;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -131,12 +132,13 @@ public class ElasticJobSpringBootTest extends AbstractJUnit4SpringContextTests {
     
     @Test
     public void assertJobScheduleCreation() {
-        assertNotNull(applicationContext);
-        Map<String, ElasticJob> elasticJobBeans = applicationContext.getBeansOfType(ElasticJob.class);
-        assertFalse(elasticJobBeans.isEmpty());
-        Map<String, JobBootstrap> jobBootstrapBeans = applicationContext.getBeansOfType(JobBootstrap.class);
-        assertFalse(jobBootstrapBeans.isEmpty());
-        BlockUtils.waitingShortTime();
+        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> {
+            assertNotNull(applicationContext);
+            Map<String, ElasticJob> elasticJobBeans = applicationContext.getBeansOfType(ElasticJob.class);
+            assertFalse(elasticJobBeans.isEmpty());
+            Map<String, JobBootstrap> jobBootstrapBeans = applicationContext.getBeansOfType(JobBootstrap.class);
+            assertFalse(jobBootstrapBeans.isEmpty());
+        });
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
@@ -114,5 +114,10 @@
             <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
@@ -19,16 +19,20 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.FooSimpleElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RequiredArgsConstructor
@@ -61,17 +65,17 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     }
     
     private void assertSimpleElasticJobBean() {
-        while (!FooSimpleElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(FooSimpleElasticJob.isCompleted(), is(true))
+        );
         assertTrue(FooSimpleElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }
     
     private void assertThroughputDataflowElasticJobBean() {
-        while (!DataflowElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(DataflowElasticJob.isCompleted(), is(true))
+        );
         assertTrue(DataflowElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + throughputDataflowJobName + "/sharding"));
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
@@ -18,18 +18,22 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.FooSimpleElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RequiredArgsConstructor
@@ -64,9 +68,9 @@ public abstract class AbstractOneOffJobSpringIntegrateTest extends AbstractZooke
     private void assertSimpleElasticJobBean() {
         OneOffJobBootstrap bootstrap = applicationContext.getBean(simpleJobName, OneOffJobBootstrap.class);
         bootstrap.execute();
-        while (!FooSimpleElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(10L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(FooSimpleElasticJob.isCompleted(), is(true))
+        );
         assertTrue(FooSimpleElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }
@@ -74,9 +78,9 @@ public abstract class AbstractOneOffJobSpringIntegrateTest extends AbstractZooke
     private void assertThroughputDataflowElasticJobBean() {
         OneOffJobBootstrap bootstrap = applicationContext.getBean(throughputDataflowJobName, OneOffJobBootstrap.class);
         bootstrap.execute();
-        while (!DataflowElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(10L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(DataflowElasticJob.isCompleted(), is(true))
+        );
         assertTrue(DataflowElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + throughputDataflowJobName + "/sharding"));
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
@@ -18,16 +18,20 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/withJobRef.xml")
@@ -55,9 +59,9 @@ public final class JobSpringNamespaceWithRefTest extends AbstractZookeeperJUnit4
     }
 
     private void assertSimpleElasticJobBean() {
-        while (!RefFooSimpleElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(RefFooSimpleElasticJob.isCompleted(), is(true))
+        );
         assertTrue(RefFooSimpleElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
@@ -19,16 +19,20 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobRef.xml")
@@ -58,9 +62,9 @@ public final class OneOffJobSpringNamespaceWithRefTest extends AbstractZookeeper
     }
 
     private void assertOneOffSimpleElasticJobBean() {
-        while (!RefFooSimpleElasticJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(RefFooSimpleElasticJob.isCompleted(), is(true))
+        );
         assertTrue(RefFooSimpleElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + oneOffSimpleJobName + "/sharding"));
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -17,15 +17,17 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 
@@ -46,7 +48,8 @@ public final class OneOffJobSpringNamespaceWithTypeTest extends AbstractZookeepe
     public void jobScriptWithJobTypeTest() {
         OneOffJobBootstrap bootstrap = applicationContext.getBean(scriptJobName, OneOffJobBootstrap.class);
         bootstrap.execute();
-        BlockUtils.sleep(1000L);
-        assertTrue(regCenter.isExisted("/" + scriptJobName + "/sharding"));
+        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertTrue(regCenter.isExisted("/" + scriptJobName + "/sharding"))
+        );
     }
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
@@ -18,16 +18,20 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.scanner;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.elasticjob.infra.concurrent.BlockUtils;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.annotation.AnnotationSimpleJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RequiredArgsConstructor
@@ -55,9 +59,9 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     }
     
     private void assertSimpleElasticJobBean() {
-        while (!AnnotationSimpleJob.isCompleted()) {
-            BlockUtils.waitingShortTime();
-        }
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+                assertThat(AnnotationSimpleJob.isCompleted(), is(true))
+        );
         assertTrue(AnnotationSimpleJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>4.8.0</mockito.version>
+        <awaitility.version>4.2.0</awaitility.version>
         
         <apache-rat-plugin.version>0.15</apache-rat-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -345,6 +346,12 @@
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjweaver</artifactId>
                 <version>${aspectj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Fixes #2219.

Changes proposed in this pull request:
- Use Awaitility instead of BlockUtils in unit tests. Awaitility is actually the most widely used testing library for asynchronous debugging and is compatible with the Junit Platform and GraalVM Native Build Tools.
- Also fixes #2242 .
- Also fixes #2202 .
