### PR TITLE
Relax the conditions for unit tests involving awaitility to fix CI

### DIFF
--- a/core/src/test/java/org/apache/shardingsphere/elasticjob/engine/integrate/disable/DisabledJobIntegrateTest.java
+++ b/core/src/test/java/org/apache/shardingsphere/elasticjob/engine/integrate/disable/DisabledJobIntegrateTest.java
@@ -42,7 +42,7 @@ public abstract class DisabledJobIntegrateTest extends BaseIntegrateTest {
     }
     
     protected final void assertDisabledRegCenterInfo() {
-        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> {
+        Awaitility.await().atLeast(1L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> {
             assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
             assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));
         });

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/engine/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/engine/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -52,6 +52,6 @@ class OneOffJobSpringNamespaceWithTypeTest extends AbstractZookeeperJUnitJupiter
     void jobScriptWithJobTypeTest() {
         OneOffJobBootstrap bootstrap = applicationContext.getBean(scriptJobName, OneOffJobBootstrap.class);
         bootstrap.execute();
-        Awaitility.await().atLeast(100L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertTrue(regCenter.isExisted("/" + scriptJobName + "/sharding")));
+        Awaitility.await().atLeast(1L, TimeUnit.MILLISECONDS).atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertTrue(regCenter.isExisted("/" + scriptJobName + "/sharding")));
     }
 }

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/engine/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/engine/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractJobSpringIntegrateTest extends AbstractZookeeperJU
     }
     
     private void assertSimpleElasticJobBean() {
-        Awaitility.await().atMost(5L, TimeUnit.SECONDS).untilAsserted(() -> assertThat(AnnotationSimpleJob.isCompleted(), is(true)));
+        Awaitility.await().atMost(10L, TimeUnit.SECONDS).untilAsserted(() -> assertThat(AnnotationSimpleJob.isCompleted(), is(true)));
         assertTrue(AnnotationSimpleJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }


### PR DESCRIPTION
For #2258 and #2278.

Changes proposed in this pull request:
- Relax the conditions for unit tests involving awaitility to fix CI.
- Detached from #2268 .
