### PR TITLE
move zkRegCenter.init() and zkRegCenter.close() to @BeforeAll and @AfterAll to make tests run faster and look similar to other tests

### DIFF
--- a/bootstrap/src/test/java/org/apache/shardingsphere/elasticjob/bootstrap/type/OneOffJobBootstrapTest.java
+++ b/bootstrap/src/test/java/org/apache/shardingsphere/elasticjob/bootstrap/type/OneOffJobBootstrapTest.java
@@ -25,9 +25,8 @@ import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
 import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.apache.shardingsphere.elasticjob.test.util.ReflectionUtils;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -48,21 +47,17 @@ class OneOffJobBootstrapTest {
     
     private static final int SHARDING_TOTAL_COUNT = 3;
     
-    private ZookeeperRegistryCenter zkRegCenter;
+    private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void init() {
         EMBED_TESTING_SERVER.start();
-    }
-    
-    @BeforeEach
-    void setUp() {
         zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
         zkRegCenter.init();
     }
     
-    @AfterEach
-    void tearDown() {
+    @AfterAll
+    static void tearDown() {
         zkRegCenter.close();
     }
     


### PR DESCRIPTION
Changes proposed in this pull request:
- put `zkRegCenter.init();` and `zkRegCenter.close();` into the method body of `@BeforeAll` and `@AfterAll`. There are three tests in the test class `OneOffJobBootstrapTest`. However, these three tests are justing trying to use `zkRegCenter` to initialize some objects and they are not modifying `zkRegCenter`. 
- Besides, we searched for all the tests which contain `zkRegCenter.init();` and `zkRegCenter.close();`. All tests in the project `apache/shardingsphere-elasticjob` except `OneOffJobBootstrapTest` put `zkRegCenter.init();` and `zkRegCenter.close();` into the method body of `@BeforeAll` and `@AfterAll`.
- The test runtime can jump from `3.489 s` to `2.403 s` after applying the changes when run on our machine.
