### PR TITLE
Update dependencies to avoid CVE

### DIFF
--- a/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/fixture/EmbedTestingServer.java
+++ b/elasticjob-cloud/elasticjob-cloud-scheduler/src/test/java/org/apache/shardingsphere/elasticjob/cloud/scheduler/fixture/EmbedTestingServer.java
@@ -19,43 +19,111 @@ package org.apache.shardingsphere.elasticjob.cloud.scheduler.fixture;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
+import org.apache.zookeeper.KeeperException;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public final class EmbedTestingServer {
     
     private static final int PORT = 10181;
-    
+
     private static volatile TestingServer testingServer;
-    
+
+    private static final Object INIT_LOCK = new Object();
+
     /**
-     * Start the embed server.
+     * Start embed zookeeper server.
      */
     public static void start() {
         if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
             return;
         }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
         try {
-            testingServer = new TestingServer(PORT, new File(String.format("target/test_zk_data/%s/", System.nanoTime())));
+            testingServer = new TestingServer(PORT, true);
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
         } finally {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
                     testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
+                } catch (final IOException ignored) {
                 }
+                log.info("Close embed zookeeper server done");
             }));
         }
     }
-    
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
+            client.start();
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
+        }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
     /**
      * Get the connection string.
      *

--- a/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/src/main/release-docs/LICENSE
+++ b/elasticjob-distribution/elasticjob-cloud-scheduler-distribution/src/main/release-docs/LICENSE
@@ -216,44 +216,44 @@ The following components are provided under the Apache License. See project link
 The text of each license is the standard Apache 2.0 license.
 
     audience-annotations 0.5.0: https://github.com/apache/yetus, Apache 2.0
-    commons-codec 1.10: https://github.com/apache/commons-codec, Apache 2.0
-    commons-dbcp2 2.9.0: https://github.com/apache/commons-dbcp, Apache 2.0
+    commons-codec 1.16.0: https://github.com/apache/commons-codec, Apache 2.0
+    commons-dbcp2 2.11.1: https://github.com/apache/commons-dbcp, Apache 2.0
     commons-exec 1.3: http://commons.apache.org/proper/commons-exec, Apache 2.0
     commons-lang 2.6: https://github.com/apache/commons-lang, Apache 2.0
     commons-lang3 3.4: https://github.com/apache/commons-lang, Apache 2.0
     commons-logging 1.2: https://github.com/apache/commons-logging, Apache 2.0
     commons-pool2 2.8.1: https://github.com/apache/commons-pool, Apache 2.0
-    curator-client 5.1.0: https://github.com/apache/curator,  Apache 2.0
-    curator-framework 5.1.0: https://github.com/apache/curator,  Apache 2.0
-    curator-recipes 5.1.0: https://github.com/apache/curator,  Apache 2.0
+    curator-client 5.5.0: https://github.com/apache/curator,  Apache 2.0
+    curator-framework 5.5.0: https://github.com/apache/curator,  Apache 2.0
+    curator-recipes 5.5.0: https://github.com/apache/curator,  Apache 2.0
     error_prone_annotations 2.3.4: https://github.com/google/error-prone, Apache 2.0
     failureaccess 1.0.1:https://github.com/google/guava, Apache 2.0 
-    fenzo-core 0.11.1: https://github.com/Netflix/Fenzo, Apache 2.0
-    gson 2.6.1: https://github.com/google/gson, Apache 2.0
-    guava 29.0-jre: https://github.com/google/guava, Apache 2.0
+    fenzo-core 1.0.1: https://github.com/Netflix/Fenzo, Apache 2.0
+    gson 2.10.1: https://github.com/google/gson, Apache 2.0
+    guava 30.0-jre: https://github.com/google/guava, Apache 2.0
     HikariCP-java7 2.4.13: https://github.com/brettwooldridge/HikariCP, Apache 2.0
-    httpclient 4.5.13: https://github.com/apache/httpcomponents-client, Apache 2.0
-    httpcore 4.4.13: https://github.com/apache/httpcomponents-core, Apache 2.0
+    httpclient 4.5.14: https://github.com/apache/httpcomponents-client, Apache 2.0
+    httpcore 4.4.16: https://github.com/apache/httpcomponents-core, Apache 2.0
     jackson-annotations 2.4.0: https://github.com/FasterXML/jackson-annotations, Apache 2.0
     jackson-core 2.4.5: https://github.com/FasterXML/jackson-core, Apache 2.0
     jackson-databind 2.4.5: https://github.com/FasterXML/jackson-core, Apache 2.0
     listenablefuture 9999.0-empty-to-avoid-conflict-with-guava:https://github.com/google/guava, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
-    log4j-over-slf4j 1.7.7: https://github.com/qos-ch/slf4j, Apache 2.0
-    mesos 1.1.0: http://mesos.apache.org/, Apache 2.0
-    netty-buffer 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.45.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.45.Final: https://github.com/netty, Apache 2.0
+    log4j-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
+    mesos 1.11.0: http://mesos.apache.org/, Apache 2.0
+    netty-buffer 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.97.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.97.Final: https://github.com/netty, Apache 2.0
     quartz 2.3.2: https://github.com/quartz-scheduler/quartz, Apache 2.0
-    snakeyaml 1.26: http://www.snakeyaml.org, Apache 2.0
-    zookeeper 3.6.0: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.6.0: https://github.com/apache/zookeeper, Apache 2.0
+    snakeyaml 2.0: https://bitbucket.org/snakeyaml/snakeyaml/src, Apache 2.0
+    zookeeper 3.9.0: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.9.0: https://github.com/apache/zookeeper, Apache 2.0
 
 ========================================================================
 EPL licenses
@@ -264,8 +264,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
     jakarta.annotation-api 1.3.5: https://github.com/eclipse-ee4j/common-annotations-api, EPL 2.0
     jakarta.el 3.0.3: https://github.com/eclipse-ee4j/el-ri, EPL 2.0
-    logback-classic 1.2.3: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.2.3: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.2.12: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java/tree/mchange-commons-java-0.2.15, EPL 1.0
 
 ========================================================================
@@ -276,6 +276,6 @@ The following components are provided under the MIT License. See project link fo
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
     checker-qual 2.11.1: https://github.com/typetools/checker-framework, MIT
-    jcl-over-slf4j 1.7.7: https://github.com/qos-ch/slf4j, MIT
-    jul-to-slf4j 1.7.7: https://github.com/qos-ch/slf4j, MIT
-    slf4j-api 1.7.7: https://github.com/qos-ch/slf4j, MIT
+    jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, MIT
+    jul-to-slf4j 1.7.36: https://github.com/qos-ch/slf4j, MIT
+    slf4j-api 1.7.36: https://github.com/qos-ch/slf4j, MIT

--- a/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/fixture/EmbedTestingServer.java
+++ b/elasticjob-infra/elasticjob-registry-center/elasticjob-regitry-center-provider/elasticjob-registry-center-zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/fixture/EmbedTestingServer.java
@@ -19,19 +19,111 @@ package org.apache.shardingsphere.elasticjob.reg.zookeeper.fixture;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
+import org.apache.zookeeper.KeeperException;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EmbedTestingServer {
     
     private static final int PORT = 9181;
-    
+
     private static volatile TestingServer testingServer;
-    
+
+    private static final Object INIT_LOCK = new Object();
+
+    /**
+     * Start embed zookeeper server.
+     */
+    public static void start() {
+        if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
+            return;
+        }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
+        try {
+            testingServer = new TestingServer(PORT, true);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
+        } finally {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    testingServer.close();
+                } catch (final IOException ignored) {
+                }
+                log.info("Close embed zookeeper server done");
+            }));
+        }
+    }
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
+            client.start();
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
+        }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
     /**
      * Get the connection string.
      *
@@ -39,30 +131,6 @@ public final class EmbedTestingServer {
      */
     public static String getConnectionString() {
         return "localhost:" + PORT;
-    }
-    
-    /**
-     * Start the server.
-     */
-    public static void start() {
-        if (null != testingServer) {
-            return;
-        }
-        try {
-            testingServer = new TestingServer(PORT, new File(String.format("target/test_zk_data/%s/", System.nanoTime())));
-            // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
-            // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
-        } finally {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
-                }
-            }));
-        }
     }
 }
 

