### PR TITLE
Migrate the JDK used by CI from Temurin to Zulu

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Build with Maven in Windows
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
For #2405.

Changes proposed in this pull request:
- Migrate the JDK used by CI from Temurin to Zulu. This is actually a copy of https://github.com/apache/shardingsphere/issues/31144. According to https://github.com/actions/setup-java/issues/625 and https://github.com/adoptium/adoptium/issues/96, OpenJDK 8u does not provide builds for arm64 on MacOS.
