### PR TITLE
fix status badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ You are welcome to communicate with the community via the [mailing list](mailto:
 [![GitHub release](https://img.shields.io/github/release/apache/shardingsphere-elasticjob.svg)](https://github.com/apache/shardingsphere-elasticjob/releases)
 
 [![Maven Status](https://maven-badges.herokuapp.com/maven-central/org.apache.shardingsphere.elasticjob/elasticjob/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.shardingsphere.elasticjob/elasticjob)
-[![Build Status](https://secure.travis-ci.org/apache/shardingsphere-elasticjob.png?branch=master)](https://travis-ci.org/apache/shardingsphere-elasticjob)
-[![GitHub Workflow](https://img.shields.io/github/workflow/status/apache/shardingsphere-elasticjob/Java%20CI%20with%20Maven%20on%20macOS/master)](https://github.com/apache/shardingsphere-elasticjob/actions?query=workflow%3A%22Java+CI+with+Maven+on+macOS%22)
+[![Build Status](https://api.travis-ci.com/apache/shardingsphere-elasticjob.svg?branch=master)](https://travis-ci.org/apache/shardingsphere-elasticjob)
+[![GitHub Workflow](https://img.shields.io/github/actions/workflow/status/apache/shardingsphere-elasticjob/maven.yml?branch=master)](https://github.com/apache/shardingsphere-elasticjob/actions/workflows/maven.yml?query=branch%3Amaster)
 [![codecov](https://codecov.io/gh/apache/shardingsphere-elasticjob/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/shardingsphere-elasticjob)
 [![Maintainability](https://cloud.quality-gate.com/dashboard/api/badge?projectName=apache_shardingsphere-elasticjob&branchName=master)](https://cloud.quality-gate.com/dashboard/branches/396041#overview)
 


### PR DESCRIPTION
See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main