--- a/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerService.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/main/java/org/apache/shardingsphere/elasticjob/lite/internal/server/ServerService.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.internal.server;
 
 import com.google.common.base.Strings;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.elasticjob.lite.internal.instance.InstanceNode;
 import org.apache.shardingsphere.elasticjob.lite.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.lite.internal.storage.JobNodeStorage;

--- a/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/fixture/EmbedTestingServer.java
+++ b/elasticjob-lite/elasticjob-lite-core/src/test/java/org/apache/shardingsphere/elasticjob/lite/fixture/EmbedTestingServer.java
@@ -19,19 +19,111 @@ package org.apache.shardingsphere.elasticjob.lite.fixture;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
+import org.apache.zookeeper.KeeperException;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public final class EmbedTestingServer {
     
     private static final int PORT = 7181;
-    
+
     private static volatile TestingServer testingServer;
-    
+
+    private static final Object INIT_LOCK = new Object();
+
+    /**
+     * Start embed zookeeper server.
+     */
+    public static void start() {
+        if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
+            return;
+        }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
+        try {
+            testingServer = new TestingServer(PORT, true);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
+        } finally {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    testingServer.close();
+                } catch (final IOException ignored) {
+                }
+                log.info("Close embed zookeeper server done");
+            }));
+        }
+    }
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
+            client.start();
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
+        }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
     /**
      * Get the connection string.
      *
@@ -40,29 +132,4 @@ public final class EmbedTestingServer {
     public static String getConnectionString() {
         return "localhost:" + PORT;
     }
-    
-    /**
-     * Start the server.
-     */
-    public static void start() {
-        if (null != testingServer) {
-            return;
-        }
-        try {
-            testingServer = new TestingServer(PORT, new File(String.format("target/test_zk_data/%s/", System.nanoTime())));
-            // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
-            // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
-        } finally {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
-                }
-            }));
-        }
-    }
 }
