### PR TITLE
Migrate from Junit Vintage to Junit Jupiter

### DIFF
--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/ElasticJobConfigurationTest.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/annotation/ElasticJobConfigurationTest.java
@@ -17,16 +17,17 @@
 
 package org.apache.shardingsphere.elasticjob.annotation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.shardingsphere.elasticjob.annotation.job.impl.SimpleTestJob;
+import org.apache.shardingsphere.elasticjob.api.JobExtraConfigurationFactory;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
-import org.apache.shardingsphere.elasticjob.annotation.job.impl.SimpleTestJob;
-import org.apache.shardingsphere.elasticjob.api.JobExtraConfigurationFactory;
-import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public final class ElasticJobConfigurationTest {
     

--- a/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/api/JobConfigurationTest.java
+++ b/elasticjob-api/src/test/java/org/apache/shardingsphere/elasticjob/api/JobConfigurationTest.java
@@ -17,13 +17,14 @@
 
 package org.apache.shardingsphere.elasticjob.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class JobConfigurationTest {
     
@@ -81,13 +82,15 @@ public final class JobConfigurationTest {
         assertFalse(actual.isOverwrite());
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertBuildWithEmptyJobName() {
-        JobConfiguration.newBuilder("", 3).cron("0/1 * * * * ?").build();
+        assertThrows(IllegalArgumentException.class, () ->
+                JobConfiguration.newBuilder("", 3).cron("0/1 * * * * ?").build());
     }
-    
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test
     public void assertBuildWithInvalidShardingTotalCount() {
-        JobConfiguration.newBuilder("test_job", -1).cron("0/1 * * * * ?").build();
+        assertThrows(IllegalArgumentException.class, () ->
+                JobConfiguration.newBuilder("test_job", -1).cron("0/1 * * * * ?").build());
     }
 }

--- a/elasticjob-cloud/elasticjob-cloud-common/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-common/pom.xml
@@ -102,14 +102,6 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
         
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/elasticjob-cloud/elasticjob-cloud-common/src/test/java/org/apache/shardingsphere/elasticjob/cloud/config/pojo/CloudJobConfigurationPOJOTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-common/src/test/java/org/apache/shardingsphere/elasticjob/cloud/config/pojo/CloudJobConfigurationPOJOTest.java
@@ -21,13 +21,13 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.cloud.config.CloudJobConfiguration;
 import org.apache.shardingsphere.elasticjob.cloud.config.CloudJobExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class CloudJobConfigurationPOJOTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-common/src/test/java/org/apache/shardingsphere/elasticjob/cloud/statistics/rdb/StatisticRdbRepositoryTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-common/src/test/java/org/apache/shardingsphere/elasticjob/cloud/statistics/rdb/StatisticRdbRepositoryTest.java
@@ -23,23 +23,23 @@ import org.apache.shardingsphere.elasticjob.cloud.statistics.type.job.JobRegiste
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.job.JobRunningStatistics;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskResultStatistics;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskRunningStatistics;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StatisticRdbRepositoryTest {
     
     private StatisticRdbRepository repository;
     
-    @Before
+    @BeforeEach
     public void setup() throws SQLException {
         BasicDataSource dataSource = new BasicDataSource();
         dataSource.setDriverClassName(org.h2.Driver.class.getName());

--- a/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-executor/pom.xml
@@ -51,14 +51,6 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/facade/CloudJobFacadeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/facade/CloudJobFacadeTest.java
@@ -27,21 +27,21 @@ import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.tracing.JobTracingEventBus;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.State;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudJobFacadeTest {
     
     private ShardingContexts shardingContexts;
@@ -51,7 +51,7 @@ public final class CloudJobFacadeTest {
     
     private JobFacade jobFacade;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         shardingContexts = getShardingContexts();
         jobFacade = new CloudJobFacade(shardingContexts, getJobConfiguration(), jobTracingEventBus);

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/local/LocalTaskExecutorTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/local/LocalTaskExecutorTest.java
@@ -23,13 +23,14 @@ import org.apache.shardingsphere.elasticjob.cloud.executor.fixture.TestSimpleJob
 import org.apache.shardingsphere.elasticjob.dataflow.props.DataflowJobProperties;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.script.props.ScriptJobProperties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class LocalTaskExecutorTest {
     
@@ -56,8 +57,9 @@ public final class LocalTaskExecutorTest {
                 .cron("*/2 * * * * ?").setProperty(ScriptJobProperties.SCRIPT_KEY, "echo test").build(), 1).execute();
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertNotExistsJobType() {
-        new LocalTaskExecutor("not exist", JobConfiguration.newBuilder("not exist", 3).cron("*/2 * * * * ?").build(), 1).execute();
+        assertThrows(JobConfigurationException.class, () ->
+                new LocalTaskExecutor("not exist", JobConfiguration.newBuilder("not exist", 3).cron("*/2 * * * * ?").build(), 1).execute());
     }
 }

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/DaemonTaskSchedulerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/DaemonTaskSchedulerTest.java
@@ -29,22 +29,22 @@ import org.apache.shardingsphere.elasticjob.cloud.facade.CloudJobFacade;
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.script.props.ScriptJobProperties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobExecutionContext;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DaemonTaskSchedulerTest {
     
     @Mock
@@ -69,7 +69,7 @@ public final class DaemonTaskSchedulerTest {
     
     private DaemonJob daemonJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         daemonJob = new DaemonJob();
         daemonJob.setJobFacade(jobFacade);

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/TaskExecutorTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/TaskExecutorTest.java
@@ -28,22 +28,22 @@ import org.apache.mesos.Protos.SlaveInfo;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.shardingsphere.elasticjob.cloud.executor.fixture.TestSimpleJob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TaskExecutorTest {
     
     @Mock
@@ -60,7 +60,7 @@ public final class TaskExecutorTest {
     
     private TaskExecutor taskExecutor;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         taskExecutor = new TaskExecutor(new TestSimpleJob());
         setExecutorService();

--- a/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/TaskExecutorThreadTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-executor/src/test/java/org/apache/shardingsphere/elasticjob/cloud/executor/prod/TaskExecutorThreadTest.java
@@ -32,17 +32,17 @@ import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
 import org.apache.shardingsphere.elasticjob.script.props.ScriptJobProperties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TaskExecutorThreadTest {
     
     @Mock

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/pom.xml
@@ -99,14 +99,6 @@
             <artifactId>curator-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/AbstractCloudControllerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/AbstractCloudControllerTest.java
@@ -32,16 +32,16 @@ import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractCloudControllerTest {
     
     @Getter(AccessLevel.PROTECTED)
@@ -56,7 +56,7 @@ public abstract class AbstractCloudControllerTest {
     
     private static RestfulService slaveServer;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         initRestfulServer();
         initMesosServer();
@@ -85,7 +85,7 @@ public abstract class AbstractCloudControllerTest {
         slaveServer.startup();
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         consoleBootstrap.stop();
         masterServer.shutdown();
@@ -93,7 +93,7 @@ public abstract class AbstractCloudControllerTest {
         MesosStateService.deregister();
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         reset(regCenter);
         reset(jobEventRdbSearch);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudAppControllerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudAppControllerTest.java
@@ -21,9 +21,9 @@ import org.apache.shardingsphere.elasticjob.cloud.console.AbstractCloudControlle
 import org.apache.shardingsphere.elasticjob.cloud.console.HttpTestUtil;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudAppJsonConstants;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJsonConstants;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CloudAppControllerTest extends AbstractCloudControllerTest {
     
     private static final String YAML = "appCacheEnable: true\n"

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudJobControllerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudJobControllerTest.java
@@ -32,9 +32,9 @@ import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskResul
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CloudJobControllerTest extends AbstractCloudControllerTest {
     
     private static final String YAML = "appName: test_app\n"

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudLoginTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudLoginTest.java
@@ -25,9 +25,9 @@ import org.apache.shardingsphere.elasticjob.cloud.console.HttpTestUtil;
 import org.apache.shardingsphere.elasticjob.cloud.console.security.AuthenticationConstants;
 import org.apache.shardingsphere.elasticjob.cloud.console.security.AuthenticationService;
 import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -36,7 +36,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CloudLoginTest extends AbstractCloudControllerTest {
     
     @Test

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudOperationControllerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/CloudOperationControllerTest.java
@@ -19,17 +19,17 @@ package org.apache.shardingsphere.elasticjob.cloud.console.controller;
 
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.console.AbstractCloudControllerTest;
-import org.apache.shardingsphere.elasticjob.cloud.scheduler.ha.HANode;
 import org.apache.shardingsphere.elasticjob.cloud.console.HttpTestUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.apache.shardingsphere.elasticjob.cloud.scheduler.ha.HANode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CloudOperationControllerTest extends AbstractCloudControllerTest {
     
     @Test

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearchTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearchTest.java
@@ -20,11 +20,11 @@ package org.apache.shardingsphere.elasticjob.cloud.console.controller.search;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobEventRdbSearchTest {
     
     @Mock
@@ -59,7 +59,7 @@ public final class JobEventRdbSearchTest {
     
     private JobEventRdbSearch jobEventRdbSearch;
     
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         jobEventRdbSearch = new JobEventRdbSearch(dataSource);
         when(dataSource.getConnection()).thenReturn(conn);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearchTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/console/controller/search/JobEventRdbSearchTest.java
@@ -48,8 +48,9 @@ public final class JobEventRdbSearchTest {
     
     @Mock
     private PreparedStatement preparedStatement;
-    
-    @Mock
+
+    // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private ResultSet resultSet;
     
     @Mock

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationListenerTest.java
@@ -27,19 +27,19 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos.MesosStateServ
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.producer.ProducerManager;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudAppConfigurationListenerTest {
     
     private static ZookeeperRegistryCenter regCenter;
@@ -53,7 +53,7 @@ public final class CloudAppConfigurationListenerTest {
     @InjectMocks
     private CloudAppConfigurationListener cloudAppConfigurationListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(cloudAppConfigurationListener, "producerManager", producerManager);
         ReflectionUtils.setFieldValue(cloudAppConfigurationListener, "mesosStateService", mesosStateService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationNodeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/CloudAppConfigurationServiceTest.java
@@ -21,24 +21,24 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app.pojo.Clou
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudAppConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudAppJsonConstants;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudAppConfigurationServiceTest {
     
     private static final String YAML = "appCacheEnable: true\n"

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/pojo/CloudAppConfigurationPOJOTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/app/pojo/CloudAppConfigurationPOJOTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app.pojo;
 
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app.CloudAppConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class CloudAppConfigurationPOJOTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationListenerTest.java
@@ -27,20 +27,20 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.producer.ProducerMan
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.ready.ReadyService;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudJobConfigurationListenerTest {
     
     private static ZookeeperRegistryCenter regCenter;
@@ -54,7 +54,7 @@ public final class CloudJobConfigurationListenerTest {
     @InjectMocks
     private CloudJobConfigurationListener cloudJobConfigurationListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(cloudJobConfigurationListener, "producerManager", producerManager);
         ReflectionUtils.setFieldValue(cloudJobConfigurationListener, "readyService", readyService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationNodeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/config/job/CloudJobConfigurationServiceTest.java
@@ -21,24 +21,24 @@ import org.apache.shardingsphere.elasticjob.cloud.config.pojo.CloudJobConfigurat
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJsonConstants;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudJobConfigurationServiceTest {
     
     private static final String YAML = "appName: test_app\n"

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/context/JobContextTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/context/JobContextTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.context;
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.cloud.config.CloudJobConfiguration;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/env/BootstrapEnvironmentTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.env;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -28,8 +28,8 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public final class BootstrapEnvironmentTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/ha/FrameworkIDServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/ha/FrameworkIDServiceTest.java
@@ -18,21 +18,21 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.ha;
 
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FrameworkIDServiceTest {
     
     @Mock
@@ -40,7 +40,7 @@ public class FrameworkIDServiceTest {
     
     private FrameworkIDService frameworkIDService;
     
-    @Before
+    @BeforeEach
     public void init() {
         frameworkIDService = new FrameworkIDService(registryCenter);
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/AppConstraintEvaluatorTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/AppConstraintEvaluatorTest.java
@@ -31,10 +31,10 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConf
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos.MesosStateService.ExecutorStateInfo;
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,19 +63,19 @@ public final class AppConstraintEvaluatorTest {
     
     private TaskScheduler taskScheduler;
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         facadeService = mock(FacadeService.class);
         AppConstraintEvaluator.init(facadeService);
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         taskScheduler = new TaskScheduler.Builder().withLeaseOfferExpirySecs(1000000000L).withLeaseRejectAction(virtualMachineLease -> {
         }).build();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         AppConstraintEvaluator.getInstance().clearAppRunningState();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/FacadeServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/FacadeServiceTest.java
@@ -39,11 +39,11 @@ import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext.MetaInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,14 +51,14 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class FacadeServiceTest {
     
     @Mock
@@ -90,7 +90,7 @@ public final class FacadeServiceTest {
     
     private FacadeService facadeService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         facadeService = new FacadeService(regCenter);
         ReflectionUtils.setFieldValue(facadeService, "jobConfigService", jobConfigService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/JobTaskRequestTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/JobTaskRequestTest.java
@@ -22,13 +22,13 @@ import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
 import org.hamcrest.core.StringStartsWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class JobTaskRequestTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/LaunchingTasksTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/LaunchingTasksTest.java
@@ -27,11 +27,11 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.ready.ReadySer
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.running.RunningService;
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +40,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class LaunchingTasksTest {
     
     @Mock
@@ -60,7 +60,7 @@ public final class LaunchingTasksTest {
     
     private LaunchingTasks launchingTasks;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         FacadeService facadeService = new FacadeService(regCenter);
         ReflectionUtils.setFieldValue(facadeService, "jobConfigService", jobConfigService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/LeasesQueueTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/LeasesQueueTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos;
 
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos.fixture.OfferBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class LeasesQueueTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/MesosStateServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/MesosStateServiceTest.java
@@ -21,10 +21,10 @@ import org.apache.shardingsphere.elasticjob.cloud.console.AbstractCloudControlle
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.ha.HANode;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos.MesosStateService.ExecutorStateInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
 import java.util.Map;
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MesosStateServiceTest extends AbstractCloudControllerTest {
     
     @Mock

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/ReconcileServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/ReconcileServiceTest.java
@@ -17,17 +17,17 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos;
 
-import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import com.google.common.collect.Sets;
 import org.apache.mesos.Protos;
 import org.apache.mesos.SchedulerDriver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ReconcileServiceTest {
     
     @Mock
@@ -54,7 +54,7 @@ public final class ReconcileServiceTest {
     @Captor
     private ArgumentCaptor<Collection<Protos.TaskStatus>> taskStatusCaptor;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         reconcileService = new ReconcileService(schedulerDriver, facadeService);
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerEngineTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerEngineTest.java
@@ -31,12 +31,12 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.Statistic
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.tracing.JobTracingEventBus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SchedulerEngineTest {
     
     @Mock
@@ -66,7 +66,7 @@ public final class SchedulerEngineTest {
     
     private SchedulerEngine schedulerEngine;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         schedulerEngine = new SchedulerEngine(taskScheduler, facadeService, new JobTracingEventBus(), frameworkIDService, statisticManager);
         ReflectionUtils.setFieldValue(schedulerEngine, "facadeService", facadeService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerEngineTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerEngineTest.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,7 +71,7 @@ public final class SchedulerEngineTest {
     public void setUp() {
         schedulerEngine = new SchedulerEngine(taskScheduler, facadeService, new JobTracingEventBus(), frameworkIDService, statisticManager);
         ReflectionUtils.setFieldValue(schedulerEngine, "facadeService", facadeService);
-        when(facadeService.load("test_job")).thenReturn(Optional.of(CloudJobConfigurationBuilder.createCloudJobConfiguration("test_job")));
+        lenient().when(facadeService.load("test_job")).thenReturn(Optional.of(CloudJobConfigurationBuilder.createCloudJobConfiguration("test_job")));
         new RunningService(mock(CoordinatorRegistryCenter.class)).clear();
     }
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SchedulerServiceTest.java
@@ -28,19 +28,19 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.producer.ProducerMan
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.app.CloudAppDisableListener;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.job.CloudJobDisableListener;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.StatisticManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SchedulerServiceTest {
     
     @Mock
@@ -81,7 +81,7 @@ public class SchedulerServiceTest {
     
     private SchedulerService schedulerService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         schedulerService = new SchedulerService(env, facadeService, schedulerDriver,
                 producerManager, statisticManager, cloudJobConfigurationListener,

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SupportedExtractionTypeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/SupportedExtractionTypeTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class SupportedExtractionTypeTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskInfoDataTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskInfoDataTest.java
@@ -20,14 +20,14 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.mesos;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class TaskInfoDataTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskLaunchScheduledServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskLaunchScheduledServiceTest.java
@@ -36,13 +36,13 @@ import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext.MetaInfo;
 import org.apache.shardingsphere.elasticjob.tracing.JobTracingEventBus;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TaskLaunchScheduledServiceTest {
     
     @Mock
@@ -74,14 +74,14 @@ public final class TaskLaunchScheduledServiceTest {
     
     private TaskLaunchScheduledService taskLaunchScheduledService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         when(facadeService.loadAppConfig("test_app")).thenReturn(Optional.of(CloudAppConfigurationBuilder.createCloudAppConfiguration("test_app")));
         taskLaunchScheduledService = new TaskLaunchScheduledService(schedulerDriver, taskScheduler, facadeService, jobTracingEventBus);
         taskLaunchScheduledService.startUp();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         taskLaunchScheduledService.shutDown();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskLaunchScheduledServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/mesos/TaskLaunchScheduledServiceTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,7 +77,7 @@ public final class TaskLaunchScheduledServiceTest {
     
     @BeforeEach
     public void setUp() {
-        when(facadeService.loadAppConfig("test_app")).thenReturn(Optional.of(CloudAppConfigurationBuilder.createCloudAppConfiguration("test_app")));
+        lenient().when(facadeService.loadAppConfig("test_app")).thenReturn(Optional.of(CloudAppConfigurationBuilder.createCloudAppConfiguration("test_app")));
         taskLaunchScheduledService = new TaskLaunchScheduledService(schedulerDriver, taskScheduler, facadeService, jobTracingEventBus);
         taskLaunchScheduledService.startUp();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerJobTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerJobTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.producer;
 
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.ready.ReadyService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobBuilder;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
@@ -30,7 +30,7 @@ import org.quartz.JobKey;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ProducerJobTest {
     
     @Mock
@@ -43,7 +43,7 @@ public final class ProducerJobTest {
     
     private TransientProducerScheduler.ProducerJob producerJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         producerJob = new TransientProducerScheduler.ProducerJob();
         producerJob.setRepository(repository);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerManagerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerManagerTest.java
@@ -36,9 +36,9 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationExce
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ProducerManagerTest {
     
     @Mock

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerManagerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/ProducerManagerTest.java
@@ -22,10 +22,10 @@ import org.apache.mesos.SchedulerDriver;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.config.CloudJobExecutionType;
 import org.apache.shardingsphere.elasticjob.cloud.config.pojo.CloudJobConfigurationPOJO;
-import org.apache.shardingsphere.elasticjob.cloud.scheduler.exception.AppConfigurationException;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app.CloudAppConfigurationService;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.app.pojo.CloudAppConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.config.job.CloudJobConfigurationService;
+import org.apache.shardingsphere.elasticjob.cloud.scheduler.exception.AppConfigurationException;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudAppConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.job.DisableJobService;
@@ -34,8 +34,8 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.running.Runnin
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -84,7 +85,7 @@ public final class ProducerManagerTest {
     
     private final CloudJobConfigurationPOJO daemonJobConfig = CloudJobConfigurationBuilder.createCloudJobConfiguration("daemon_test_job", CloudJobExecutionType.DAEMON);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         producerManager = new ProducerManager(schedulerDriver, regCenter);
         ReflectionUtils.setFieldValue(producerManager, "appConfigService", appConfigService);
@@ -104,23 +105,29 @@ public final class ProducerManagerTest {
         verify(readyService).addDaemon("daemon_test_job");
     }
 
-    @Test(expected = AppConfigurationException.class)
+    @Test
     public void assertRegisterJobWithoutApp() {
-        when(appConfigService.load("test_app")).thenReturn(Optional.empty());
-        producerManager.register(transientJobConfig);
+        assertThrows(AppConfigurationException.class, () -> {
+            when(appConfigService.load("test_app")).thenReturn(Optional.empty());
+            producerManager.register(transientJobConfig);
+        });
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertRegisterExistedJob() {
-        when(appConfigService.load("test_app")).thenReturn(Optional.of(appConfig));
-        when(configService.load("transient_test_job")).thenReturn(Optional.of(transientJobConfig));
-        producerManager.register(transientJobConfig);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(appConfigService.load("test_app")).thenReturn(Optional.of(appConfig));
+            when(configService.load("transient_test_job")).thenReturn(Optional.of(transientJobConfig));
+            producerManager.register(transientJobConfig);
+        });
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertRegisterDisabledJob() {
-        when(disableJobService.isDisabled("transient_test_job")).thenReturn(true);
-        producerManager.register(transientJobConfig);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(disableJobService.isDisabled("transient_test_job")).thenReturn(true);
+            producerManager.register(transientJobConfig);
+        });
     }
     
     @Test
@@ -141,10 +148,12 @@ public final class ProducerManagerTest {
         verify(readyService).addDaemon("daemon_test_job");
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertUpdateNotExisted() {
-        when(configService.load("transient_test_job")).thenReturn(Optional.empty());
-        producerManager.update(transientJobConfig);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(configService.load("transient_test_job")).thenReturn(Optional.empty());
+            producerManager.update(transientJobConfig);
+        });
     }
     
     @Test

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/TransientProducerRepositoryTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/TransientProducerRepositoryTest.java
@@ -17,17 +17,17 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.producer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobKey;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TransientProducerRepositoryTest {
     
     private final JobKey jobKey = JobKey.jobKey("0/45 * * * * ?");

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/TransientProducerSchedulerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/producer/TransientProducerSchedulerTest.java
@@ -21,11 +21,11 @@ import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.config.pojo.CloudJobConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConfigurationBuilder;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.ready.ReadyService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -38,7 +38,7 @@ import org.quartz.TriggerKey;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TransientProducerSchedulerTest {
     
     @Mock
@@ -57,7 +57,7 @@ public final class TransientProducerSchedulerTest {
                         .withSchedule(CronScheduleBuilder.cronSchedule(cloudJobConfig.getCron())
                         .withMisfireHandlingInstructionDoNothing()).build();
     
-    @Before
+    @BeforeEach
     public void setUp() {
         transientProducerScheduler = new TransientProducerScheduler(readyService);
         ReflectionUtils.setFieldValue(transientProducerScheduler, "scheduler", scheduler);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/CloudAppDisableListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/CloudAppDisableListenerTest.java
@@ -26,18 +26,18 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.EmbedTesting
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.producer.ProducerManager;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudAppDisableListenerTest {
     
     private static ZookeeperRegistryCenter regCenter;
@@ -51,7 +51,7 @@ public final class CloudAppDisableListenerTest {
     @InjectMocks
     private CloudAppDisableListener cloudAppDisableListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(cloudAppDisableListener, "producerManager", producerManager);
         initRegistryCenter();

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/DisableAppNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/DisableAppNodeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.app;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/DisableAppServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/app/DisableAppServiceTest.java
@@ -18,18 +18,18 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.app;
 
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DisableAppServiceTest {
     
     @Mock
@@ -37,7 +37,7 @@ public final class DisableAppServiceTest {
     
     private DisableAppService disableAppService;
         
-    @Before
+    @BeforeEach
     public void setUp() {
         disableAppService = new DisableAppService(regCenter);
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/CloudJobDisableListenerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/CloudJobDisableListenerTest.java
@@ -25,19 +25,19 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.EmbedTesting
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.producer.ProducerManager;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CloudJobDisableListenerTest {
     
     private static ZookeeperRegistryCenter regCenter;
@@ -48,7 +48,7 @@ public final class CloudJobDisableListenerTest {
     @InjectMocks
     private CloudJobDisableListener cloudJobDisableListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(cloudJobDisableListener, "producerManager", producerManager);
         initRegistryCenter();

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/DisableJobNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/DisableJobNodeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.job;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/DisableJobServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/disable/job/DisableJobServiceTest.java
@@ -18,18 +18,18 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.disable.job;
 
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DisableJobServiceTest {
     
     @Mock
@@ -37,7 +37,7 @@ public final class DisableJobServiceTest {
     
     private DisableJobService disableJobService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         disableJobService = new DisableJobService(regCenter);
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/failover/FailoverNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/failover/FailoverNodeTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.failover;
 
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.TaskNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/failover/FailoverServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/failover/FailoverServiceTest.java
@@ -28,11 +28,11 @@ import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext.MetaInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,12 +43,12 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class FailoverServiceTest {
     
     @Mock
@@ -62,7 +62,7 @@ public final class FailoverServiceTest {
     
     private FailoverService failoverService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         failoverService = new FailoverService(regCenter);
         ReflectionUtils.setFieldValue(failoverService, "configService", configService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/ready/ReadyNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/ready/ReadyNodeTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.ready;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/ready/ReadyServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/ready/ReadyServiceTest.java
@@ -26,12 +26,12 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.CloudJobConf
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.running.RunningService;
 import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,13 +40,13 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ReadyServiceTest {
     
     @Mock
@@ -60,7 +60,7 @@ public final class ReadyServiceTest {
     
     private ReadyService readyService;
         
-    @Before
+    @BeforeEach
     public void setUp() {
         readyService = new ReadyService(regCenter);
         ReflectionUtils.setFieldValue(readyService, "configService", configService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/running/RunningNodeTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/running/RunningNodeTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.state.running;
 
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.TaskNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/running/RunningServiceTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/state/running/RunningServiceTest.java
@@ -24,26 +24,26 @@ import org.apache.shardingsphere.elasticjob.infra.context.ExecutionType;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext.MetaInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class RunningServiceTest {
     
     private TaskContext taskContext;
@@ -55,7 +55,7 @@ public final class RunningServiceTest {
     
     private RunningService runningService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         when(regCenter.get("/config/job/test_job")).thenReturn(CloudJsonConstants.getJobJson(CloudJobExecutionType.DAEMON));
         when(regCenter.get("/config/job/test_job_t")).thenReturn(CloudJsonConstants.getJobJson("test_job_t"));
@@ -71,7 +71,7 @@ public final class RunningServiceTest {
         verify(regCenter).persist(path, taskContext.getId());
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         runningService.clear();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/StatisticManagerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/StatisticManagerTest.java
@@ -28,12 +28,12 @@ import org.apache.shardingsphere.elasticjob.cloud.statistics.type.job.JobRunning
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskResultStatistics;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskRunningStatistics;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,14 +42,14 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class StatisticManagerTest {
     
     @Mock
@@ -66,12 +66,12 @@ public final class StatisticManagerTest {
     
     private StatisticManager statisticManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         statisticManager = StatisticManager.getInstance(regCenter, null);
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         statisticManager.shutdown();
         ReflectionUtils.setStaticFieldValue(StatisticManager.class, "instance", null);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/StatisticsSchedulerTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/StatisticsSchedulerTest.java
@@ -20,18 +20,18 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics;
 import org.apache.shardingsphere.elasticjob.cloud.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.job.StatisticJob;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.job.TestStatisticJob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StatisticsSchedulerTest {
     
     private StatisticsScheduler statisticsScheduler;
@@ -39,7 +39,7 @@ public class StatisticsSchedulerTest {
     @Mock
     private Scheduler scheduler;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         statisticsScheduler = new StatisticsScheduler();
         ReflectionUtils.setFieldValue(statisticsScheduler, "scheduler", scheduler);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/TaskResultMetaDataTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/TaskResultMetaDataTest.java
@@ -17,17 +17,17 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Before;
-import org.junit.Test;
 
 public class TaskResultMetaDataTest {
     
     private TaskResultMetaData metaData;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         metaData = new TaskResultMetaData();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/BaseStatisticJobTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/BaseStatisticJobTest.java
@@ -17,21 +17,21 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.job;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.util.StatisticTimeUtils;
+import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.util.StatisticTimeUtils;
-import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BaseStatisticJobTest {
     
     private TestStatisticJob testStatisticJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         testStatisticJob = new TestStatisticJob();
     }

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/JobRunningStatisticJobTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/JobRunningStatisticJobTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.job;
 
-import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture.TaskNode;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.state.running.RunningService;
 import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.util.StatisticTimeUtils;
@@ -25,12 +24,13 @@ import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.rdb.StatisticRdbRepository;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.job.JobRunningStatistics;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskRunningStatistics;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.shardingsphere.elasticjob.infra.context.TaskContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.Trigger;
 
 import java.util.Collections;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class JobRunningStatisticJobTest {
     
     @Mock
@@ -57,7 +57,7 @@ public class JobRunningStatisticJobTest {
     
     private JobRunningStatisticJob jobRunningStatisticJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobRunningStatisticJob = new JobRunningStatisticJob();
         jobRunningStatisticJob.setRunningService(runningService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/RegisteredJobStatisticJobTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/RegisteredJobStatisticJobTest.java
@@ -23,11 +23,11 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.util.Stat
 import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.rdb.StatisticRdbRepository;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.job.JobRegisterStatistics;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.Trigger;
 
 import java.util.Collections;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RegisteredJobStatisticJobTest {
     
     @Mock
@@ -51,7 +51,7 @@ public class RegisteredJobStatisticJobTest {
     
     private RegisteredJobStatisticJob registeredJobStatisticJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         registeredJobStatisticJob = new RegisteredJobStatisticJob();
         registeredJobStatisticJob.setConfigurationService(configurationService);

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/TaskResultStatisticJobTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/job/TaskResultStatisticJobTest.java
@@ -22,11 +22,11 @@ import org.apache.shardingsphere.elasticjob.cloud.scheduler.statistics.util.Stat
 import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.rdb.StatisticRdbRepository;
 import org.apache.shardingsphere.elasticjob.cloud.statistics.type.task.TaskResultStatistics;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.Trigger;
 
 import java.util.Optional;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TaskResultStatisticJobTest {
     
     private final StatisticInterval statisticInterval = StatisticInterval.MINUTE;
@@ -50,7 +50,7 @@ public class TaskResultStatisticJobTest {
     
     private TaskResultStatisticJob taskResultStatisticJob;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         taskResultStatisticJob = new TaskResultStatisticJob();
         sharedData = new TaskResultMetaData();

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/util/StatisticTimeUtilsTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/statistics/util/StatisticTimeUtilsTest.java
@@ -24,7 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.shardingsphere.elasticjob.cloud.statistics.StatisticInterval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatisticTimeUtilsTest {
     

--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/util/IOUtilsTest.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/util/IOUtilsTest.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerPropertiesValidatorTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerPropertiesValidatorTest.java
@@ -19,17 +19,18 @@ package org.apache.shardingsphere.elasticjob.error.handler.dingtalk;
 
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerPropertiesValidator;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class DingtalkJobErrorHandlerPropertiesValidatorTest {
     
-    @Before
+    @BeforeEach
     public void startup() {
         ElasticJobServiceLoader.registerTypedService(JobErrorHandlerPropertiesValidator.class);
     }
@@ -44,10 +45,12 @@ public final class DingtalkJobErrorHandlerPropertiesValidatorTest {
         actual.validate(properties);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test
     public void assertValidateWithPropsIsNull() {
-        DingtalkJobErrorHandlerPropertiesValidator actual = getValidator();
-        actual.validate(null);
+        assertThrows(NullPointerException.class, () -> {
+            DingtalkJobErrorHandlerPropertiesValidator actual = getValidator();
+            actual.validate(null);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerTest.java
@@ -26,10 +26,10 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationExce
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -49,7 +49,7 @@ public final class DingtalkJobErrorHandlerTest {
     private static List<LoggingEvent> appenderList;
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NettyRestfulServiceConfiguration config = new NettyRestfulServiceConfiguration(PORT);
         config.setHost(HOST);
@@ -61,12 +61,12 @@ public final class DingtalkJobErrorHandlerTest {
         appenderList = appender.list;
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         appenderList.clear();
     }
     
-    @AfterClass
+    @AfterAll
     public static void close() {
         if (null != restfulService) {
             restfulService.shutdown();

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/pom.xml
@@ -48,16 +48,7 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerPropertiesValidatorTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerPropertiesValidatorTest.java
@@ -19,17 +19,18 @@ package org.apache.shardingsphere.elasticjob.error.handler.email;
 
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerPropertiesValidator;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class EmailJobErrorHandlerPropertiesValidatorTest {
     
-    @Before
+    @BeforeEach
     public void startup() {
         ElasticJobServiceLoader.registerTypedService(JobErrorHandlerPropertiesValidator.class);
     }
@@ -48,10 +49,12 @@ public final class EmailJobErrorHandlerPropertiesValidatorTest {
         actual.validate(properties);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test
     public void assertValidateWithPropsIsNull() {
-        EmailJobErrorHandlerPropertiesValidator actual = getValidator();
-        actual.validate(null);
+        assertThrows(NullPointerException.class, () -> {
+            EmailJobErrorHandlerPropertiesValidator actual = getValidator();
+            actual.validate(null);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-email/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/email/EmailJobErrorHandlerTest.java
@@ -23,12 +23,12 @@ import ch.qos.logback.core.read.ListAppender;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerFactory;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
 import javax.mail.Address;
@@ -45,7 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class EmailJobErrorHandlerTest {
     
     private static List<LoggingEvent> appenderList;
@@ -57,14 +57,14 @@ public final class EmailJobErrorHandlerTest {
     private Transport transport;
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         ch.qos.logback.classic.Logger log = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(EmailJobErrorHandler.class);
         ListAppender<LoggingEvent> appender = (ListAppender) log.getAppender("EmailJobErrorHandlerTestAppender");
         appenderList = appender.list;
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         appenderList.clear();
     }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/pom.xml
@@ -46,16 +46,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
     
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactoryTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerFactoryTest.java
@@ -20,12 +20,13 @@ package org.apache.shardingsphere.elasticjob.error.handler;
 import org.apache.shardingsphere.elasticjob.error.handler.general.LogJobErrorHandler;
 import org.apache.shardingsphere.elasticjob.error.handler.general.ThrowJobErrorHandler;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class JobErrorHandlerFactoryTest {
     
@@ -34,9 +35,10 @@ public final class JobErrorHandlerFactoryTest {
         assertThat(JobErrorHandlerFactory.createHandler("", new Properties()).orElse(null), instanceOf(LogJobErrorHandler.class));
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertGetInvalidHandler() {
-        JobErrorHandlerFactory.createHandler("INVALID", new Properties()).orElseThrow(() -> new JobConfigurationException(""));
+        assertThrows(JobConfigurationException.class, () ->
+                JobErrorHandlerFactory.createHandler("INVALID", new Properties()).orElseThrow(() -> new JobConfigurationException("")));
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/JobErrorHandlerReloadableTest.java
@@ -21,23 +21,23 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.error.handler.general.IgnoreJobErrorHandler;
 import org.apache.shardingsphere.elasticjob.error.handler.general.LogJobErrorHandler;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobErrorHandlerReloadableTest {
     
     @Mock

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/IgnoreJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/IgnoreJobErrorHandlerTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.error.handler.general;
 
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerFactory;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/LogJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/LogJobErrorHandlerTest.java
@@ -22,9 +22,9 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerFactory;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -38,14 +38,14 @@ public final class LogJobErrorHandlerTest {
     private static List<LoggingEvent> appenderList;
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @BeforeClass
+    @BeforeAll
     public static void setupLogger() {
         ch.qos.logback.classic.Logger log = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(LogJobErrorHandler.class);
         ListAppender<LoggingEvent> appender = (ListAppender) log.getAppender("LogJobErrorHandlerTestAppender");
         appenderList = appender.list;
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         appenderList.clear();
     }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/ThrowJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-general/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/general/ThrowJobErrorHandlerTest.java
@@ -20,15 +20,18 @@ package org.apache.shardingsphere.elasticjob.error.handler.general;
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerFactory;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class ThrowJobErrorHandlerTest {
-    
-    @Test(expected = JobSystemException.class)
+
+    @Test
     public void assertHandleException() {
-        JobErrorHandlerFactory.createHandler("THROW", new Properties()).orElseThrow(
-            () -> new JobConfigurationException("THROW error handler not found.")).handleException("test_job", new RuntimeException("test"));
+        assertThrows(JobSystemException.class, () ->
+                JobErrorHandlerFactory.createHandler("THROW", new Properties()).orElseThrow(() ->
+                        new JobConfigurationException("THROW error handler not found.")).handleException("test_job", new RuntimeException("test")));
     }
 }

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerPropertiesValidatorTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerPropertiesValidatorTest.java
@@ -19,17 +19,18 @@ package org.apache.shardingsphere.elasticjob.error.handler.wechat;
 
 import org.apache.shardingsphere.elasticjob.error.handler.JobErrorHandlerPropertiesValidator;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class WechatJobErrorHandlerPropertiesValidatorTest {
     
-    @Before
+    @BeforeEach
     public void startup() {
         ElasticJobServiceLoader.registerTypedService(JobErrorHandlerPropertiesValidator.class);
     }
@@ -44,10 +45,12 @@ public final class WechatJobErrorHandlerPropertiesValidatorTest {
         actual.validate(properties);
     }
     
-    @Test(expected = NullPointerException.class)
+    @Test
     public void assertValidateWithPropsIsNull() {
-        WechatJobErrorHandlerPropertiesValidator actual = getValidator();
-        actual.validate(null);
+        assertThrows(NullPointerException.class, () -> {
+            WechatJobErrorHandlerPropertiesValidator actual = getValidator();
+            actual.validate(null);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
+++ b/elasticjob-ecosystem/elasticjob-error-handler/elasticjob-error-handler-type/elasticjob-error-handler-wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
@@ -26,10 +26,10 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationExce
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -49,7 +49,7 @@ public final class WechatJobErrorHandlerTest {
     private static List<LoggingEvent> appenderList;
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
         configuration.setHost(HOST);
@@ -61,12 +61,12 @@ public final class WechatJobErrorHandlerTest {
         appenderList = appender.list;
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         appenderList.clear();
     }
     
-    @AfterClass
+    @AfterAll
     public static void close() {
         if (null != restfulService) {
             restfulService.shutdown();

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/pom.xml
@@ -52,15 +52,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
         
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -242,7 +243,7 @@ public final class ElasticJobExecutorTest {
     private void prepareForIsNotMisfire(final JobFacade jobFacade, final ShardingContexts shardingContexts) {
         when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
         when(jobFacade.misfireIfRunning(shardingContexts.getShardingItemParameters().keySet())).thenReturn(false);
-        when(jobFacade.isExecuteMisfired(shardingContexts.getShardingItemParameters().keySet())).thenReturn(false);
+        lenient().when(jobFacade.isExecuteMisfired(shardingContexts.getShardingItemParameters().keySet())).thenReturn(false);
     }
     
     private void verifyForIsNotMisfire(final JobFacade jobFacade, final ShardingContexts shardingContexts) {

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/ElasticJobExecutorTest.java
@@ -25,17 +25,18 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobExecutionEnvironm
 import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.State;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ElasticJobExecutorTest {
     
     @Mock
@@ -60,7 +61,7 @@ public final class ElasticJobExecutorTest {
     
     private ElasticJobExecutor elasticJobExecutor;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobConfig = createJobConfiguration();
         when(jobFacade.loadJobConfiguration(anyBoolean())).thenReturn(jobConfig);
@@ -80,14 +81,16 @@ public final class ElasticJobExecutorTest {
         field.set(elasticJobExecutor, jobItemExecutor);
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertExecuteWhenCheckMaxTimeDiffSecondsIntolerable() throws JobExecutionEnvironmentException {
-        doThrow(JobExecutionEnvironmentException.class).when(jobFacade).checkJobExecutionEnvironment();
-        try {
-            elasticJobExecutor.execute();
-        } finally {
-            verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
-        }
+    @Test
+    public void assertExecuteWhenCheckMaxTimeDiffSecondsIntolerable() {
+        assertThrows(JobSystemException.class, () -> {
+            doThrow(JobExecutionEnvironmentException.class).when(jobFacade).checkJobExecutionEnvironment();
+            try {
+                elasticJobExecutor.execute();
+            } finally {
+                verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
+            }
+        });
     }
     
     @Test
@@ -111,10 +114,10 @@ public final class ElasticJobExecutorTest {
         verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, "Sharding item for job 'test_job' is empty.");
         verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
     }
-    
-    @Test(expected = JobSystemException.class)
+
+    @Test
     public void assertExecuteFailureWhenThrowExceptionForSingleShardingItem() {
-        assertExecuteFailureWhenThrowException(createSingleShardingContexts());
+        assertThrows(JobSystemException.class, () -> assertExecuteFailureWhenThrowException(createSingleShardingContexts()));
     }
     
     @Test
@@ -195,28 +198,32 @@ public final class ElasticJobExecutorTest {
         verify(jobFacade, times(2)).registerJobCompleted(shardingContexts);
     }
     
-    @Test(expected = JobSystemException.class)
+    @Test
     public void assertBeforeJobExecutedFailure() {
-        ShardingContexts shardingContexts = createMultipleShardingContexts();
-        when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
-        doThrow(RuntimeException.class).when(jobFacade).beforeJobExecuted(shardingContexts);
-        try {
-            elasticJobExecutor.execute();
-        } finally {
-            verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
-        }
+        assertThrows(JobSystemException.class, () -> {
+            ShardingContexts shardingContexts = createMultipleShardingContexts();
+            when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
+            doThrow(RuntimeException.class).when(jobFacade).beforeJobExecuted(shardingContexts);
+            try {
+                elasticJobExecutor.execute();
+            } finally {
+                verify(jobItemExecutor, times(0)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
+            }
+        });
     }
     
-    @Test(expected = JobSystemException.class)
+    @Test
     public void assertAfterJobExecutedFailure() {
-        ShardingContexts shardingContexts = createMultipleShardingContexts();
-        when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
-        doThrow(RuntimeException.class).when(jobFacade).afterJobExecuted(shardingContexts);
-        try {
-            elasticJobExecutor.execute();
-        } finally {
-            verify(jobItemExecutor, times(2)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
-        }
+        assertThrows(JobSystemException.class, () -> {
+            ShardingContexts shardingContexts = createMultipleShardingContexts();
+            when(jobFacade.getShardingContexts()).thenReturn(shardingContexts);
+            doThrow(RuntimeException.class).when(jobFacade).afterJobExecuted(shardingContexts);
+            try {
+                elasticJobExecutor.execute();
+            } finally {
+                verify(jobItemExecutor, times(2)).process(eq(fooJob), eq(jobConfig), eq(jobFacade), any());
+            }
+        });
     }
     
     private ShardingContexts createSingleShardingContexts() {

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/item/JobItemExecutorFactoryTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-kernel/src/test/java/org/apache/shardingsphere/elasticjob/executor/item/JobItemExecutorFactoryTest.java
@@ -23,16 +23,18 @@ import org.apache.shardingsphere.elasticjob.executor.fixture.job.DetailedFooJob;
 import org.apache.shardingsphere.elasticjob.executor.fixture.job.FailedJob;
 import org.apache.shardingsphere.elasticjob.executor.fixture.job.FooJob;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class JobItemExecutorFactoryTest {
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertGetExecutorByClassFailureWithInvalidType() {
-        JobItemExecutorFactory.getExecutor(FailedJob.class);
+        assertThrows(JobConfigurationException.class, () ->
+                JobItemExecutorFactory.getExecutor(FailedJob.class));
     }
     
     @Test
@@ -45,9 +47,10 @@ public final class JobItemExecutorFactoryTest {
         assertThat(JobItemExecutorFactory.getExecutor(DetailedFooJob.class), instanceOf(ClassedFooJobExecutor.class));
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertGetExecutorByTypeFailureWithInvalidType() {
-        JobItemExecutorFactory.getExecutor("FAIL");
+        assertThrows(JobConfigurationException.class, () ->
+                JobItemExecutorFactory.getExecutor("FAIL"));
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/src/test/java/org/apache/shardingsphere/elasticjob/dataflow/executor/DataflowJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-dataflow-executor/src/test/java/org/apache/shardingsphere/elasticjob/dataflow/executor/DataflowJobExecutorTest.java
@@ -22,11 +22,11 @@ import org.apache.shardingsphere.elasticjob.api.ShardingContext;
 import org.apache.shardingsphere.elasticjob.dataflow.job.DataflowJob;
 import org.apache.shardingsphere.elasticjob.dataflow.props.DataflowJobProperties;
 import org.apache.shardingsphere.elasticjob.executor.JobFacade;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DataflowJobExecutorTest {
     
     private DataflowJobExecutor jobExecutor;
@@ -58,7 +58,7 @@ public final class DataflowJobExecutorTest {
     @Mock
     private Properties properties;
     
-    @Before
+    @BeforeEach
     public void createJobExecutor() {
         jobExecutor = new DataflowJobExecutor();
     }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/HttpJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/HttpJobExecutorTest.java
@@ -28,21 +28,22 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobExecutionExceptio
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class HttpJobExecutorTest {
     
     private static final int PORT = 9876;
@@ -68,7 +69,7 @@ public final class HttpJobExecutorTest {
     
     private HttpJobExecutor jobExecutor;
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
         configuration.setHost(HOST);
@@ -77,30 +78,34 @@ public final class HttpJobExecutorTest {
         restfulService.startup();
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         when(jobConfig.getProps()).thenReturn(properties);
         jobExecutor = new HttpJobExecutor();
     }
     
-    @AfterClass
+    @AfterAll
     public static void close() {
         if (null != restfulService) {
             restfulService.shutdown();
         }
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertUrlEmpty() {
-        when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn("");
-        jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn("");
+            jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        });
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertMethodEmpty() {
-        when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn(getRequestUri("/getName"));
-        when(jobConfig.getProps().getProperty(HttpJobProperties.METHOD_KEY)).thenReturn("");
-        jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn(getRequestUri("/getName"));
+            when(jobConfig.getProps().getProperty(HttpJobProperties.METHOD_KEY)).thenReturn("");
+            jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        });
     }
     
     @Test
@@ -143,14 +148,16 @@ public final class HttpJobExecutorTest {
         jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
     }
     
-    @Test(expected = JobExecutionException.class)
+    @Test
     public void assertProcessWithIOException() {
-        when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn(getRequestUri("/postWithTimeout"));
-        when(jobConfig.getProps().getProperty(HttpJobProperties.METHOD_KEY)).thenReturn("POST");
-        when(jobConfig.getProps().getProperty(HttpJobProperties.DATA_KEY)).thenReturn("name=elasticjob");
-        when(jobConfig.getProps().getProperty(HttpJobProperties.CONNECT_TIMEOUT_KEY, "3000")).thenReturn("1");
-        when(jobConfig.getProps().getProperty(HttpJobProperties.READ_TIMEOUT_KEY, "5000")).thenReturn("1");
-        jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        assertThrows(JobExecutionException.class, () -> {
+            when(jobConfig.getProps().getProperty(HttpJobProperties.URI_KEY)).thenReturn(getRequestUri("/postWithTimeout"));
+            when(jobConfig.getProps().getProperty(HttpJobProperties.METHOD_KEY)).thenReturn("POST");
+            when(jobConfig.getProps().getProperty(HttpJobProperties.DATA_KEY)).thenReturn("name=elasticjob");
+            when(jobConfig.getProps().getProperty(HttpJobProperties.CONNECT_TIMEOUT_KEY, "3000")).thenReturn("1");
+            when(jobConfig.getProps().getProperty(HttpJobProperties.READ_TIMEOUT_KEY, "5000")).thenReturn("1");
+            jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/HttpJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-http-executor/src/test/java/org/apache/shardingsphere/elasticjob/http/executor/HttpJobExecutorTest.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -60,8 +61,9 @@ public final class HttpJobExecutorTest {
     
     @Mock
     private JobFacade jobFacade;
-    
-    @Mock
+
+    // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private Properties properties;
     
     @Mock
@@ -80,7 +82,7 @@ public final class HttpJobExecutorTest {
     
     @BeforeEach
     public void setUp() {
-        when(jobConfig.getProps()).thenReturn(properties);
+        lenient().when(jobConfig.getProps()).thenReturn(properties);
         jobExecutor = new HttpJobExecutor();
     }
     

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/src/test/java/org/apache/shardingsphere/elasticjob/script/ScriptJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-script-executor/src/test/java/org/apache/shardingsphere/elasticjob/script/ScriptJobExecutorTest.java
@@ -26,19 +26,20 @@ import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationExce
 import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor;
 import org.apache.shardingsphere.elasticjob.script.props.ScriptJobProperties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ScriptJobExecutorTest {
     
     @Mock
@@ -58,22 +59,26 @@ public final class ScriptJobExecutorTest {
     
     private ScriptJobExecutor jobExecutor;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobExecutor = new ScriptJobExecutor();
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertProcessWithJobConfigurationException() {
-        when(jobConfig.getProps()).thenReturn(properties);
-        jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        assertThrows(JobConfigurationException.class, () -> {
+            when(jobConfig.getProps()).thenReturn(properties);
+            jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        });
     }
     
-    @Test(expected = JobSystemException.class)
+    @Test
     public void assertProcessWithJobSystemException() {
-        when(jobConfig.getProps()).thenReturn(properties);
-        when(properties.getProperty(ScriptJobProperties.SCRIPT_KEY)).thenReturn("demo.sh");
-        jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        assertThrows(JobSystemException.class, () -> {
+            when(jobConfig.getProps()).thenReturn(properties);
+            when(properties.getProperty(ScriptJobProperties.SCRIPT_KEY)).thenReturn("demo.sh");
+            jobExecutor.process(elasticJob, jobConfig, jobFacade, shardingContext);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/src/test/java/org/apache/shardingsphere/elasticjob/simple/executor/SimpleJobExecutorTest.java
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/elasticjob-simple-executor/src/test/java/org/apache/shardingsphere/elasticjob/simple/executor/SimpleJobExecutorTest.java
@@ -21,11 +21,11 @@ import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.executor.JobFacade;
 import org.apache.shardingsphere.elasticjob.simple.job.FooSimpleJob;
 import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SimpleJobExecutorTest {
     
     @Mock
@@ -47,7 +47,7 @@ public final class SimpleJobExecutorTest {
     
     private SimpleJobExecutor jobExecutor;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobExecutor = new SimpleJobExecutor();
     }

--- a/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-executor/elasticjob-executor-type/pom.xml
@@ -39,13 +39,5 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/pom.xml
@@ -58,14 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/JobTracingEventBusTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/JobTracingEventBusTest.java
@@ -24,11 +24,11 @@ import org.apache.shardingsphere.elasticjob.tracing.event.JobEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
 import org.apache.shardingsphere.elasticjob.tracing.fixture.JobEventCaller;
 import org.apache.shardingsphere.elasticjob.tracing.fixture.TestTracingListener;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobTracingEventBusTest {
     
     @Mock

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEventTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/event/JobExecutionEventTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.shardingsphere.elasticjob.tracing.event;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class JobExecutionEventTest {
     

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/listener/TracingListenerFactoryTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/listener/TracingListenerFactoryTest.java
@@ -21,21 +21,24 @@ import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.apache.shardingsphere.elasticjob.tracing.exception.TracingConfigurationException;
 import org.apache.shardingsphere.elasticjob.tracing.fixture.JobEventCallerConfiguration;
 import org.apache.shardingsphere.elasticjob.tracing.fixture.TestTracingListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class TracingListenerFactoryTest {
     
-    @Test(expected = TracingConfigurationException.class)
-    public void assertGetListenerWithNullType() throws TracingConfigurationException {
-        TracingListenerFactory.getListener(new TracingConfiguration<>("", null));
+    @Test
+    public void assertGetListenerWithNullType() {
+        assertThrows(TracingConfigurationException.class, () ->
+                TracingListenerFactory.getListener(new TracingConfiguration<>("", null)));
     }
-    
-    @Test(expected = TracingConfigurationException.class)
-    public void assertGetInvalidListener() throws TracingConfigurationException {
-        TracingListenerFactory.getListener(new TracingConfiguration<>("INVALID", null));
+
+    @Test
+    public void assertGetInvalidListener() {
+        assertThrows(TracingConfigurationException.class, () ->
+                TracingListenerFactory.getListener(new TracingConfiguration<>("INVALID", null)));
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/storage/TracingStorageConverterFactoryTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/storage/TracingStorageConverterFactoryTest.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.elasticjob.tracing.storage;
 
 import org.apache.shardingsphere.elasticjob.tracing.fixture.JobEventCaller;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class TracingStorageConverterFactoryTest {
     

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/yaml/YamlTracingConfigurationConverterTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-api/src/test/java/org/apache/shardingsphere/elasticjob/tracing/yaml/YamlTracingConfigurationConverterTest.java
@@ -19,12 +19,12 @@ package org.apache.shardingsphere.elasticjob.tracing.yaml;
 
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.apache.shardingsphere.elasticjob.tracing.fixture.JobEventCaller;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class YamlTracingConfigurationConverterTest {
     

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/pom.xml
@@ -39,14 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceConfigurationTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceConfigurationTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.tracing.rdb.datasource;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -31,9 +31,9 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class DataSourceConfigurationTest {
     

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceRegistryTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceRegistryTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.elasticjob.tracing.rdb.datasource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.sql.DataSource;
 
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DataSourceRegistryTest {
     
     @Mock

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceTracingStorageConverterTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/datasource/DataSourceTracingStorageConverterTest.java
@@ -22,10 +22,10 @@ import org.apache.shardingsphere.elasticjob.tracing.api.TracingStorageConfigurat
 import org.apache.shardingsphere.elasticjob.tracing.exception.TracingStorageUnavailableException;
 import org.apache.shardingsphere.elasticjob.tracing.storage.TracingStorageConverter;
 import org.apache.shardingsphere.elasticjob.tracing.storage.TracingStorageConverterFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -33,12 +33,13 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DataSourceTracingStorageConverterTest {
     
     @Mock
@@ -60,11 +61,13 @@ public final class DataSourceTracingStorageConverterTest {
         assertNotNull(configuration);
     }
     
-    @Test(expected = TracingStorageUnavailableException.class)
-    public void assertConvertFailed() throws SQLException {
-        DataSourceTracingStorageConverter converter = new DataSourceTracingStorageConverter();
-        doThrow(SQLException.class).when(dataSource).getConnection();
-        converter.convertObjectToConfiguration(dataSource);
+    @Test
+    public void assertConvertFailed() {
+        assertThrows(TracingStorageUnavailableException.class, () -> {
+            DataSourceTracingStorageConverter converter = new DataSourceTracingStorageConverter();
+            doThrow(SQLException.class).when(dataSource).getConnection();
+            converter.convertObjectToConfiguration(dataSource);
+        });
     }
     
     @Test

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerConfigurationTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerConfigurationTest.java
@@ -19,10 +19,11 @@ package org.apache.shardingsphere.elasticjob.tracing.rdb.listener;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.shardingsphere.elasticjob.tracing.exception.TracingConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class RDBTracingListenerConfigurationTest {
     
@@ -36,8 +37,9 @@ public final class RDBTracingListenerConfigurationTest {
         assertThat(new RDBTracingListenerConfiguration().createTracingListener(dataSource), instanceOf(RDBTracingListener.class));
     }
     
-    @Test(expected = TracingConfigurationException.class)
-    public void assertCreateTracingListenerFailure() throws TracingConfigurationException {
-        new RDBTracingListenerConfiguration().createTracingListener(new BasicDataSource());
+    @Test
+    public void assertCreateTracingListenerFailure() {
+        assertThrows(TracingConfigurationException.class, () ->
+                new RDBTracingListenerConfiguration().createTracingListener(new BasicDataSource()));
     }
 }

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/listener/RDBTracingListenerTest.java
@@ -26,11 +26,11 @@ import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.Source;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.State;
 import org.apache.shardingsphere.elasticjob.tracing.rdb.storage.RDBJobEventStorage;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
@@ -39,7 +39,7 @@ import java.sql.SQLException;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class RDBTracingListenerTest {
     
     private static final String JOB_NAME = "test_rdb_event_listener";
@@ -49,7 +49,7 @@ public final class RDBTracingListenerTest {
     
     private JobTracingEventBus jobTracingEventBus;
     
-    @Before
+    @BeforeEach
     public void setUp() throws SQLException {
         BasicDataSource dataSource = new BasicDataSource();
         dataSource.setDriverClassName(org.h2.Driver.class.getName());

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/storage/RDBJobEventStorageTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/storage/RDBJobEventStorageTest.java
@@ -22,19 +22,19 @@ import org.apache.shardingsphere.elasticjob.tracing.event.JobExecutionEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.Source;
 import org.apache.shardingsphere.elasticjob.tracing.event.JobStatusTraceEvent.State;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RDBJobEventStorageTest {
     
@@ -42,7 +42,7 @@ public final class RDBJobEventStorageTest {
 
     private BasicDataSource dataSource;
     
-    @Before
+    @BeforeEach
     public void setup() throws SQLException {
         dataSource = new BasicDataSource();
         dataSource.setDriverClassName(org.h2.Driver.class.getName());
@@ -52,7 +52,7 @@ public final class RDBJobEventStorageTest {
         storage = RDBJobEventStorage.getInstance(dataSource);
     }
     
-    @After
+    @AfterEach
     public void teardown() throws SQLException {
         dataSource.close();
     }

--- a/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/yaml/YamlDataSourceConfigurationConverterTest.java
+++ b/elasticjob-ecosystem/elasticjob-tracing/elasticjob-tracing-rdb/src/test/java/org/apache/shardingsphere/elasticjob/tracing/rdb/yaml/YamlDataSourceConfigurationConverterTest.java
@@ -19,14 +19,14 @@ package org.apache.shardingsphere.elasticjob.tracing.rdb.yaml;
 
 import org.apache.shardingsphere.elasticjob.tracing.rdb.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.elasticjob.tracing.yaml.YamlTracingStorageConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class YamlDataSourceConfigurationConverterTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/pom.xml
+++ b/elasticjob-infra/elasticjob-infra-common/pom.xml
@@ -61,14 +61,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
@@ -18,15 +18,15 @@
 package org.apache.shardingsphere.elasticjob.infra.concurrent;
 
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ElasticJobExecutorServiceTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ElasticJobExecutorServiceTest.java
@@ -40,13 +40,13 @@ public final class ElasticJobExecutorServiceTest {
         assertFalse(executorServiceObject.isShutdown());
         ExecutorService executorService = executorServiceObject.createExecutorService();
         executorService.submit(new FooTask());
-        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
+        Awaitility.await().atLeast(1L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
             assertThat(executorServiceObject.getActiveThreadCount(), is(1));
             assertThat(executorServiceObject.getWorkQueueSize(), is(0));
             assertFalse(executorServiceObject.isShutdown());
         });
         executorService.submit(new FooTask());
-        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
+        Awaitility.await().atLeast(1L, TimeUnit.MILLISECONDS).atMost(5L, TimeUnit.MINUTES).untilAsserted(() -> {
             assertThat(executorServiceObject.getActiveThreadCount(), is(1));
             assertThat(executorServiceObject.getWorkQueueSize(), is(1));
             assertFalse(executorServiceObject.isShutdown());

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/concurrent/ExecutorServiceReloadableTest.java
@@ -19,22 +19,22 @@ package org.apache.shardingsphere.elasticjob.infra.concurrent;
 
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ExecutorServiceReloadableTest {
     
     @Mock

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/context/ShardingItemParametersTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/context/ShardingItemParametersTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.context;
 
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,17 +26,18 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ShardingItemParametersTest {
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertNewWhenPairFormatInvalid() {
-        new ShardingItemParameters("xxx-xxx");
+        assertThrows(JobConfigurationException.class, () -> new ShardingItemParameters("xxx-xxx"));
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertNewWhenItemIsNotNumber() {
-        new ShardingItemParameters("xxx=xxx");
+        assertThrows(JobConfigurationException.class, () -> new ShardingItemParameters("xxx=xxx"));
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/context/TaskContextTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/context/TaskContextTest.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.elasticjob.infra.context;
 
 import org.apache.shardingsphere.elasticjob.infra.context.TaskContext.MetaInfo;
 import org.apache.shardingsphere.elasticjob.infra.context.fixture.TaskNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class TaskContextTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/HostExceptionTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/HostExceptionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.env;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtilsTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/IpUtilsTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.env;
 
 import lombok.SneakyThrows;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -30,10 +30,10 @@ import java.util.List;
 import java.util.Vector;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/TimeServiceTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/env/TimeServiceTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.infra.env;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TimeServiceTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/ExceptionUtilsTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/ExceptionUtilsTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.elasticjob.infra.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ExceptionUtilsTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobConfigurationExceptionTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobConfigurationExceptionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobExecutionEnvironmentExceptionTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobExecutionEnvironmentExceptionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobStatisticExceptionTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobStatisticExceptionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobSystemExceptionTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/exception/JobSystemExceptionTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.exception;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobInstanceTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobInstanceTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.infra.handler.sharding;
 
 import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/JobShardingStrategyFactoryTest.java
@@ -20,10 +20,11 @@ package org.apache.shardingsphere.elasticjob.infra.handler.sharding;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.impl.AverageAllocationJobShardingStrategy;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.impl.OdevitySortByNameJobShardingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class JobShardingStrategyFactoryTest {
     
@@ -32,9 +33,10 @@ public final class JobShardingStrategyFactoryTest {
         assertThat(JobShardingStrategyFactory.getStrategy(null), instanceOf(AverageAllocationJobShardingStrategy.class));
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertGetInvalidStrategy() {
-        JobShardingStrategyFactory.getStrategy("INVALID");
+        assertThrows(JobConfigurationException.class, () ->
+                JobShardingStrategyFactory.getStrategy("INVALID"));
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/AverageAllocationJobShardingStrategyTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/AverageAllocationJobShardingStrategyTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.infra.handler.sharding.impl;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobShardingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/OdevitySortByNameJobShardingStrategyTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/OdevitySortByNameJobShardingStrategyTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.handler.sharding.impl;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RotateServerByNameJobShardingStrategyTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/sharding/impl/RotateServerByNameJobShardingStrategyTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.handler.sharding.impl;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/JobExecutorServiceHandlerFactoryTest.java
@@ -20,10 +20,11 @@ package org.apache.shardingsphere.elasticjob.infra.handler.threadpool;
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.impl.CPUUsageJobExecutorServiceHandler;
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.impl.SingleThreadJobExecutorServiceHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class JobExecutorServiceHandlerFactoryTest {
     
@@ -32,9 +33,10 @@ public final class JobExecutorServiceHandlerFactoryTest {
         assertThat(JobExecutorServiceHandlerFactory.getHandler(""), instanceOf(CPUUsageJobExecutorServiceHandler.class));
     }
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertGetInvalidHandler() {
-        JobExecutorServiceHandlerFactory.getHandler("INVALID");
+        assertThrows(JobConfigurationException.class, () ->
+                JobExecutorServiceHandlerFactory.getHandler("INVALID"));
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/impl/CPUUsageJobExecutorServiceHandlerTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/impl/CPUUsageJobExecutorServiceHandlerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.handler.threadpool.impl;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/impl/SingleThreadJobExecutorServiceHandlerTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/handler/threadpool/impl/SingleThreadJobExecutorServiceHandlerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.handler.threadpool.impl;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.threadpool.JobExecutorServiceHandlerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/json/GsonFactoryTest.java
@@ -22,11 +22,13 @@ import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class GsonFactoryTest {
     
@@ -66,10 +68,12 @@ public final class GsonFactoryTest {
         assertThat(GsonFactory.getJsonParser().parse(json).getAsJsonObject().get("name").getAsString(), is("test"));
     }
     
-    @Test(expected = JsonParseException.class)
+    @Test
     public void assertParserWithException() {
-        String json = "{\"name\":\"test\"";
-        assertThat(GsonFactory.getJsonParser().parse(json).getAsJsonObject().get("name").getAsString(), is("test"));
+        assertThrows(JsonParseException.class, () -> {
+            String json = "{\"name\":\"test\"";
+            assertThat(GsonFactory.getJsonParser().parse(json).getAsJsonObject().get("name").getAsString(), is("test"));
+        });
     }
 }
 

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/listener/ElasticJobListenerFactoryTest.java
@@ -19,16 +19,18 @@ package org.apache.shardingsphere.elasticjob.infra.listener;
 
 import org.apache.shardingsphere.elasticjob.infra.exception.JobConfigurationException;
 import org.apache.shardingsphere.elasticjob.infra.listener.fixture.FooElasticJobListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ElasticJobListenerFactoryTest {
     
-    @Test(expected = JobConfigurationException.class)
+    @Test
     public void assertCreateInvalidJobListener() {
-        ElasticJobListenerFactory.createListener("INVALID").orElseThrow(() -> new JobConfigurationException("Invalid elastic job listener!"));
+        assertThrows(JobConfigurationException.class, () ->
+                ElasticJobListenerFactory.createListener("INVALID").orElseThrow(() -> new JobConfigurationException("Invalid elastic job listener!")));
     }
     
     @Test

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/listener/ShardingContextsTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/listener/ShardingContextsTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.infra.listener;
 
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/pojo/JobConfigurationPOJOTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/pojo/JobConfigurationPOJOTest.java
@@ -19,16 +19,16 @@ package org.apache.shardingsphere.elasticjob.infra.pojo;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class JobConfigurationPOJOTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoaderTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/spi/ElasticJobServiceLoaderTest.java
@@ -19,8 +19,9 @@ package org.apache.shardingsphere.elasticjob.infra.spi;
 
 import org.apache.shardingsphere.elasticjob.infra.spi.fixture.TypedFooService;
 import org.apache.shardingsphere.elasticjob.infra.spi.fixture.UnRegisteredTypedFooService;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -29,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class ElasticJobServiceLoaderTest {
     
-    @BeforeClass
+    @BeforeAll
     public static void register() {
         ElasticJobServiceLoader.registerTypedService(TypedFooService.class);
     }
@@ -44,23 +45,27 @@ public final class ElasticJobServiceLoaderTest {
         assertThat(ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "typedFooServiceImpl").orElse(null), instanceOf(TypedFooService.class));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertGetCacheTypedServiceFailureWithUnRegisteredServiceInterface() {
-        ElasticJobServiceLoader.getCachedTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl").orElseThrow(IllegalArgumentException::new);
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                ElasticJobServiceLoader.getCachedTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl").orElseThrow(IllegalArgumentException::new));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertGetCacheTypedServiceFailureWithInvalidType() {
-        ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "INVALID").orElseThrow(IllegalArgumentException::new);
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                ElasticJobServiceLoader.getCachedTypedServiceInstance(TypedFooService.class, "INVALID").orElseThrow(IllegalArgumentException::new));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertNewTypedServiceInstanceFailureWithUnRegisteredServiceInterface() {
-        ElasticJobServiceLoader.newTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl", new Properties()).orElseThrow(IllegalArgumentException::new);
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                ElasticJobServiceLoader.newTypedServiceInstance(UnRegisteredTypedFooService.class, "unRegisteredTypedFooServiceImpl", new Properties()).orElseThrow(IllegalArgumentException::new));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertNewTypedServiceInstanceFailureWithInvalidType() {
-        ElasticJobServiceLoader.newTypedServiceInstance(TypedFooService.class, "INVALID", new Properties()).orElseThrow(IllegalArgumentException::new);
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                ElasticJobServiceLoader.newTypedServiceInstance(TypedFooService.class, "INVALID", new Properties()).orElseThrow(IllegalArgumentException::new));
     }
 }

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/validator/JobPropertiesValidateRuleTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/validator/JobPropertiesValidateRuleTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.infra.validator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/yaml/YamlEngineTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/yaml/YamlEngineTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.elasticjob.infra.yaml;
 
 import org.apache.shardingsphere.elasticjob.infra.yaml.fixture.FooYamlConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class YamlEngineTest {
     

--- a/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/yaml/config/YamlConfigurationConverterFactoryTest.java
+++ b/elasticjob-infra/elasticjob-infra-common/src/test/java/org/apache/shardingsphere/elasticjob/infra/yaml/config/YamlConfigurationConverterFactoryTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.infra.yaml.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public final class YamlConfigurationConverterFactoryTest {
     

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/pom.xml
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/pom.xml
@@ -36,14 +36,6 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/test/java/org/apache/shardingsphere/elasticjob/reg/base/transaction/TransactionOperationTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/test/java/org/apache/shardingsphere/elasticjob/reg/base/transaction/TransactionOperationTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.reg.base.transaction;
 
 import org.apache.shardingsphere.elasticjob.reg.base.transaction.TransactionOperation.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/test/java/org/apache/shardingsphere/elasticjob/reg/exception/RegExceptionHandlerTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-registry-center-api/src/test/java/org/apache/shardingsphere/elasticjob/reg/exception/RegExceptionHandlerTest.java
@@ -17,13 +17,15 @@
 
 package org.apache.shardingsphere.elasticjob.reg.exception;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class RegExceptionHandlerTest {
     
     @Test
-    @Ignore
+    @Disabled
     // TODO throw InterruptedException will cause zookeeper TestingServer break. Ignore first, fix it later.
     public void assertHandleExceptionWithInterruptedException() {
         RegExceptionHandler.handleException(new InterruptedException());
@@ -34,8 +36,8 @@ public final class RegExceptionHandlerTest {
         RegExceptionHandler.handleException(null);
     }
     
-    @Test(expected = RegException.class)
+    @Test
     public void assertHandleExceptionWithOtherException() {
-        RegExceptionHandler.handleException(new RuntimeException());
+        assertThrows(RegException.class, () -> RegExceptionHandler.handleException(new RuntimeException()));
     }
 }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/pom.xml
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/pom.xml
@@ -56,14 +56,6 @@
             <artifactId>curator-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfigurationTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfigurationTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperElectionServiceTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperElectionServiceTest.java
@@ -25,11 +25,11 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.KillSession;
 import org.apache.shardingsphere.elasticjob.reg.base.ElectionCandidate;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZookeeperElectionServiceTest {
     
     private static final String HOST_AND_PORT = "localhost:8899";
@@ -49,7 +49,7 @@ public class ZookeeperElectionServiceTest {
     @Mock
     private ElectionCandidate electionCandidate;
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
     }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterExecuteInLeaderTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterExecuteInLeaderTest.java
@@ -20,13 +20,15 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.reg.base.LeaderExecutionCallback;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class ZookeeperRegistryCenterExecuteInLeaderTest {
@@ -36,7 +38,7 @@ public final class ZookeeperRegistryCenterExecuteInLeaderTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
@@ -44,12 +46,13 @@ public final class ZookeeperRegistryCenterExecuteInLeaderTest {
         zkRegCenter.init();
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }
     
-    @Test(timeout = 10000L)
+    @Test
+    @Timeout(value = 10000L, unit = TimeUnit.MILLISECONDS)
     public void assertExecuteInLeader() throws InterruptedException {
         final int threads = 10;
         CountDownLatch countDownLatch = new CountDownLatch(threads);

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterForAuthTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterForAuthTest.java
@@ -23,12 +23,13 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
 import org.apache.zookeeper.KeeperException.NoAuthException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ZookeeperRegistryCenterForAuthTest {
     
@@ -38,7 +39,7 @@ public final class ZookeeperRegistryCenterForAuthTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIGURATION.setDigest("digest:password");
@@ -49,7 +50,7 @@ public final class ZookeeperRegistryCenterForAuthTest {
         ZookeeperRegistryCenterTestUtil.persist(zkRegCenter);
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }
@@ -65,11 +66,13 @@ public final class ZookeeperRegistryCenterForAuthTest {
         assertThat(client.getData().forPath("/" + ZookeeperRegistryCenterForAuthTest.class.getName() + "/test/deep/nested"), is("deepNested".getBytes()));
     }
     
-    @Test(expected = NoAuthException.class)
-    public void assertInitWithDigestFailure() throws Exception {
-        CuratorFramework client = CuratorFrameworkFactory.newClient(EmbedTestingServer.getConnectionString(), new RetryOneTime(2000));
-        client.start();
-        client.blockUntilConnected();
-        client.getData().forPath("/" + ZookeeperRegistryCenterForAuthTest.class.getName() + "/test/deep/nested");
+    @Test
+    public void assertInitWithDigestFailure() {
+        assertThrows(NoAuthException.class, () -> {
+            CuratorFramework client = CuratorFrameworkFactory.newClient(EmbedTestingServer.getConnectionString(), new RetryOneTime(2000));
+            client.start();
+            client.blockUntilConnected();
+            client.getData().forPath("/" + ZookeeperRegistryCenterForAuthTest.class.getName() + "/test/deep/nested");
+        });
     }
 }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterInitFailureTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterInitFailureTest.java
@@ -18,13 +18,17 @@
 package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
 import org.apache.shardingsphere.elasticjob.reg.exception.RegException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ZookeeperRegistryCenterInitFailureTest {
-    
-    @Test(expected = RegException.class)
+
+    @Test
     public void assertInitFailure() {
-        ZookeeperRegistryCenter zkRegCenter = new ZookeeperRegistryCenter(new ZookeeperConfiguration("localhost:1", ZookeeperRegistryCenterInitFailureTest.class.getName()));
-        zkRegCenter.init();
+        assertThrows(RegException.class, () -> {
+            ZookeeperRegistryCenter zkRegCenter = new ZookeeperRegistryCenter(new ZookeeperConfiguration("localhost:1", ZookeeperRegistryCenterInitFailureTest.class.getName()));
+            zkRegCenter.init();
+        });
     }
 }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterListenerTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterListenerTest.java
@@ -23,25 +23,25 @@ import org.apache.curator.framework.recipes.cache.CuratorCache;
 import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZookeeperRegistryCenterListenerTest {
 
     @Mock
@@ -63,7 +63,7 @@ public class ZookeeperRegistryCenterListenerTest {
 
     private final String jobPath = "/test_job";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         regCenter = new ZookeeperRegistryCenter(null);
         ZookeeperRegistryCenterTestUtil.setFieldValue(regCenter, "caches", caches);
@@ -79,7 +79,7 @@ public class ZookeeperRegistryCenterListenerTest {
     }
 
     @Test
-    public void testWatch() throws Exception {
+    public void testWatch() {
         when(caches.get(jobPath + "/")).thenReturn(cache);
         when(cache.listenable()).thenReturn(dataListenable);
         regCenter.watch(jobPath, null, null);
@@ -88,7 +88,7 @@ public class ZookeeperRegistryCenterListenerTest {
     }
 
     @Test
-    public void testRemoveDataListenersNonCache() throws Exception {
+    public void testRemoveDataListenersNonCache() {
         when(cache.listenable()).thenReturn(dataListenable);
         regCenter.removeDataListeners(jobPath);
         verify(cache.listenable(), never()).removeListener(any());
@@ -96,7 +96,7 @@ public class ZookeeperRegistryCenterListenerTest {
     }
 
     @Test
-    public void testRemoveDataListenersHasCache() throws Exception {
+    public void testRemoveDataListenersHasCache() {
         when(caches.get(jobPath + "/")).thenReturn(cache);
         when(cache.listenable()).thenReturn(dataListenable);
         List<CuratorCacheListener> list = new ArrayList<>();
@@ -118,7 +118,7 @@ public class ZookeeperRegistryCenterListenerTest {
     }
 
     @Test
-    public void testRemoveConnStateListener() throws Exception {
+    public void testRemoveConnStateListener() {
         when(client.getConnectionStateListenable()).thenReturn(connStateListenable);
         List<ConnectionStateListener> list = new ArrayList<>();
         list.add(null);

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
@@ -20,9 +20,9 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.CuratorCache;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -35,7 +35,7 @@ public final class ZookeeperRegistryCenterMiscellaneousTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
@@ -44,7 +44,7 @@ public final class ZookeeperRegistryCenterMiscellaneousTest {
         zkRegCenter.addCacheData("/test");
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
@@ -22,18 +22,18 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ZookeeperRegistryCenterModifyTest {
     
@@ -41,7 +41,7 @@ public final class ZookeeperRegistryCenterModifyTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
@@ -50,7 +50,7 @@ public final class ZookeeperRegistryCenterModifyTest {
         ZookeeperRegistryCenterTestUtil.persist(zkRegCenter);
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithCacheTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithCacheTest.java
@@ -19,13 +19,13 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class ZookeeperRegistryCenterQueryWithCacheTest {
     
@@ -34,7 +34,7 @@ public final class ZookeeperRegistryCenterQueryWithCacheTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
@@ -44,7 +44,7 @@ public final class ZookeeperRegistryCenterQueryWithCacheTest {
         zkRegCenter.addCacheData("/test");
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithoutCacheTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithoutCacheTest.java
@@ -19,18 +19,18 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ZookeeperRegistryCenterQueryWithoutCacheTest {
     
@@ -39,7 +39,7 @@ public final class ZookeeperRegistryCenterQueryWithoutCacheTest {
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
@@ -49,7 +49,7 @@ public final class ZookeeperRegistryCenterQueryWithoutCacheTest {
         zkRegCenter.addCacheData("/other");
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterTransactionTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterTransactionTest.java
@@ -21,37 +21,37 @@ import org.apache.shardingsphere.elasticjob.reg.base.transaction.TransactionOper
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
 import org.apache.zookeeper.KeeperException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public final class ZookeeperRegistryCenterTransactionTest {
-    
+
     private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
             new ZookeeperConfiguration(EmbedTestingServer.getConnectionString(), ZookeeperRegistryCenterTransactionTest.class.getName());
-    
+
     private static ZookeeperRegistryCenter zkRegCenter;
-    
-    @BeforeClass
+
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
         ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
     }
-    
-    @Before
+
+    @BeforeEach
     public void setup() {
         ZookeeperRegistryCenterTestUtil.persist(zkRegCenter);
     }
-    
+
     @Test
     public void assertExecuteInTransactionSucceeded() throws Exception {
         List<TransactionOperation> operations = new ArrayList<>(3);
@@ -62,7 +62,7 @@ public final class ZookeeperRegistryCenterTransactionTest {
         zkRegCenter.executeInTransaction(operations);
         assertThat(zkRegCenter.getDirectly("/test/transaction"), is("transaction"));
     }
-    
+
     @Test
     public void assertExecuteInTransactionFailed() throws Exception {
         List<TransactionOperation> operations = new ArrayList<>(3);

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterWatchTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterWatchTest.java
@@ -21,25 +21,27 @@ import org.apache.curator.utils.ThreadUtils;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.util.ZookeeperRegistryCenterTestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class ZookeeperRegistryCenterWatchTest {
-    
+
     private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EmbedTestingServer.getConnectionString(), ZookeeperRegistryCenterWatchTest.class.getName());
-    
+
     private static ZookeeperRegistryCenter zkRegCenter;
-    
-    @BeforeClass
+
+    @BeforeAll
     public static void setUp() {
         EmbedTestingServer.start();
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
@@ -47,13 +49,14 @@ public final class ZookeeperRegistryCenterWatchTest {
         zkRegCenter.init();
         ZookeeperRegistryCenterTestUtil.persist(zkRegCenter);
     }
-    
-    @AfterClass
+
+    @AfterAll
     public static void tearDown() {
         zkRegCenter.close();
     }
 
-    @Test(timeout = 10000L)
+    @Test
+    @Timeout(value = 10000L, unit = TimeUnit.MILLISECONDS)
     public void assertWatchWithoutExecutor() throws InterruptedException {
         CountDownLatch waitingForCountDownValue = new CountDownLatch(1);
         String key = "/test-watch-without-executor";
@@ -70,8 +73,9 @@ public final class ZookeeperRegistryCenterWatchTest {
         zkRegCenter.update(key, "countDown");
         waitingForCountDownValue.await();
     }
-    
-    @Test(timeout = 10000L)
+
+    @Test
+    @Timeout(value = 10000L, unit = TimeUnit.MILLISECONDS)
     public void assertWatchWithExecutor() throws InterruptedException {
         CountDownLatch waitingForCountDownValue = new CountDownLatch(1);
         String key = "/test-watch-with-executor";

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/exception/ZookeeperCuratorIgnoredExceptionProviderTest.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/exception/ZookeeperCuratorIgnoredExceptionProviderTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper.exception;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/elasticjob-infra/elasticjob-restful/pom.xml
+++ b/elasticjob-infra/elasticjob-restful/pom.xml
@@ -48,14 +48,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
         </dependency>

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexPathMatcherTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexPathMatcherTest.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.elasticjob.restful;
 
 import org.apache.shardingsphere.elasticjob.restful.mapping.PathMatcher;
 import org.apache.shardingsphere.elasticjob.restful.mapping.RegexPathMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RegexPathMatcherTest {
     

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexUrlPatternMapTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/RegexUrlPatternMapTest.java
@@ -19,12 +19,13 @@ package org.apache.shardingsphere.elasticjob.restful;
 
 import org.apache.shardingsphere.elasticjob.restful.mapping.MappingContext;
 import org.apache.shardingsphere.elasticjob.restful.mapping.RegexUrlPatternMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class RegexUrlPatternMapTest {
     
@@ -58,11 +59,13 @@ public final class RegexUrlPatternMapTest {
         assertThat(mappingContext.payload(), is(11));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertDuplicate() {
-        RegexUrlPatternMap<Integer> urlPatternMap = new RegexUrlPatternMap<>();
-        urlPatternMap.put("/app/{jobName}/enable", 0);
-        urlPatternMap.put("/app/{jobName}", 1);
-        urlPatternMap.put("/app/{appName}", 2);
+        assertThrows(IllegalArgumentException.class, () -> {
+            RegexUrlPatternMap<Integer> urlPatternMap = new RegexUrlPatternMap<>();
+            urlPatternMap.put("/app/{jobName}/enable", 0);
+            urlPatternMap.put("/app/{jobName}", 1);
+            urlPatternMap.put("/app/{appName}", 2);
+        });
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/deserializer/RequestBodyDeserializerFactoryTest.java
@@ -18,9 +18,10 @@
 package org.apache.shardingsphere.elasticjob.restful.deserializer;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class RequestBodyDeserializerFactoryTest {
     
@@ -30,8 +31,9 @@ public final class RequestBodyDeserializerFactoryTest {
         assertNotNull(deserializer);
     }
     
-    @Test(expected = RequestBodyDeserializerNotFoundException.class)
+    @Test
     public void assertDeserializerNotFound() {
-        RequestBodyDeserializerFactory.getRequestBodyDeserializer("Unknown");
+        assertThrows(RequestBodyDeserializerNotFoundException.class, () ->
+                RequestBodyDeserializerFactory.getRequestBodyDeserializer("Unknown"));
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChainTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/filter/DefaultFilterChainTest.java
@@ -24,25 +24,26 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.restful.Filter;
 import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
 import org.apache.shardingsphere.elasticjob.restful.handler.Handler;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DefaultFilterChainTest {
     
     @Mock
@@ -56,7 +57,7 @@ public final class DefaultFilterChainTest {
     
     private HandleContext<Handler> handleContext;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         handleContext = new HandleContext<>(httpRequest, httpResponse);
     }
@@ -127,23 +128,27 @@ public final class DefaultFilterChainTest {
         verify(ctx).writeAndFlush(httpResponse);
     }
     
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void assertInvokeFinishedFilterChainWithoutFilter() {
-        DefaultFilterChain filterChain = new DefaultFilterChain(Collections.emptyList(), ctx, handleContext);
-        filterChain.next(httpRequest);
-        filterChain.next(httpRequest);
+        assertThrows(IllegalStateException.class, () -> {
+            DefaultFilterChain filterChain = new DefaultFilterChain(Collections.emptyList(), ctx, handleContext);
+            filterChain.next(httpRequest);
+            filterChain.next(httpRequest);
+        });
     }
     
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void assertInvokePassedThroughFilterChainWithTwoFilters() {
-        Filter firstFilter = spy(new PassableFilter());
-        Filter secondFilter = spy(new PassableFilter());
-        DefaultFilterChain filterChain = new DefaultFilterChain(Arrays.asList(firstFilter, secondFilter), ctx, handleContext);
-        filterChain.next(httpRequest);
-        verify(firstFilter).doFilter(httpRequest, httpResponse, filterChain);
-        verify(secondFilter).doFilter(httpRequest, httpResponse, filterChain);
-        verify(ctx).fireChannelRead(handleContext);
-        filterChain.next(httpRequest);
+        assertThrows(IllegalStateException.class, () -> {
+            Filter firstFilter = spy(new PassableFilter());
+            Filter secondFilter = spy(new PassableFilter());
+            DefaultFilterChain filterChain = new DefaultFilterChain(Arrays.asList(firstFilter, secondFilter), ctx, handleContext);
+            filterChain.next(httpRequest);
+            verify(firstFilter).doFilter(httpRequest, httpResponse, filterChain);
+            verify(secondFilter).doFilter(httpRequest, httpResponse, filterChain);
+            verify(ctx).fireChannelRead(handleContext);
+            filterChain.next(httpRequest);
+        });
     }
     
     private boolean isPassedThrough(final DefaultFilterChain filterChain) {

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandlerTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/FilterChainInboundHandlerTest.java
@@ -22,11 +22,11 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.restful.Filter;
 import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
 import org.apache.shardingsphere.elasticjob.restful.handler.Handler;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class FilterChainInboundHandlerTest {
     
     @Mock
@@ -46,7 +46,7 @@ public final class FilterChainInboundHandlerTest {
     
     private EmbeddedChannel channel;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(new FilterChainInboundHandler(filterInstances));
     }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HandlerParameterDecoderTest.java
@@ -35,8 +35,8 @@ import org.apache.shardingsphere.elasticjob.restful.annotation.Mapping;
 import org.apache.shardingsphere.elasticjob.restful.annotation.Param;
 import org.apache.shardingsphere.elasticjob.restful.annotation.ParamSource;
 import org.apache.shardingsphere.elasticjob.restful.annotation.RequestBody;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -47,7 +47,7 @@ public final class HandlerParameterDecoderTest {
     
     private EmbeddedChannel channel;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ContextInitializationInboundHandler contextInitializationInboundHandler = new ContextInitializationInboundHandler();
         HttpRequestDispatcher httpRequestDispatcher = new HttpRequestDispatcher(Collections.singletonList(new DecoderTestController()), false);

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/HttpRequestDispatcherTest.java
@@ -26,14 +26,18 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.apache.shardingsphere.elasticjob.restful.controller.JobController;
 import org.apache.shardingsphere.elasticjob.restful.handler.HandleContext;
 import org.apache.shardingsphere.elasticjob.restful.handler.HandlerNotFoundException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class HttpRequestDispatcherTest {
     
-    @Test(expected = HandlerNotFoundException.class)
+    @Test
     public void assertDispatcherHandlerNotFound() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDispatcher(Lists.newArrayList(new JobController()), false));
-        FullHttpRequest fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/myJob/myCron");
-        channel.writeInbound(new HandleContext<>(fullHttpRequest, null));
+        assertThrows(HandlerNotFoundException.class, () -> {
+            EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDispatcher(Lists.newArrayList(new JobController()), false));
+            FullHttpRequest fullHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/myJob/myCron");
+            channel.writeInbound(new HandleContext<>(fullHttpRequest, null));
+        });
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTest.java
@@ -34,16 +34,18 @@ import org.apache.shardingsphere.elasticjob.restful.controller.IndexController;
 import org.apache.shardingsphere.elasticjob.restful.controller.JobController;
 import org.apache.shardingsphere.elasticjob.restful.handler.CustomIllegalStateExceptionHandler;
 import org.apache.shardingsphere.elasticjob.restful.pojo.JobPojo;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class NettyRestfulServiceTest {
     
@@ -55,7 +57,7 @@ public final class NettyRestfulServiceTest {
     
     private static RestfulService restfulService;
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
         configuration.setHost(HOST);
@@ -66,7 +68,8 @@ public final class NettyRestfulServiceTest {
     }
     
     @SneakyThrows
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertRequestWithParameters() {
         String cron = "0 * * * * ?";
         String uri = String.format("/job/myGroup/myJob?cron=%s", URLEncoder.encode(cron, "UTF-8"));
@@ -88,7 +91,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertCustomExceptionHandler() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalState");
         request.headers().set("Exception-Message", "An illegal state exception message.");
@@ -98,7 +102,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertUsingDefaultExceptionHandler() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/throw/IllegalArgument");
         request.headers().set("Exception-Message", "An illegal argument exception message.");
@@ -108,7 +113,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertReturnStatusCode() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/job/code/204");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
@@ -116,7 +122,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertHandlerNotFound() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/not/found");
         HttpClient.request(HOST, PORT, request, httpResponse -> {
@@ -124,7 +131,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertRequestIndexWithSlash() {
         DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
@@ -132,7 +140,8 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertRequestIndexWithoutSlash() {
         DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "");
         HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
@@ -140,7 +149,7 @@ public final class NettyRestfulServiceTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         if (null != restfulService) {
             restfulService.shutdown();

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashInsensitiveTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashInsensitiveTest.java
@@ -21,7 +21,9 @@ import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
 import org.apache.shardingsphere.elasticjob.restful.controller.TrailingSlashTestController;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class NettyRestfulServiceTrailingSlashInsensitiveTest {
     
@@ -29,12 +31,14 @@ public final class NettyRestfulServiceTrailingSlashInsensitiveTest {
     
     private static final int PORT = 18082;
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertPathDuplicateWhenTrailingSlashInsensitive() {
-        NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
-        configuration.setHost(HOST);
-        configuration.addControllerInstances(new TrailingSlashTestController());
-        RestfulService restfulService = new NettyRestfulService(configuration);
-        restfulService.startup();
+        assertThrows(IllegalArgumentException.class, () -> {
+            NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
+            configuration.setHost(HOST);
+            configuration.addControllerInstances(new TrailingSlashTestController());
+            RestfulService restfulService = new NettyRestfulService(configuration);
+            restfulService.startup();
+        });
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/pipeline/NettyRestfulServiceTrailingSlashSensitiveTest.java
@@ -25,11 +25,13 @@ import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulServiceConfiguration;
 import org.apache.shardingsphere.elasticjob.restful.RestfulService;
 import org.apache.shardingsphere.elasticjob.restful.controller.TrailingSlashTestController;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,7 +46,7 @@ public final class NettyRestfulServiceTrailingSlashSensitiveTest {
     
     private static RestfulService restfulService;
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         NettyRestfulServiceConfiguration configuration = new NettyRestfulServiceConfiguration(PORT);
         configuration.setHost(HOST);
@@ -54,7 +56,8 @@ public final class NettyRestfulServiceTrailingSlashSensitiveTest {
         restfulService.startup();
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertWithoutTrailingSlash() {
         DefaultFullHttpRequest requestWithSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash");
         HttpClient.request(HOST, PORT, requestWithSlash, httpResponse -> {
@@ -65,7 +68,8 @@ public final class NettyRestfulServiceTrailingSlashSensitiveTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @Test(timeout = TESTCASE_TIMEOUT)
+    @Test
+    @Timeout(value = TESTCASE_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void assertWithTrailingSlash() {
         DefaultFullHttpRequest requestWithoutSlash = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/trailing/slash/");
         HttpClient.request(HOST, PORT, requestWithoutSlash, httpResponse -> {
@@ -76,7 +80,7 @@ public final class NettyRestfulServiceTrailingSlashSensitiveTest {
         }, TESTCASE_TIMEOUT);
     }
     
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         if (null != restfulService) {
             restfulService.shutdown();

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactoryTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/serializer/ResponseBodySerializerFactoryTest.java
@@ -18,9 +18,10 @@
 package org.apache.shardingsphere.elasticjob.restful.serializer;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ResponseBodySerializerFactoryTest {
     
@@ -30,8 +31,9 @@ public final class ResponseBodySerializerFactoryTest {
         assertNotNull(serializer);
     }
     
-    @Test(expected = ResponseBodySerializerNotFoundException.class)
+    @Test
     public void assertSerializerNotFound() {
-        ResponseBodySerializerFactory.getResponseBodySerializer("Unknown");
+        assertThrows(ResponseBodySerializerNotFoundException.class, () ->
+                ResponseBodySerializerFactory.getResponseBodySerializer("Unknown"));
     }
 }

--- a/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/wrapper/QueryParameterMapTest.java
+++ b/elasticjob-infra/elasticjob-restful/src/test/java/org/apache/shardingsphere/elasticjob/restful/wrapper/QueryParameterMapTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.restful.wrapper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public final class QueryParameterMapTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-core/pom.xml
@@ -99,14 +99,6 @@
             <artifactId>curator-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/bootstrap/impl/OneOffJobBootstrapTest.java
@@ -25,10 +25,10 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduler;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
 import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 
@@ -37,7 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class OneOffJobBootstrapTest {
 
@@ -47,26 +48,27 @@ public final class OneOffJobBootstrapTest {
 
     private ZookeeperRegistryCenter zkRegCenter;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
         zkRegCenter.init();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         zkRegCenter.close();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertConfigFailedWithCron() {
-        new OneOffJobBootstrap(zkRegCenter, (SimpleJob) shardingContext -> {
-        }, JobConfiguration.newBuilder("test_one_off_job_execute_with_config_cron", SHARDING_TOTAL_COUNT).cron("0/5 * * * * ?").build());
+        assertThrows(IllegalArgumentException.class, () ->
+                new OneOffJobBootstrap(zkRegCenter, (SimpleJob) shardingContext -> {
+                }, JobConfiguration.newBuilder("test_one_off_job_execute_with_config_cron", SHARDING_TOTAL_COUNT).cron("0/5 * * * * ?").build()));
     }
 
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/listener/DistributeOnceElasticJobListenerTest.java
@@ -18,28 +18,29 @@
 package org.apache.shardingsphere.elasticjob.lite.api.listener;
 
 import com.google.common.collect.Sets;
+import org.apache.shardingsphere.elasticjob.infra.env.TimeService;
+import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.infra.listener.ShardingContexts;
 import org.apache.shardingsphere.elasticjob.lite.api.listener.fixture.ElasticJobListenerCaller;
 import org.apache.shardingsphere.elasticjob.lite.api.listener.fixture.TestDistributeOnceElasticJobListener;
-import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.lite.internal.guarantee.GuaranteeService;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.apache.shardingsphere.elasticjob.infra.env.TimeService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class DistributeOnceElasticJobListenerTest {
     
     @Mock
@@ -55,7 +56,7 @@ public final class DistributeOnceElasticJobListenerTest {
     
     private TestDistributeOnceElasticJobListener distributeOnceElasticJobListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         distributeOnceElasticJobListener = new TestDistributeOnceElasticJobListener(elasticJobListenerCaller);
         distributeOnceElasticJobListener.setGuaranteeService(guaranteeService);
@@ -85,14 +86,16 @@ public final class DistributeOnceElasticJobListenerTest {
         verify(guaranteeService, times(0)).clearAllStartedInfo();
     }
     
-    @Test(expected = JobSystemException.class)
+    @Test
     public void assertBeforeJobExecutedWhenIsNotAllStartedAndTimeout() {
-        when(guaranteeService.isRegisterStartSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
-        when(guaranteeService.isAllStarted()).thenReturn(false);
-        when(timeService.getCurrentMillis()).thenReturn(0L, 2L);
-        distributeOnceElasticJobListener.beforeJobExecuted(shardingContexts);
-        verify(guaranteeService).registerStart(Arrays.asList(0, 1));
-        verify(guaranteeService, times(0)).clearAllStartedInfo();
+        assertThrows(JobSystemException.class, () -> {
+            when(guaranteeService.isRegisterStartSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
+            when(guaranteeService.isAllStarted()).thenReturn(false);
+            when(timeService.getCurrentMillis()).thenReturn(0L, 2L);
+            distributeOnceElasticJobListener.beforeJobExecuted(shardingContexts);
+            verify(guaranteeService).registerStart(Arrays.asList(0, 1));
+            verify(guaranteeService, times(0)).clearAllStartedInfo();
+        });
     }
     
     @Test
@@ -114,13 +117,15 @@ public final class DistributeOnceElasticJobListenerTest {
         verify(guaranteeService, times(0)).clearAllCompletedInfo();
     }
     
-    @Test(expected = JobSystemException.class)
+    @Test
     public void assertAfterJobExecutedWhenIsAllCompletedAndTimeout() {
-        when(guaranteeService.isRegisterCompleteSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
-        when(guaranteeService.isAllCompleted()).thenReturn(false);
-        when(timeService.getCurrentMillis()).thenReturn(0L, 2L);
-        distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
-        verify(guaranteeService).registerComplete(Arrays.asList(0, 1));
-        verify(guaranteeService, times(0)).clearAllCompletedInfo();
+        assertThrows(JobSystemException.class, () -> {
+            when(guaranteeService.isRegisterCompleteSuccess(Sets.newHashSet(0, 1))).thenReturn(true);
+            when(guaranteeService.isAllCompleted()).thenReturn(false);
+            when(timeService.getCurrentMillis()).thenReturn(0L, 2L);
+            distributeOnceElasticJobListener.afterJobExecuted(shardingContexts);
+            verify(guaranteeService).registerComplete(Arrays.asList(0, 1));
+            verify(guaranteeService, times(0)).clearAllCompletedInfo();
+        });
     }
 }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistryTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/api/registry/JobInstanceRegistryTest.java
@@ -24,15 +24,16 @@ import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobInstanceRegistryTest {
     
     @Mock
@@ -53,18 +54,22 @@ public final class JobInstanceRegistryTest {
         verify(regCenter, times(0)).get("/jobName");
     }
     
-    @Test(expected = RuntimeException.class)
+    @Test
     public void assertListenScheduleJob() {
-        JobInstanceRegistry jobInstanceRegistry = new JobInstanceRegistry(regCenter, new JobInstance("id"));
-        String jobConfig = toYaml(JobConfiguration.newBuilder("jobName", 1).cron("0/1 * * * * ?").label("label").build());
-        jobInstanceRegistry.new JobInstanceRegistryListener().onChange(new DataChangedEvent(Type.ADDED, "/jobName/config", jobConfig));
+        assertThrows(RuntimeException.class, () -> {
+            JobInstanceRegistry jobInstanceRegistry = new JobInstanceRegistry(regCenter, new JobInstance("id"));
+            String jobConfig = toYaml(JobConfiguration.newBuilder("jobName", 1).cron("0/1 * * * * ?").label("label").build());
+            jobInstanceRegistry.new JobInstanceRegistryListener().onChange(new DataChangedEvent(Type.ADDED, "/jobName/config", jobConfig));
+        });
     }
     
-    @Test(expected = RuntimeException.class)
+    @Test
     public void assertListenOneOffJob() {
-        JobInstanceRegistry jobInstanceRegistry = new JobInstanceRegistry(regCenter, new JobInstance("id", "label"));
-        String jobConfig = toYaml(JobConfiguration.newBuilder("jobName", 1).label("label").build());
-        jobInstanceRegistry.new JobInstanceRegistryListener().onChange(new DataChangedEvent(Type.ADDED, "/jobName/config", jobConfig));
+        assertThrows(RuntimeException.class, () -> {
+            JobInstanceRegistry jobInstanceRegistry = new JobInstanceRegistry(regCenter, new JobInstance("id", "label"));
+            String jobConfig = toYaml(JobConfiguration.newBuilder("jobName", 1).label("label").build());
+            jobInstanceRegistry.new JobInstanceRegistryListener().onChange(new DataChangedEvent(Type.ADDED, "/jobName/config", jobConfig));
+        });
     }
     
     private String toYaml(final JobConfiguration build) {

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/BaseIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/BaseIntegrateTest.java
@@ -19,21 +19,21 @@ package org.apache.shardingsphere.elasticjob.lite.integrate;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.apache.shardingsphere.elasticjob.api.ElasticJob;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.JobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
-import org.apache.shardingsphere.elasticjob.api.ElasticJob;
-import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
+import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 @Getter(AccessLevel.PROTECTED)
 public abstract class BaseIntegrateTest {
@@ -73,14 +73,14 @@ public abstract class BaseIntegrateTest {
         }
     }
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIG.setConnectionTimeoutMilliseconds(30000);
         REGISTRY_CENTER.init();
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         if (jobBootstrap instanceof ScheduleJobBootstrap) {
             ((ScheduleJobBootstrap) jobBootstrap).schedule();
@@ -89,7 +89,7 @@ public abstract class BaseIntegrateTest {
         }
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         jobBootstrap.shutdown();
         ReflectionUtils.setFieldValue(JobRegistry.getInstance(), "instance", null);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/DisabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/DisabledJobIntegrateTest.java
@@ -32,7 +32,7 @@ import org.hamcrest.core.IsNull;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public abstract class DisabledJobIntegrateTest extends BaseIntegrateTest {

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/OneOffDisabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/OneOffDisabledJobIntegrateTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.integrate.disable;
 
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class OneOffDisabledJobIntegrateTest extends DisabledJobIntegrateTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/ScheduleDisabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/disable/ScheduleDisabledJobIntegrateTest.java
@@ -22,13 +22,13 @@ import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ScheduleDisabledJobIntegrateTest extends DisabledJobIntegrateTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/EnabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/EnabledJobIntegrateTest.java
@@ -17,21 +17,21 @@
 
 package org.apache.shardingsphere.elasticjob.lite.integrate.enable;
 
-import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.apache.shardingsphere.elasticjob.lite.integrate.BaseIntegrateTest;
+import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
+import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
+import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
+import org.apache.shardingsphere.elasticjob.lite.integrate.BaseIntegrateTest;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
-import org.apache.shardingsphere.elasticjob.infra.env.IpUtils;
-import org.apache.shardingsphere.elasticjob.infra.yaml.YamlEngine;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class EnabledJobIntegrateTest extends BaseIntegrateTest {
     
@@ -39,7 +39,7 @@ public abstract class EnabledJobIntegrateTest extends BaseIntegrateTest {
         super(type, elasticJob);
     }
     
-    @Before
+    @BeforeEach
     public final void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/OneOffEnabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/OneOffEnabledJobIntegrateTest.java
@@ -20,13 +20,13 @@ package org.apache.shardingsphere.elasticjob.lite.integrate.enable;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class OneOffEnabledJobIntegrateTest extends EnabledJobIntegrateTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/ScheduleEnabledJobIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/integrate/enable/ScheduleEnabledJobIntegrateTest.java
@@ -20,13 +20,13 @@ package org.apache.shardingsphere.elasticjob.lite.integrate.enable;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ScheduleEnabledJobIntegrateTest extends EnabledJobIntegrateTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/JobAnnotationBuilderTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/JobAnnotationBuilderTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.annotation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.AnnotationSimpleJob;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class JobAnnotationBuilderTest {
    

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/BaseAnnotationTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/BaseAnnotationTest.java
@@ -32,9 +32,9 @@ import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 @Getter(AccessLevel.PROTECTED)
 public abstract class BaseAnnotationTest {
@@ -73,14 +73,14 @@ public abstract class BaseAnnotationTest {
         }
     }
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIG.setConnectionTimeoutMilliseconds(30000);
         REGISTRY_CENTER.init();
     }
     
-    @Before
+    @BeforeEach
     public void setUp() {
         if (jobBootstrap instanceof ScheduleJobBootstrap) {
             ((ScheduleJobBootstrap) jobBootstrap).schedule();
@@ -89,7 +89,7 @@ public abstract class BaseAnnotationTest {
         }
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         jobBootstrap.shutdown();
         ReflectionUtils.setFieldValue(JobRegistry.getInstance(), "instance", null);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/OneOffEnabledJobTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/OneOffEnabledJobTest.java
@@ -25,15 +25,15 @@ import org.apache.shardingsphere.elasticjob.lite.fixture.job.AnnotationUnShardin
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
 import org.awaitility.Awaitility;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class OneOffEnabledJobTest extends BaseAnnotationTest {
     
@@ -41,7 +41,7 @@ public final class OneOffEnabledJobTest extends BaseAnnotationTest {
         super(TestType.ONE_OFF, new AnnotationUnShardingJob());
     }
     
-    @Before
+    @BeforeEach
     public void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(1));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/ScheduleEnabledJobTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/annotation/integrate/ScheduleEnabledJobTest.java
@@ -25,15 +25,15 @@ import org.apache.shardingsphere.elasticjob.lite.fixture.job.AnnotationSimpleJob
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerStatus;
 import org.awaitility.Awaitility;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ScheduleEnabledJobTest extends BaseAnnotationTest {
     
@@ -41,7 +41,7 @@ public final class ScheduleEnabledJobTest extends BaseAnnotationTest {
         super(TestType.SCHEDULE, new AnnotationSimpleJob());
     }
     
-    @Before
+    @BeforeEach
     public void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/ConfigurationNodeTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ConfigurationNodeTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/RescheduleListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/config/RescheduleListenerManagerTest.java
@@ -25,18 +25,18 @@ import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class RescheduleListenerManagerTest {
     
     @Mock
@@ -50,7 +50,7 @@ public final class RescheduleListenerManagerTest {
     
     private final RescheduleListenerManager rescheduleListenerManager = new RescheduleListenerManager(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setSuperclassFieldValue(rescheduleListenerManager, "jobNodeStorage", jobNodeStorage);
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/ElectionListenerManagerTest.java
@@ -27,18 +27,18 @@ import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ElectionListenerManagerTest {
     
     @Mock
@@ -58,7 +58,7 @@ public final class ElectionListenerManagerTest {
     
     private final ElectionListenerManager electionListenerManager = new ElectionListenerManager(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
         ReflectionUtils.setSuperclassFieldValue(electionListenerManager, "jobNodeStorage", jobNodeStorage);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/LeaderNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/LeaderNodeTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.election;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class LeaderNodeTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/LeaderServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/election/LeaderServiceTest.java
@@ -25,21 +25,21 @@ import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class LeaderServiceTest {
     
     @Mock
@@ -56,7 +56,7 @@ public final class LeaderServiceTest {
     
     private LeaderService leaderService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
         leaderService = new LeaderService(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverListenerManagerTest.java
@@ -32,12 +32,12 @@ import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class FailoverListenerManagerTest {
     
     @Mock
@@ -79,7 +79,7 @@ public final class FailoverListenerManagerTest {
     
     private final FailoverListenerManager failoverListenerManager = new FailoverListenerManager(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setSuperclassFieldValue(failoverListenerManager, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(failoverListenerManager, "configService", configService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverNodeTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.failover;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class FailoverNodeTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/failover/FailoverServiceTest.java
@@ -24,14 +24,14 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class FailoverServiceTest {
     
     @Mock
@@ -65,7 +65,7 @@ public final class FailoverServiceTest {
     
     private final FailoverService failoverService = new FailoverService(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(failoverService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(failoverService, "shardingService", shardingService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeListenerManagerTest.java
@@ -24,11 +24,11 @@ import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
@@ -36,7 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class GuaranteeListenerManagerTest {
     
     @Mock
@@ -50,7 +50,7 @@ public final class GuaranteeListenerManagerTest {
     
     private GuaranteeListenerManager guaranteeListenerManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         guaranteeListenerManager = new GuaranteeListenerManager(null, "test_job", Arrays.asList(elasticJobListener, distributeOnceElasticJobListener));
         ReflectionUtils.setSuperclassFieldValue(guaranteeListenerManager, "jobNodeStorage", jobNodeStorage);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeNodeTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.guarantee;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class GuaranteeNodeTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/guarantee/GuaranteeServiceTest.java
@@ -23,21 +23,21 @@ import org.apache.shardingsphere.elasticjob.lite.api.listener.AbstractDistribute
 import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class GuaranteeServiceTest {
     
     @Mock
@@ -54,7 +54,7 @@ public final class GuaranteeServiceTest {
     
     private final GuaranteeService guaranteeService = new GuaranteeService(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(guaranteeService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(guaranteeService, "configService", configService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceNodeTest.java
@@ -19,19 +19,19 @@ package org.apache.shardingsphere.elasticjob.lite.internal.instance;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class InstanceNodeTest {
     
     private static InstanceNode instanceNode;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         instanceNode = new InstanceNode("test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/InstanceServiceTest.java
@@ -22,22 +22,22 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class InstanceServiceTest {
     
     @Mock
@@ -48,7 +48,7 @@ public final class InstanceServiceTest {
     
     private InstanceService instanceService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
         instanceService = new InstanceService(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/instance/ShutdownListenerManagerTest.java
@@ -26,19 +26,19 @@ import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ShutdownListenerManagerTest {
     
     @Mock
@@ -58,7 +58,7 @@ public final class ShutdownListenerManagerTest {
     
     private ShutdownListenerManager shutdownListenerManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         shutdownListenerManager = new ShutdownListenerManager(null, "test_job");
@@ -67,7 +67,7 @@ public final class ShutdownListenerManagerTest {
         ReflectionUtils.setSuperclassFieldValue(shutdownListenerManager, "jobNodeStorage", jobNodeStorage);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown("test_job");
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerManagerTest.java
@@ -27,17 +27,17 @@ import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingListe
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.internal.trigger.TriggerListenerManager;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ListenerManagerTest {
     
     @Mock
@@ -72,7 +72,7 @@ public final class ListenerManagerTest {
     
     private final ListenerManager listenerManager = new ListenerManager(null, "test_job", Collections.emptyList());
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(listenerManager, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(listenerManager, "electionListenerManager", electionListenerManager);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/ListenerNotifierManagerTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.listener;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.Executor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ListenerNotifierManagerTest {
 
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/RegistryCenterConnectionStateListenerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/listener/RegistryCenterConnectionStateListenerTest.java
@@ -27,11 +27,11 @@ import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingServi
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.ConnectionStateChangedEventListener.State;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class RegistryCenterConnectionStateListenerTest {
     
     @Mock
@@ -62,7 +62,7 @@ public final class RegistryCenterConnectionStateListenerTest {
     
     private RegistryCenterConnectionStateListener regCenterConnectionStateListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
         regCenterConnectionStateListener = new RegistryCenterConnectionStateListener(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/reconcile/ReconcileServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/reconcile/ReconcileServiceTest.java
@@ -25,17 +25,17 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ReconcileServiceTest {
     
     @Mock
@@ -49,7 +49,7 @@ public final class ReconcileServiceTest {
     
     private ReconcileService reconcileService;
     
-    @Before
+    @BeforeEach
     public void setup() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         reconcileService = new ReconcileService(regCenter, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobRegistryTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobRegistryTest.java
@@ -20,12 +20,12 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduleControllerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobScheduleControllerTest.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 
 import org.apache.shardingsphere.elasticjob.infra.exception.JobSystemException;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -33,8 +33,9 @@ import org.quartz.TriggerKey;
 import org.quartz.impl.triggers.CronTriggerImpl;
 import org.quartz.impl.triggers.SimpleTriggerImpl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobScheduleControllerTest {
     
     @Mock
@@ -53,20 +54,22 @@ public final class JobScheduleControllerTest {
     
     private JobScheduleController jobScheduleController;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobScheduleController = new JobScheduleController(scheduler, jobDetail, "test_job_Trigger");
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertIsPausedFailure() throws SchedulerException {
-        doThrow(SchedulerException.class).when(scheduler).getTriggerState(new TriggerKey("test_job_Trigger"));
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.isPaused();
-        } finally {
-            verify(scheduler).getTriggerState(new TriggerKey("test_job_Trigger"));
-        }
+    @Test
+    public void assertIsPausedFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            doThrow(SchedulerException.class).when(scheduler).getTriggerState(new TriggerKey("test_job_Trigger"));
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.isPaused();
+            } finally {
+                verify(scheduler).getTriggerState(new TriggerKey("test_job_Trigger"));
+            }
+        });
     }
     
     @Test
@@ -98,15 +101,17 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).pauseAll();
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertPauseJobFailure() throws SchedulerException {
-        doThrow(SchedulerException.class).when(scheduler).pauseAll();
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.pauseJob();
-        } finally {
-            verify(scheduler).pauseAll();
-        }
+    @Test
+    public void assertPauseJobFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            doThrow(SchedulerException.class).when(scheduler).pauseAll();
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.pauseJob();
+            } finally {
+                verify(scheduler).pauseAll();
+            }
+        });
     }
     
     @Test
@@ -124,15 +129,17 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).resumeAll();
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertResumeJobFailure() throws SchedulerException {
-        doThrow(SchedulerException.class).when(scheduler).resumeAll();
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.resumeJob();
-        } finally {
-            verify(scheduler).resumeAll();
-        }
+    @Test
+    public void assertResumeJobFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            doThrow(SchedulerException.class).when(scheduler).resumeAll();
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.resumeJob();
+            } finally {
+                verify(scheduler).resumeAll();
+            }
+        });
     }
     
     @Test
@@ -152,20 +159,22 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).triggerJob(any());
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertTriggerJobFailure() throws SchedulerException {
-        JobKey jobKey = new JobKey("test_job");
-        when(jobDetail.getKey()).thenReturn(jobKey);
-        when(scheduler.checkExists(jobKey)).thenReturn(true);
-        doThrow(SchedulerException.class).when(scheduler).triggerJob(jobKey);
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        ReflectionUtils.setFieldValue(jobScheduleController, "jobDetail", jobDetail);
-        try {
-            jobScheduleController.triggerJob();
-        } finally {
-            verify(jobDetail, times(2)).getKey();
-            verify(scheduler).triggerJob(jobKey);
-        }
+    @Test
+    public void assertTriggerJobFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            JobKey jobKey = new JobKey("test_job");
+            when(jobDetail.getKey()).thenReturn(jobKey);
+            when(scheduler.checkExists(jobKey)).thenReturn(true);
+            doThrow(SchedulerException.class).when(scheduler).triggerJob(jobKey);
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            ReflectionUtils.setFieldValue(jobScheduleController, "jobDetail", jobDetail);
+            try {
+                jobScheduleController.triggerJob();
+            } finally {
+                verify(jobDetail, times(2)).getKey();
+                verify(scheduler).triggerJob(jobKey);
+            }
+        });
     }
     
     @Test
@@ -201,15 +210,17 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).shutdown();
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertShutdownFailure() throws SchedulerException {
-        doThrow(SchedulerException.class).when(scheduler).shutdown(false);
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.shutdown();
-        } finally {
-            verify(scheduler).shutdown(false);
-        }
+    @Test
+    public void assertShutdownFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            doThrow(SchedulerException.class).when(scheduler).shutdown(false);
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.shutdown();
+            } finally {
+                verify(scheduler).shutdown(false);
+            }
+        });
     }
     
     @Test
@@ -227,16 +238,18 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertRescheduleJobFailure() throws SchedulerException {
-        when(scheduler.getTrigger(TriggerKey.triggerKey("test_job_Trigger"))).thenReturn(new CronTriggerImpl());
-        doThrow(SchedulerException.class).when(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.rescheduleJob("0/1 * * * * ?", null);
-        } finally {
-            verify(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
-        }
+    @Test
+    public void assertRescheduleJobFailure() {
+        assertThrows(JobSystemException.class, () -> {
+            when(scheduler.getTrigger(TriggerKey.triggerKey("test_job_Trigger"))).thenReturn(new CronTriggerImpl());
+            doThrow(SchedulerException.class).when(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.rescheduleJob("0/1 * * * * ?", null);
+            } finally {
+                verify(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
+            }
+        });
     }
     
     @Test
@@ -262,16 +275,18 @@ public final class JobScheduleControllerTest {
         verify(scheduler, times(0)).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
     }
     
-    @Test(expected = JobSystemException.class)
-    public void assertRescheduleJobFailureForOneOffJob() throws SchedulerException {
-        when(scheduler.getTrigger(TriggerKey.triggerKey("test_job_Trigger"))).thenReturn(new SimpleTriggerImpl());
-        doThrow(SchedulerException.class).when(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
-        ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
-        try {
-            jobScheduleController.rescheduleJob();
-        } finally {
-            verify(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
-        }
+    @Test
+    public void assertRescheduleJobFailureForOneOffJob() {
+        assertThrows(JobSystemException.class, () -> {
+            when(scheduler.getTrigger(TriggerKey.triggerKey("test_job_Trigger"))).thenReturn(new SimpleTriggerImpl());
+            doThrow(SchedulerException.class).when(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
+            ReflectionUtils.setFieldValue(jobScheduleController, "scheduler", scheduler);
+            try {
+                jobScheduleController.rescheduleJob();
+            } finally {
+                verify(scheduler).rescheduleJob(eq(TriggerKey.triggerKey("test_job_Trigger")), any());
+            }
+        });
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobTriggerListenerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/JobTriggerListenerTest.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ExecutionService;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.Trigger;
 
 import java.util.Collections;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobTriggerListenerTest {
     
     @Mock
@@ -49,7 +49,7 @@ public final class JobTriggerListenerTest {
     
     private JobTriggerListener jobTriggerListener;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobTriggerListener = new JobTriggerListener(executionService, shardingService);
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/LiteJobFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/LiteJobFacadeTest.java
@@ -30,11 +30,11 @@ import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ExecutionServ
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.tracing.JobTracingEventBus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class LiteJobFacadeTest {
     
     @Mock
@@ -73,7 +73,7 @@ public final class LiteJobFacadeTest {
 
     private StringBuilder orderResult;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         orderResult = new StringBuilder();
         TestElasticJobListener l1 = new TestElasticJobListener(caller, "l1", 2, orderResult);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/schedule/SchedulerFacadeTest.java
@@ -20,19 +20,19 @@ package org.apache.shardingsphere.elasticjob.lite.internal.schedule;
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.election.LeaderService;
 import org.apache.shardingsphere.elasticjob.lite.internal.sharding.ShardingService;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SchedulerFacadeTest {
     
     @Mock
@@ -49,7 +49,7 @@ public final class SchedulerFacadeTest {
     
     private SchedulerFacade schedulerFacade;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         schedulerFacade = new SchedulerFacade(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerNodeTest.java
@@ -19,19 +19,19 @@ package org.apache.shardingsphere.elasticjob.lite.internal.server;
 
 import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ServerNodeTest {
     
     private final ServerNode serverNode = new ServerNode("test_job");
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerServiceTest.java
@@ -21,24 +21,24 @@ import org.apache.shardingsphere.elasticjob.infra.handler.sharding.JobInstance;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobScheduleController;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
-import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ServerServiceTest {
     
     @Mock
@@ -52,7 +52,7 @@ public final class ServerServiceTest {
     
     private ServerService serverService;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0", null, "127.0.0.1"));
         serverService = new ServerService(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/DefaultJobClassNameProviderTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/DefaultJobClassNameProviderTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.lite.internal.setup;
 
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.FooJob;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactoryTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/JobClassNameProviderFactoryTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.setup;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/setup/SetUpFacadeTest.java
@@ -26,18 +26,18 @@ import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerService;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SetUpFacadeTest {
     
     @Mock
@@ -60,7 +60,7 @@ public final class SetUpFacadeTest {
     
     private SetUpFacade setUpFacade;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         setUpFacade = new SetUpFacade(regCenter, "test_job", Collections.emptyList());

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionContextServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionContextServiceTest.java
@@ -25,11 +25,11 @@ import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationSe
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,10 +38,10 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ExecutionContextServiceTest {
     
     @Mock
@@ -52,7 +52,7 @@ public final class ExecutionContextServiceTest {
     
     private final ExecutionContextService executionContextService = new ExecutionContextService(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(executionContextService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(executionContextService, "configService", configService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ExecutionServiceTest.java
@@ -24,12 +24,12 @@ import org.apache.shardingsphere.elasticjob.lite.internal.config.ConfigurationSe
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,16 +37,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class ExecutionServiceTest {
     
     @Mock
@@ -57,13 +57,13 @@ public final class ExecutionServiceTest {
     
     private final ExecutionService executionService = new ExecutionService(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(executionService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(executionService, "configService", configService);
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown("test_job");
     }

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/MonitorExecutionListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/MonitorExecutionListenerManagerTest.java
@@ -22,16 +22,16 @@ import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class MonitorExecutionListenerManagerTest {
     
     @Mock
@@ -42,7 +42,7 @@ public final class MonitorExecutionListenerManagerTest {
     
     private final MonitorExecutionListenerManager monitorExecutionListenerManager = new MonitorExecutionListenerManager(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setSuperclassFieldValue(monitorExecutionListenerManager, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(monitorExecutionListenerManager, "executionService", executionService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingListenerManagerTest.java
@@ -30,18 +30,18 @@ import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent.Type;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ShardingListenerManagerTest {
     
     @Mock
@@ -61,7 +61,7 @@ public final class ShardingListenerManagerTest {
     
     private ShardingListenerManager shardingListenerManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         shardingListenerManager = new ShardingListenerManager(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingNodeTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingNodeTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.sharding;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class ShardingNodeTest {
     

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/sharding/ShardingServiceTest.java
@@ -29,27 +29,27 @@ import org.apache.shardingsphere.elasticjob.lite.internal.server.ServerService;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class ShardingServiceTest {
     
     @Mock
@@ -78,7 +78,7 @@ public final class ShardingServiceTest {
     
     private final ShardingService shardingService = new ShardingService(null, "test_job");
     
-    @Before
+    @BeforeEach
     public void setUp() {
         ReflectionUtils.setFieldValue(shardingService, "jobNodeStorage", jobNodeStorage);
         ReflectionUtils.setFieldValue(shardingService, "leaderService", leaderService);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/BaseSnapshotServiceTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/BaseSnapshotServiceTest.java
@@ -19,18 +19,18 @@ package org.apache.shardingsphere.elasticjob.lite.internal.snapshot;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.ScheduleJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
+import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class BaseSnapshotServiceTest {
     
@@ -53,20 +53,20 @@ public abstract class BaseSnapshotServiceTest {
         bootstrap = new ScheduleJobBootstrap(REG_CENTER, elasticJob, JobConfiguration.newBuilder(jobName, 3).cron("0/1 * * * * ?").overwrite(true).build());
     }
     
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
         ZOOKEEPER_CONFIG.setConnectionTimeoutMilliseconds(30000);
         REG_CENTER.init();
     }
     
-    @Before
+    @BeforeEach
     public final void setUp() {
         REG_CENTER.init();
         bootstrap.schedule();
     }
     
-    @After
+    @AfterEach
     public final void tearDown() {
         bootstrap.shutdown();
         ReflectionUtils.setFieldValue(JobRegistry.getInstance(), "instance", null);

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotServiceDisableTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotServiceDisableTest.java
@@ -19,13 +19,14 @@ package org.apache.shardingsphere.elasticjob.lite.internal.snapshot;
 
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ServerSocket;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SnapshotServiceDisableTest extends BaseSnapshotServiceTest {
     
@@ -33,15 +34,17 @@ public final class SnapshotServiceDisableTest extends BaseSnapshotServiceTest {
         super(new DetailedFooJob());
     }
     
-    @Test(expected = IOException.class)
-    public void assertMonitorWithDumpCommand() throws IOException {
-        SocketUtils.sendCommand(SnapshotService.DUMP_COMMAND, DUMP_PORT - 1);
+    @Test
+    public void assertMonitorWithDumpCommand() {
+        assertThrows(IOException.class, () -> SocketUtils.sendCommand(SnapshotService.DUMP_COMMAND, DUMP_PORT - 1));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertPortInvalid() {
-        SnapshotService snapshotService = new SnapshotService(getREG_CENTER(), -1);
-        snapshotService.listen();
+        assertThrows(IllegalArgumentException.class, () -> {
+            SnapshotService snapshotService = new SnapshotService(getREG_CENTER(), -1);
+            snapshotService.listen();
+        });
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotServiceEnableTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/snapshot/SnapshotServiceEnableTest.java
@@ -18,14 +18,14 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.snapshot;
 
 import org.apache.shardingsphere.elasticjob.lite.fixture.job.DetailedFooJob;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class SnapshotServiceEnableTest extends BaseSnapshotServiceTest {
     
@@ -33,12 +33,12 @@ public final class SnapshotServiceEnableTest extends BaseSnapshotServiceTest {
         super(new DetailedFooJob());
     }
     
-    @Before
+    @BeforeEach
     public void listenMonitor() {
         getSnapshotService().listen();
     }
     
-    @After
+    @AfterEach
     public void closeMonitor() {
         getSnapshotService().close();
     }
@@ -50,7 +50,7 @@ public final class SnapshotServiceEnableTest extends BaseSnapshotServiceTest {
     }
 
     @Test
-    public void assertDumpJobDirectly() throws IOException {
+    public void assertDumpJobDirectly() {
         assertNotNull(getSnapshotService().dumpJobDirectly(getJobName()));
     }
 

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodePathTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodePathTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.storage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/storage/JobNodeStorageTest.java
@@ -24,11 +24,11 @@ import org.apache.shardingsphere.elasticjob.reg.base.transaction.TransactionOper
 import org.apache.shardingsphere.elasticjob.reg.exception.RegException;
 import org.apache.shardingsphere.elasticjob.reg.listener.ConnectionStateChangedEventListener;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEventListener;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -37,7 +37,8 @@ import java.util.concurrent.Executor;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -45,7 +46,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobNodeStorageTest {
     
     @Mock
@@ -53,7 +54,7 @@ public final class JobNodeStorageTest {
     
     private JobNodeStorage jobNodeStorage;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobNodeStorage = new JobNodeStorage(regCenter, "test_job");
         ReflectionUtils.setFieldValue(jobNodeStorage, "regCenter", regCenter);
@@ -162,10 +163,12 @@ public final class JobNodeStorageTest {
         verify(regCenter).executeInTransaction(any(List.class));
     }
     
-    @Test(expected = RegException.class)
-    public void assertExecuteInTransactionFailure() throws Exception {
-        doThrow(RuntimeException.class).when(regCenter).executeInTransaction(any(List.class));
-        jobNodeStorage.executeInTransaction(Collections.singletonList(TransactionOperation.opAdd("/test_transaction", "")));
+    @Test
+    public void assertExecuteInTransactionFailure() {
+        assertThrows(RegException.class, () -> {
+            doThrow(RuntimeException.class).when(regCenter).executeInTransaction(any(List.class));
+            jobNodeStorage.executeInTransaction(Collections.singletonList(TransactionOperation.opAdd("/test_transaction", "")));
+        });
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/trigger/TriggerListenerManagerTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/trigger/TriggerListenerManagerTest.java
@@ -24,17 +24,17 @@ import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage
 import org.apache.shardingsphere.elasticjob.lite.util.ReflectionUtils;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.listener.DataChangedEvent;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TriggerListenerManagerTest {
     
     @Mock
@@ -51,7 +51,7 @@ public final class TriggerListenerManagerTest {
     
     private TriggerListenerManager triggerListenerManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         JobRegistry.getInstance().addJobInstance("test_job", new JobInstance("127.0.0.1@-@0"));
         triggerListenerManager = new TriggerListenerManager(null, "test_job");

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/util/SensitiveInfoUtilsTest.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/internal/util/SensitiveInfoUtilsTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.internal.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;

--- a/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/pom.xml
@@ -52,15 +52,6 @@
             <artifactId>curator-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-        </dependency>
-        
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/AbstractEmbedZookeeperBaseTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/AbstractEmbedZookeeperBaseTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.lite.lifecycle;
 
 import org.apache.curator.test.TestingServer;
 import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +30,7 @@ public abstract class AbstractEmbedZookeeperBaseTest {
     
     private static volatile TestingServer testingServer;
     
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         startEmbedTestingServer();
     }

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/api/JobAPIFactoryTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/api/JobAPIFactoryTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.lifecycle.api;
 
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.AbstractEmbedZookeeperBaseTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/domain/ShardingStatusTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/domain/ShardingStatusTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.lite.lifecycle.domain;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/JobOperateAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/JobOperateAPIImplTest.java
@@ -19,21 +19,21 @@ package org.apache.shardingsphere.elasticjob.lite.lifecycle.internal.operate;
 
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobOperateAPI;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobOperateAPIImplTest {
 
     static final int DUMP_PORT = 9000;
@@ -43,7 +43,7 @@ public final class JobOperateAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobOperateAPI = new JobOperateAPIImpl(regCenter);
     }

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/JobOperateAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/JobOperateAPIImplTest.java
@@ -39,8 +39,9 @@ public final class JobOperateAPIImplTest {
     static final int DUMP_PORT = 9000;
 
     private JobOperateAPI jobOperateAPI;
-    
-    @Mock
+
+    // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private CoordinatorRegistryCenter regCenter;
     
     @BeforeEach

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/ShardingOperateAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/operate/ShardingOperateAPIImplTest.java
@@ -19,15 +19,15 @@ package org.apache.shardingsphere.elasticjob.lite.lifecycle.internal.operate;
 
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.ShardingOperateAPI;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ShardingOperateAPIImplTest {
     
     private ShardingOperateAPI shardingOperateAPI;
@@ -35,7 +35,7 @@ public final class ShardingOperateAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         shardingOperateAPI = new ShardingOperateAPIImpl(regCenter);
     }

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/reg/RegistryCenterFactoryTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/reg/RegistryCenterFactoryTest.java
@@ -21,13 +21,13 @@ import org.apache.shardingsphere.elasticjob.lite.lifecycle.AbstractEmbedZookeepe
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class RegistryCenterFactoryTest extends AbstractEmbedZookeeperBaseTest {
     

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/settings/JobConfigurationAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/settings/JobConfigurationAPIImplTest.java
@@ -23,21 +23,22 @@ import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobConfigurationA
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.fixture.LifecycleYamlConstants;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.apache.shardingsphere.elasticjob.script.props.ScriptJobProperties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobConfigurationAPIImplTest {
     
     private JobConfigurationAPI jobConfigAPI;
@@ -45,7 +46,7 @@ public final class JobConfigurationAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobConfigAPI = new JobConfigurationAPIImpl(regCenter);
     }
@@ -109,28 +110,34 @@ public final class JobConfigurationAPIImplTest {
         verify(regCenter).update("/test_job/config", LifecycleYamlConstants.getDataflowJobYaml());
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertUpdateJobConfigIfJobNameIsEmpty() {
-        JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
-        jobConfiguration.setJobName("");
-        jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        assertThrows(IllegalArgumentException.class, () -> {
+            JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
+            jobConfiguration.setJobName("");
+            jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        });
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertUpdateJobConfigIfCronIsEmpty() {
-        JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
-        jobConfiguration.setJobName("test_job");
-        jobConfiguration.setCron("");
-        jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        assertThrows(IllegalArgumentException.class, () -> {
+            JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
+            jobConfiguration.setJobName("test_job");
+            jobConfiguration.setCron("");
+            jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        });
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void assertUpdateJobConfigIfShardingTotalCountLessThanOne() {
-        JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
-        jobConfiguration.setJobName("test_job");
-        jobConfiguration.setCron("0/1 * * * * ?");
-        jobConfiguration.setShardingTotalCount(0);
-        jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        assertThrows(IllegalArgumentException.class, () -> {
+            JobConfigurationPOJO jobConfiguration = new JobConfigurationPOJO();
+            jobConfiguration.setJobName("test_job");
+            jobConfiguration.setCron("0/1 * * * * ?");
+            jobConfiguration.setShardingTotalCount(0);
+            jobConfigAPI.updateJobConfiguration(jobConfiguration);
+        });
     }
     
     @Test

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
@@ -21,11 +21,11 @@ import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobStatisticsAPI;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.domain.JobBriefInfo;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.fixture.LifecycleYamlConstants;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class JobStatisticsAPIImplTest {
     
     private JobStatisticsAPI jobStatisticsAPI;
@@ -42,7 +42,7 @@ public final class JobStatisticsAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         jobStatisticsAPI = new JobStatisticsAPIImpl(regCenter);
     }

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
@@ -38,8 +38,9 @@ import static org.mockito.Mockito.when;
 public final class JobStatisticsAPIImplTest {
     
     private JobStatisticsAPI jobStatisticsAPI;
-    
-    @Mock
+
+    // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private CoordinatorRegistryCenter regCenter;
     
     @BeforeEach

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ServerStatisticsAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ServerStatisticsAPIImplTest.java
@@ -20,21 +20,21 @@ package org.apache.shardingsphere.elasticjob.lite.lifecycle.internal.statistics;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.ServerStatisticsAPI;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.domain.ServerBriefInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ServerStatisticsAPIImplTest {
     
     private ServerStatisticsAPI serverStatisticsAPI;
@@ -42,7 +42,7 @@ public final class ServerStatisticsAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         serverStatisticsAPI = new ServerStatisticsAPIImpl(regCenter);
     }

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ShardingStatisticsAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ShardingStatisticsAPIImplTest.java
@@ -37,8 +37,9 @@ import static org.mockito.Mockito.when;
 public final class ShardingStatisticsAPIImplTest {
     
     private ShardingStatisticsAPI shardingStatisticsAPI;
-    
-    @Mock
+
+    // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private CoordinatorRegistryCenter regCenter;
     
     @BeforeEach

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ShardingStatisticsAPIImplTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/internal/statistics/ShardingStatisticsAPIImplTest.java
@@ -20,20 +20,20 @@ package org.apache.shardingsphere.elasticjob.lite.lifecycle.internal.statistics;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.ShardingStatisticsAPI;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.domain.ShardingInfo;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class ShardingStatisticsAPIImplTest {
     
     private ShardingStatisticsAPI shardingStatisticsAPI;
@@ -41,7 +41,7 @@ public final class ShardingStatisticsAPIImplTest {
     @Mock
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         shardingStatisticsAPI = new ShardingStatisticsAPIImpl(regCenter);
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationPropertiesTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobConfigurationPropertiesTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.Collections;
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ElasticJobConfigurationPropertiesTest {
 

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootScannerTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootScannerTest.java
@@ -22,25 +22,29 @@ import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.EmbedTe
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.job.impl.AnnotationCustomJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.core.scanner.ElasticJobScan;
 import org.awaitility.Awaitility;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @ActiveProfiles("elasticjob")
 @ElasticJobScan(basePackages = "org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.job.impl")
-public class ElasticJobSpringBootScannerTest extends AbstractJUnit4SpringContextTests {
-    
-    @BeforeClass
+public class ElasticJobSpringBootScannerTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
         AnnotationCustomJob.reset();

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/ElasticJobSpringBootTest.java
@@ -30,12 +30,13 @@ import org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing.TracingProp
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.awaitility.Awaitility;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
@@ -49,18 +50,21 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @SpringBootApplication
 @ActiveProfiles("elasticjob")
-public class ElasticJobSpringBootTest extends AbstractJUnit4SpringContextTests {
-    
-    @BeforeClass
+public class ElasticJobSpringBootTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/reg/ZookeeperPropertiesTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/reg/ZookeeperPropertiesTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ZookeeperPropertiesTest {
 

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/reg/snapshot/ElasticJobSnapshotServiceConfigurationTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/reg/snapshot/ElasticJobSnapshotServiceConfigurationTest.java
@@ -17,23 +17,27 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.boot.reg.snapshot;
 
-import static org.junit.Assert.assertNotNull;
-
 import org.apache.shardingsphere.elasticjob.lite.internal.snapshot.SnapshotService;
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.EmbedTestingServer;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @SpringBootApplication
 @ActiveProfiles("snapshot")
-public class ElasticJobSnapshotServiceConfigurationTest extends AbstractJUnit4SpringContextTests {
+public class ElasticJobSnapshotServiceConfigurationTest {
 
-    @BeforeClass
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/tracing/TracingConfigurationTest.java
@@ -19,27 +19,31 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.tracing;
 
 import org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 import javax.sql.DataSource;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest
 @SpringBootApplication
 @ActiveProfiles("tracing")
-public class TracingConfigurationTest extends AbstractJUnit4SpringContextTests {
+public class TracingConfigurationTest {
 
-    @BeforeClass
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @BeforeAll
     public static void init() {
         EmbedTestingServer.start();
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/core/setup/JobClassNameProviderFactoryTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/core/setup/JobClassNameProviderFactoryTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.setup.JobClassNameProviderFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class JobClassNameProviderFactoryTest {
     

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/core/util/AopTargetUtilsTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/core/util/AopTargetUtilsTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.core.util;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.shardingsphere.elasticjob.api.ElasticJob;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class AopTargetUtilsTest {
     

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/pom.xml
@@ -83,10 +83,6 @@
             <artifactId>aspectjweaver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/fixture/aspect/SimpleAspect.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/fixture/aspect/SimpleAspect.java
@@ -33,7 +33,11 @@ public class SimpleAspect {
     @Pointcut("execution(* org.apache.shardingsphere.elasticjob.lite.spring.fixture..*(..))")
     public void aspect() {
     }
-    
+
+    /**
+     * Before operator.
+     * @param joinPoint joinPoint
+     */
     @Before("aspect()")
     public void before(final JoinPoint joinPoint) {
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractJobSpringIntegrateTest.java
@@ -21,22 +21,22 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.FooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RequiredArgsConstructor
-public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJUnit4SpringContextTests {
+public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String simpleJobName;
     
@@ -45,14 +45,14 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     @Autowired
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         FooSimpleElasticJob.reset();
         DataflowElasticJob.reset();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(simpleJobName);
         JobRegistry.getInstance().shutdown(throughputDataflowJobName);

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
@@ -22,38 +22,42 @@ import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBoo
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.FooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RequiredArgsConstructor
-public abstract class AbstractOneOffJobSpringIntegrateTest extends AbstractZookeeperJUnit4SpringContextTests {
+public abstract class AbstractOneOffJobSpringIntegrateTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String simpleJobName;
     
     private final String throughputDataflowJobName;
+
+    @Autowired
+    private ApplicationContext applicationContext;
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         FooSimpleElasticJob.reset();
         DataflowElasticJob.reset();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(simpleJobName);
         JobRegistry.getInstance().shutdown(throughputDataflowJobName);

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithRefTest.java
@@ -19,12 +19,12 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -32,23 +32,23 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/withJobRef.xml")
-public final class JobSpringNamespaceWithRefTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class JobSpringNamespaceWithRefTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String simpleJobName = "simpleElasticJob_job_ref";
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         RefFooSimpleElasticJob.reset();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(simpleJobName);
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,10 +33,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/withJobType.xml")
-public final class JobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class JobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String scriptJobName = "scriptElasticJob_job_type";
     
@@ -45,7 +45,7 @@ public final class JobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnit
     
     private Scheduler scheduler;
 
-    @After
+    @AfterEach
     public void tearDown() {
         Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
                 assertThat(scheduler.getCurrentlyExecutingJobs().isEmpty(), is(true))

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
@@ -20,36 +20,40 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobRef.xml")
-public final class OneOffJobSpringNamespaceWithRefTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class OneOffJobSpringNamespaceWithRefTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String oneOffSimpleJobName = "oneOffSimpleElasticJobRef";
-    
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Autowired
     private CoordinatorRegistryCenter regCenter;
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         RefFooSimpleElasticJob.reset();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(oneOffSimpleJobName);
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -19,27 +19,31 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.lite.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobType.xml")
-public final class OneOffJobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class OneOffJobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String scriptJobName = "oneOffScriptElasticJob_job_type";
-    
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Autowired
     private CoordinatorRegistryCenter regCenter;
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(scriptJobName);
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
@@ -20,35 +20,35 @@ package org.apache.shardingsphere.elasticjob.lite.spring.namespace.scanner;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.spring.namespace.fixture.job.annotation.AnnotationSimpleJob;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RequiredArgsConstructor
-public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJUnit4SpringContextTests {
+public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     private final String simpleJobName;
 
     @Autowired
     private CoordinatorRegistryCenter regCenter;
     
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void reset() {
         AnnotationSimpleJob.reset();
     }
     
-    @After
+    @AfterEach
     public void tearDown() {
         JobRegistry.getInstance().shutdown(simpleJobName);
     }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
@@ -52,14 +52,14 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     public void tearDown() {
         JobRegistry.getInstance().shutdown(simpleJobName);
     }
-    
+
     @Test
     public void assertSpringJobBean() {
         assertSimpleElasticJobBean();
     }
     
     private void assertSimpleElasticJobBean() {
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() ->
+        Awaitility.await().atMost(5L, TimeUnit.SECONDS).untilAsserted(() ->
                 assertThat(AnnotationSimpleJob.isCompleted(), is(true))
         );
         assertTrue(AnnotationSimpleJob.isCompleted());

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/snapshot/SnapshotSpringNamespaceDisableTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/snapshot/SnapshotSpringNamespaceDisableTest.java
@@ -18,17 +18,19 @@
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.snapshot;
 
 import org.apache.shardingsphere.elasticjob.lite.internal.snapshot.SnapshotService;
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
-import org.junit.Test;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotDisabled.xml")
-public final class SnapshotSpringNamespaceDisableTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class SnapshotSpringNamespaceDisableTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
-    @Test(expected = IOException.class)
-    public void assertSnapshotDisable() throws IOException {
-        SocketUtils.sendCommand(SnapshotService.DUMP_COMMAND, 9998);
+    @Test
+    public void assertSnapshotDisable() {
+        assertThrows(IOException.class, () -> SocketUtils.sendCommand(SnapshotService.DUMP_COMMAND, 9998));
     }
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/snapshot/SnapshotSpringNamespaceEnableTest.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/snapshot/SnapshotSpringNamespaceEnableTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.snapshot;
 
-import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnit4SpringContextTests;
-import org.junit.Test;
+import org.apache.shardingsphere.elasticjob.lite.spring.namespace.test.AbstractZookeeperJUnitJupiterSpringContextTests;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotEnabled.xml")
-public final class SnapshotSpringNamespaceEnableTest extends AbstractZookeeperJUnit4SpringContextTests {
+public final class SnapshotSpringNamespaceEnableTest extends AbstractZookeeperJUnitJupiterSpringContextTests {
     
     @Test
     public void assertSnapshotEnable() throws IOException {

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/AbstractZookeeperJUnitJupiterSpringContextTests.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/AbstractZookeeperJUnitJupiterSpringContextTests.java
@@ -17,9 +17,11 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.test;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
 @TestExecutionListeners(EmbedZookeeperTestExecutionListener.class)
-public abstract class AbstractZookeeperJUnit4SpringContextTests extends AbstractJUnit4SpringContextTests {
+public abstract class AbstractZookeeperJUnitJupiterSpringContextTests {
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/AbstractZookeeperJUnitJupiterSpringContextTests.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/AbstractZookeeperJUnitJupiterSpringContextTests.java
@@ -21,7 +21,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+/**
+ * Background reference AbstractJUnit4SpringContextTests
+ * and <a href="https://github.com/spring-projects/spring-framework/issues/29149">spring-projects/spring-framework#29149</a>.
+ *
+ * @see org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests
+ */
 @ExtendWith(SpringExtension.class)
-@TestExecutionListeners(EmbedZookeeperTestExecutionListener.class)
+@TestExecutionListeners(listeners = {EmbedZookeeperTestExecutionListener.class},
+        inheritListeners = false,
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public abstract class AbstractZookeeperJUnitJupiterSpringContextTests {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjweaver</artifactId>
                 <version>${aspectj.version}</version>
@@ -374,6 +380,26 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,7 @@
         
         <mysql-connector-java.version>8.0.16</mysql-connector-java.version>
         <h2.version>1.4.184</h2.version>
-        <junit.version>4.13.2</junit.version>
-        <junit5.version>5.10.0</junit5.version>
+        <junit.version>5.10.0</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>4.11.0</mockito.version>
         <awaitility.version>4.2.0</awaitility.version>
@@ -314,14 +313,8 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -330,12 +323,6 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -364,7 +351,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>${junit5.version}</version>
+                <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -373,18 +360,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -117,7 +117,7 @@
         <!-- Imports -->
         <module name="AvoidStarImport"/>
         <module name="AvoidStaticImport">
-            <property name="excludes" value="org.junit.Assert.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*"/>
+            <property name="excludes" value="org.junit.jupiter.api.Assertions.*,org.junit.jupiter.api.Assumptions.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*"/>
         </module>
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>

--- a/src/main/resources/checkstyle_ci.xml
+++ b/src/main/resources/checkstyle_ci.xml
@@ -112,7 +112,7 @@
         <!-- Imports -->
         <module name="AvoidStarImport"/>
         <module name="AvoidStaticImport">
-            <property name="excludes" value="org.junit.Assert.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*"/>
+            <property name="excludes" value="org.junit.jupiter.api.Assertions.*,org.junit.jupiter.api.Assumptions.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*"/>
         </module>
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>
@@ -226,7 +226,7 @@
         
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
-            <property name="allowedAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass, Parameterized, Parameters"/>
+            <property name="allowedAnnotations" value="Override, Test, BeforeEach, AfterEach, BeforeAll, AfterAll, Parameterized, Parameters"/>
             <property name="ignoreMethodNamesRegex" value="^assert.*$|^verify.*$"/>
             <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
         </module>


### PR DESCRIPTION
For #2258.

Changes proposed in this pull request:
- Split from #2263.
- Migrate from Junit Vintage to Junit Jupiter.
- Some todos for Mockito were added to avoid the defects of the existing tests.
- Also for #2264 .