### PR TITLE
fix #2014, autowire OneOffJobBootstrap failed.

### DIFF
--- a/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/job/ElasticJobBootstrapConfiguration.java
+++ b/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/job/ElasticJobBootstrapConfiguration.java
@@ -25,12 +25,14 @@ import org.apache.shardingsphere.elasticjob.api.ElasticJob;
 import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
 import org.apache.shardingsphere.elasticjob.kernel.api.bootstrap.impl.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.kernel.api.bootstrap.impl.ScheduleJobBootstrap;
-import org.apache.shardingsphere.elasticjob.spring.boot.tracing.TracingProperties;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.boot.tracing.TracingProperties;
 import org.apache.shardingsphere.elasticjob.tracing.api.TracingConfiguration;
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
+import org.springframework.beans.factory.support.MergedBeanDefinitionPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,13 +43,13 @@ import java.util.Map;
  * JobBootstrap configuration.
  */
 @Slf4j
-public class ElasticJobBootstrapConfiguration implements SmartInitializingSingleton, ApplicationContextAware {
+public class ElasticJobBootstrapConfiguration implements MergedBeanDefinitionPostProcessor, ApplicationContextAware, InitializingBean {
     
     @Setter
     private ApplicationContext applicationContext;
-    
+
     @Override
-    public void afterSingletonsInstantiated() {
+    public void afterPropertiesSet() throws Exception {
         log.info("creating Job Bootstrap Beans");
         createJobBootstrapBeans();
         log.info("Job Bootstrap Beans created.");
@@ -133,5 +135,11 @@ public class ElasticJobBootstrapConfiguration implements SmartInitializingSingle
                 && !tracingProperties.getExcludeJobNames().contains(jobConfig.getJobName())) {
             jobConfig.getExtraConfigurations().add(tracingConfig);
         }
+    }
+
+
+    @Override
+    public void postProcessMergedBeanDefinition(RootBeanDefinition beanDefinition, Class<?> beanType, String beanName) {
+        // do nothing, in purpose to initialize bean
     }
 }


### PR DESCRIPTION
Fixes   
[#2014](https://github.com/apache/shardingsphere-elasticjob/issues/2014)

Changes proposed in this pull request:
- **ElasticJobBootstrapConfiguration**

cause of issue:
the bean which is registered in method afterSingletonsInstantiated  can't be autowired, because autowire is earlier than afterSingletonsInstantiated  which is executed by AutowiredAnnotationBeanPostProcessor.

solution:
OneOffBootStrap need to be registered before autowire phase, and AutowiredAnnotationBeanPostProcessor is a MergedBeanDefinitionPostProcessor bean, so ElasticJobBootstrapConfiguration need to be a MergedBeanDefinitionPostProcessor bean too, and OneOffBootStrap should be registered after ElasticJobBootstrapConfiguration initialized immediately.