-

--- a/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/AbstractEmbedZookeeperBaseTest.java
+++ b/elasticjob-lite/elasticjob-lite-lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lite/lifecycle/AbstractEmbedZookeeperBaseTest.java
@@ -17,45 +17,116 @@
 
 package org.apache.shardingsphere.elasticjob.lite.lifecycle;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
+import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.BeforeAll;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 public abstract class AbstractEmbedZookeeperBaseTest {
-    
+
     private static final int PORT = 8181;
-    
+
     private static volatile TestingServer testingServer;
-    
+
+    private static final Object INIT_LOCK = new Object();
+
     @BeforeAll
     public static void setUp() {
         startEmbedTestingServer();
     }
-    
+
+    /**
+     * Start embed zookeeper server.
+     */
     private static void startEmbedTestingServer() {
         if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
             return;
         }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
         try {
-            testingServer = new TestingServer(PORT, new File(String.format("target/test_zk_data/%s/", System.nanoTime())));
+            testingServer = new TestingServer(PORT, true);
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
         } finally {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
                     testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
+                } catch (final IOException ignored) {
                 }
+                log.info("Close embed zookeeper server done");
             }));
         }
     }
-    
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
+            client.start();
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
+        }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
     /**
      * Get the connection string.
      *

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/EmbedTestingServer.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/boot/job/fixture/EmbedTestingServer.java
@@ -19,25 +19,111 @@ package org.apache.shardingsphere.elasticjob.lite.spring.boot.job.fixture;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.curator.CuratorZookeeperClient;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
-import org.awaitility.Awaitility;
-import org.hamcrest.Matchers;
+import org.apache.zookeeper.KeeperException;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public final class EmbedTestingServer {
-    
+
     private static final int PORT = 18181;
-    
+
     private static volatile TestingServer testingServer;
-    
+
+    private static final Object INIT_LOCK = new Object();
+
+    /**
+     * Start embed zookeeper server.
+     */
+    public static void start() {
+        if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
+            return;
+        }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
+        try {
+            testingServer = new TestingServer(PORT, true);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
+        } finally {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    testingServer.close();
+                } catch (final IOException ignored) {
+                }
+                log.info("Close embed zookeeper server done");
+            }));
+        }
+    }
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
+            client.start();
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
+        }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
     /**
      * Get the connection string.
      *
@@ -45,42 +131,5 @@ public final class EmbedTestingServer {
      */
     public static String getConnectionString() {
         return "localhost:" + PORT;
-    }
-    
-    /**
-     * Start the server.
-     */
-    public static void start() {
-        if (null != testingServer) {
-            return;
-        }
-        try {
-            testingServer = new TestingServer(PORT, true);
-            // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
-            // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
-        } finally {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
-                }
-            }));
-        }
-        try (CuratorZookeeperClient client = new CuratorZookeeperClient(getConnectionString(),
-                60 * 1000, 500, null,
-                new ExponentialBackoffRetry(500, 3, 500 * 3))) {
-            client.start();
-            Awaitility.await()
-                    .atLeast(100L, TimeUnit.MILLISECONDS)
-                    .atMost(500 * 60L, TimeUnit.MILLISECONDS)
-                    .untilAsserted(() -> assertThat(client.isConnected(), Matchers.is(true)));
-            // CHECKSTYLE:OFF
-        } catch (Exception e) {
-            // CHECKSTYLE:ON
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/EmbedZookeeperTestExecutionListener.java
+++ b/elasticjob-lite/elasticjob-lite-spring/elasticjob-lite-spring-namespace/src/test/java/org/apache/shardingsphere/elasticjob/lite/spring/namespace/test/EmbedZookeeperTestExecutionListener.java
@@ -17,60 +17,126 @@
 
 package org.apache.shardingsphere.elasticjob.lite.spring.namespace.test;
 
-import org.apache.curator.CuratorZookeeperClient;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler;
-import org.awaitility.Awaitility;
-import org.hamcrest.Matchers;
+import org.apache.zookeeper.KeeperException;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
 public final class EmbedZookeeperTestExecutionListener extends AbstractTestExecutionListener {
-    
+
+    private static final int PORT = 3181;
+
     private static volatile TestingServer testingServer;
+
+    private static final Object INIT_LOCK = new Object();
     
     @Override
     public void beforeTestClass(final TestContext testContext) {
         startEmbedTestingServer();
     }
 
+    /**
+     * Start embed zookeeper server.
+     */
     private static void startEmbedTestingServer() {
         if (null != testingServer) {
+            log.info("Embed zookeeper server already exists 1, on {}", testingServer.getConnectString());
             return;
         }
+        log.info("Starting embed zookeeper server...");
+        synchronized (INIT_LOCK) {
+            if (null != testingServer) {
+                log.info("Embed zookeeper server already exists 2, on {}", testingServer.getConnectString());
+                return;
+            }
+            start0();
+            waitTestingServerReady();
+        }
+    }
+
+    private static void start0() {
         try {
-            testingServer = new TestingServer(3181, true);
+            testingServer = new TestingServer(PORT, true);
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
-            RegExceptionHandler.handleException(ex);
+            if (!isIgnoredException(ex)) {
+                throw new RuntimeException(ex);
+            } else {
+                log.warn("Start embed zookeeper server got exception: {}", ex.getMessage());
+            }
         } finally {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 try {
                     testingServer.close();
-                } catch (final IOException ex) {
-                    RegExceptionHandler.handleException(ex);
+                } catch (final IOException ignored) {
                 }
+                log.info("Close embed zookeeper server done");
             }));
         }
