### PR TITLE
fix: Tracing is incompatible with Spring Boot 3.2.x #2401

### DIFF
--- a/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/tracing/ElasticJobTracingConfiguration.java
+++ b/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/tracing/ElasticJobTracingConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.spring.boot.tracing;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.elasticjob.kernel.tracing.config.TracingConfiguration;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -68,7 +69,8 @@ public class ElasticJobTracingConfiguration {
          */
         @Bean
         @ConditionalOnBean(DataSource.class)
-        public TracingConfiguration<DataSource> tracingConfiguration(final DataSource dataSource, @Nullable final DataSource tracingDataSource) {
+        public TracingConfiguration<DataSource> tracingConfiguration(@Qualifier("dataSource") DataSource dataSource,
+                                                                     @Qualifier("tracingDataSource") @Nullable final DataSource tracingDataSource) {
             return new TracingConfiguration<>("RDB", null == tracingDataSource ? dataSource : tracingDataSource);
         }
     }

--- a/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/tracing/ElasticJobTracingConfiguration.java
+++ b/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/tracing/ElasticJobTracingConfiguration.java
@@ -69,7 +69,7 @@ public class ElasticJobTracingConfiguration {
          */
         @Bean
         @ConditionalOnBean(DataSource.class)
-        public TracingConfiguration<DataSource> tracingConfiguration(@Qualifier("dataSource") DataSource dataSource,
+        public TracingConfiguration<DataSource> tracingConfiguration(@Qualifier("dataSource") final DataSource dataSource,
                                                                      @Qualifier("tracingDataSource") @Nullable final DataSource tracingDataSource) {
             return new TracingConfiguration<>("RDB", null == tracingDataSource ? dataSource : tracingDataSource);
         }


### PR DESCRIPTION
Fixes #2401.

Changes proposed in this pull request:
-
-
-
I have tested this patch in Spring Boot 3.2.2 and it works, but I'm sorry that I can't write any test cases in the project because the test framework is based on Spring Boot 2, this issue is only effect Spring Boot 3.2+