-        try (CuratorZookeeperClient client = new CuratorZookeeperClient(testingServer.getConnectString(),
-                60 * 1000, 500, null,
-                new ExponentialBackoffRetry(500, 3, 500 * 3))) {
+    }
+
+    private static void waitTestingServerReady() {
+        int maxRetries = 60;
+        try (CuratorFramework client = buildCuratorClient()) {
             client.start();
-            Awaitility.await()
-                    .atLeast(100L, TimeUnit.MILLISECONDS)
-                    .atMost(500 * 60L, TimeUnit.MILLISECONDS)
-                    .untilAsserted(() -> assertThat(client.isConnected(), Matchers.is(true)));
-            // CHECKSTYLE:OFF
-        } catch (Exception e) {
-            // CHECKSTYLE:ON
-            throw new RuntimeException(e);
+            int round = 0;
+            while (round < maxRetries) {
+                try {
+                    if (client.getZookeeperClient().isConnected()) {
+                        log.info("client is connected");
+                        break;
+                    }
+                    if (client.blockUntilConnected(500, TimeUnit.MILLISECONDS)) {
+                        CuratorFrameworkState state = client.getState();
+                        Collection<String> childrenKeys = client.getChildren().forPath("/");
+                        log.info("TestingServer connected, state={}, childrenKeys={}", state, childrenKeys);
+                        break;
+                    }
+                    // CHECKSTYLE:OFF
+                } catch (final Exception ignored) {
+                    // CHECKSTYLE:ON
+                }
+                ++round;
+            }
         }
+    }
+
+    private static CuratorFramework buildCuratorClient() {
+        CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
+        int retryIntervalMilliseconds = 500;
+        int maxRetries = 3;
+        builder.connectString(getConnectionString())
+                .retryPolicy(new ExponentialBackoffRetry(retryIntervalMilliseconds, maxRetries, retryIntervalMilliseconds * maxRetries))
+                .namespace("test");
+        builder.sessionTimeoutMs(60 * 1000);
+        builder.connectionTimeoutMs(500);
+        return builder.build();
+    }
+
+    private static boolean isIgnoredException(final Throwable cause) {
+        return cause instanceof KeeperException.ConnectionLossException || cause instanceof KeeperException.NoNodeException || cause instanceof KeeperException.NodeExistsException;
+    }
+
+    /**
+     * Get the connection string.
+     *
+     * @return connection string
+     */
+    public static String getConnectionString() {
+        return "localhost:" + PORT;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,26 +46,27 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.locale>zh_CN</project.build.locale>
         
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <quartz.version>2.3.2</quartz.version>
-        <curator.version>5.1.0</curator.version>
+        <zookeeper.version>3.9.0</zookeeper.version>
+        <curator.version>5.5.0</curator.version>
         <lombok.version>1.18.24</lombok.version>
         <aspectj.version>1.9.1</aspectj.version>
-        <slf4j.version>1.7.7</slf4j.version>
-        <logback.version>1.2.3</logback.version>
-        <commons-codec.version>1.10</commons-codec.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <logback.version>1.2.12</logback.version>
+        <commons-codec.version>1.16.0</commons-codec.version>
         <commons-exec.version>1.3</commons-exec.version>
-        <httpclient.version>4.5.13</httpclient.version>
-        <httpcore.version>4.4.13</httpcore.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <gson.version>2.6.1</gson.version>
-        <netty.version>4.1.59.Final</netty.version>
-        <mesos.version>1.1.0</mesos.version>
-        <fenzo.version>0.11.1</fenzo.version>
-        
-        <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
-        <commons-pool2.version>2.8.1</commons-pool2.version>
+        <gson.version>2.10.1</gson.version>
+        <netty.version>4.1.97.Final</netty.version>
+        <mesos.version>1.11.0</mesos.version>
+        <fenzo.version>1.0.1</fenzo.version>
+
+        <commons-dbcp2.version>2.10.0</commons-dbcp2.version>
+        <commons-pool2.version>2.11.1</commons-pool2.version>
         <hikaricp.version>3.4.2</hikaricp.version>
         <mail.version>1.6.0</mail.version>
         
@@ -227,46 +228,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
             
             <dependency>
                 <groupId>org.apache.mesos</groupId>
@@ -319,24 +280,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjweaver</artifactId>
                 <version>${aspectj.version}</version>
@@ -354,6 +297,24 @@
                 <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
For #2258.

Changes proposed in this pull request:

- Update Netty to 4.1.97.Final. 
    - Fixes #2256. 
    - Fixes #2234.

- Update Mesos Client to 1.11.0 and update Fenzo to 1.0.1.
    - Fixes #1750.
    - The Fenzo project has been archived, maybe we should consider changing to a mesos client. Refer to https://github.com/Netflix/Fenzo .

- Update Guava to 30.0-jre. 
    - Synchronize with https://github.com/apache/shardingsphere/blob/master/pom.xml .
    - Fixes #2232.

- Update Zookeeper Client to 3.9.0 and update Curator to 5.5.0.
    -  Split from #2263.
    - Avoid ZOOKEEPER-4460 to break the GraalVM Native Image build. Refer to https://github.com/oracle/graalvm-reachability-metadata/issues/163#issuecomment-1373872491 .

- Update Slf4j to 1.7.36 and update logback to 1.2.12.
     - Synchronize GraalVM Reachability Metadata from https://github.com/oracle/graalvm-reachability-metadata/tree/883199aa0a6212942f95ee2150f552d438eb8e14/metadata/ch.qos.logback/logback-classic . 

- Update Apache Commons dependency to avoid CVE.
    - Fixes #2158 . 
- Update Gson to 2.10.1 to avoid CVE.
