### PR TITLE
Prevent unit tests and E2E from using host ports `1`, `2181`, `7181`, `8181`, `8899`, `9000`, `9181`, `9872` and `9875`

### DIFF
--- a/bootstrap/src/test/java/org/apache/shardingsphere/elasticjob/bootstrap/type/OneOffJobBootstrapTest.java
+++ b/bootstrap/src/test/java/org/apache/shardingsphere/elasticjob/bootstrap/type/OneOffJobBootstrapTest.java
@@ -41,9 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OneOffJobBootstrapTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(7181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), OneOffJobBootstrapTest.class.getSimpleName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static final int SHARDING_TOTAL_COUNT = 3;
     
@@ -52,7 +50,8 @@ class OneOffJobBootstrapTest {
     @BeforeAll
     static void init() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), OneOffJobBootstrapTest.class.getSimpleName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
         zkRegCenter.init();
     }
     

--- a/ecosystem/error-handler/dingtalk/pom.xml
+++ b/ecosystem/error-handler/dingtalk/pom.xml
@@ -46,5 +46,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ecosystem/error-handler/dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerTest.java
+++ b/ecosystem/error-handler/dingtalk/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/dingtalk/DingtalkJobErrorHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.error.handler.dingtalk;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.elasticjob.error.handler.dingtalk.fixture.DingtalkInternalController;
 import org.apache.shardingsphere.elasticjob.spi.executor.error.handler.JobErrorHandler;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
@@ -40,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class DingtalkJobErrorHandlerTest {
     
-    private static final int PORT = 9875;
+    private static final int PORT = InstanceSpec.getRandomPort();
     
     private static final String HOST = "localhost";
     
@@ -75,7 +76,7 @@ class DingtalkJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithNotifySuccessful() {
-        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:9875/send?access_token=mocked_token"));
+        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/send?access_token=mocked_token"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));
@@ -85,7 +86,7 @@ class DingtalkJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithWrongToken() {
-        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:9875/send?access_token=wrong_token"));
+        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/send?access_token=wrong_token"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));
@@ -95,7 +96,7 @@ class DingtalkJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithUrlIsNotFound() {
-        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:9875/404"));
+        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/404"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));
@@ -115,7 +116,7 @@ class DingtalkJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithNoSign() {
-        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createNoSignJobConfigurationProperties("http://localhost:9875/send?access_token=mocked_token"));
+        DingtalkJobErrorHandler actual = getDingtalkJobErrorHandler(createNoSignJobConfigurationProperties("http://localhost:" + PORT + "/send?access_token=mocked_token"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));

--- a/ecosystem/error-handler/wechat/pom.xml
+++ b/ecosystem/error-handler/wechat/pom.xml
@@ -46,5 +46,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ecosystem/error-handler/wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
+++ b/ecosystem/error-handler/wechat/src/test/java/org/apache/shardingsphere/elasticjob/error/handler/wechat/WechatJobErrorHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.elasticjob.error.handler.wechat;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.elasticjob.error.handler.wechat.fixture.WechatInternalController;
 import org.apache.shardingsphere.elasticjob.spi.executor.error.handler.JobErrorHandler;
 import org.apache.shardingsphere.elasticjob.restful.NettyRestfulService;
@@ -40,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class WechatJobErrorHandlerTest {
     
-    private static final int PORT = 9872;
+    private static final int PORT = InstanceSpec.getRandomPort();
     
     private static final String HOST = "localhost";
     
@@ -75,7 +76,7 @@ class WechatJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithNotifySuccessful() {
-        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:9872/send?key=mocked_key"));
+        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/send?key=mocked_key"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));
@@ -85,7 +86,7 @@ class WechatJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithWrongToken() {
-        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:9872/send?key=wrong_key"));
+        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/send?key=wrong_key"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));
@@ -105,7 +106,7 @@ class WechatJobErrorHandlerTest {
     
     @Test
     void assertHandleExceptionWithUrlIsNotFound() {
-        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:9872/404"));
+        WechatJobErrorHandler actual = getWechatJobErrorHandler(createConfigurationProperties("http://localhost:" + PORT + "/404"));
         Throwable cause = new RuntimeException("test");
         actual.handleException("test_job", cause);
         assertThat(appenderList.size(), is(1));

--- a/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/api/JobAPIFactoryTest.java
+++ b/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/api/JobAPIFactoryTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class JobAPIFactoryTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(8181);
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     @BeforeAll
     static void setUp() {

--- a/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/operate/JobOperateAPIImplTest.java
+++ b/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/operate/JobOperateAPIImplTest.java
@@ -36,8 +36,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class JobOperateAPIImplTest {
     
-    static final int DUMP_PORT = 9000;
-    
     private JobOperateAPI jobOperateAPI;
     
     // TODO We should not use `Mock.Strictness.LENIENT` here, but the default. This is a flaw in the unit test design.

--- a/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/reg/RegistryCenterFactoryTest.java
+++ b/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/reg/RegistryCenterFactoryTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class RegistryCenterFactoryTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(8181);
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     @BeforeAll
     static void setUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <quartz.version>2.3.2</quartz.version>
         
         <zookeeper.version>3.9.2</zookeeper.version>
-        <curator.version>5.5.0</curator.version>
+        <curator.version>5.7.0</curator.version>
         
         <mail.version>1.6.0</mail.version>
         <commons-codec.version>1.16.0</commons-codec.version>

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfigurationTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfigurationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
+import org.apache.curator.test.InstanceSpec;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -26,8 +27,9 @@ class ZookeeperConfigurationTest {
     
     @Test
     void assertNewZookeeperConfigurationForServerListsAndNamespace() {
-        ZookeeperConfiguration zkConfig = new ZookeeperConfiguration("localhost:2181", "myNamespace");
-        assertThat(zkConfig.getServerLists(), is("localhost:2181"));
+        int randomPort = InstanceSpec.getRandomPort();
+        ZookeeperConfiguration zkConfig = new ZookeeperConfiguration("localhost:" + randomPort, "myNamespace");
+        assertThat(zkConfig.getServerLists(), is("localhost:" + randomPort));
         assertThat(zkConfig.getNamespace(), is("myNamespace"));
         assertThat(zkConfig.getBaseSleepTimeMilliseconds(), is(1000));
         assertThat(zkConfig.getMaxSleepTimeMilliseconds(), is(3000));

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperElectionServiceTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperElectionServiceTest.java
@@ -21,6 +21,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.KillSession;
 import org.apache.shardingsphere.elasticjob.reg.base.ElectionCandidate;
 import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
@@ -43,9 +44,11 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class ZookeeperElectionServiceTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
-    private static final String HOST_AND_PORT = "localhost:8899";
+    private static final int RANDOM_PORT = InstanceSpec.getRandomPort();
+    
+    private static final String HOST_AND_PORT = "localhost:" + RANDOM_PORT;
     
     private static final String ELECTION_PATH = "/election";
     
@@ -66,7 +69,7 @@ class ZookeeperElectionServiceTest {
         service.start();
         ElectionCandidate anotherElectionCandidate = mock(ElectionCandidate.class);
         CuratorFramework anotherClient = CuratorFrameworkFactory.newClient(EMBED_TESTING_SERVER.getConnectionString(), new RetryOneTime(2000));
-        ZookeeperElectionService anotherService = new ZookeeperElectionService("ANOTHER_CLIENT:8899", anotherClient, ELECTION_PATH, anotherElectionCandidate);
+        ZookeeperElectionService anotherService = new ZookeeperElectionService("ANOTHER_CLIENT:" + RANDOM_PORT, anotherClient, ELECTION_PATH, anotherElectionCandidate);
         anotherClient.start();
         anotherClient.blockUntilConnected();
         anotherService.start();

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterExecuteInLeaderTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterExecuteInLeaderTest.java
@@ -33,18 +33,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class ZookeeperRegistryCenterExecuteInLeaderTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
-            new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterExecuteInLeaderTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterExecuteInLeaderTest.class.getName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
     }
     

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterForAuthTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterForAuthTest.java
@@ -33,21 +33,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ZookeeperRegistryCenterForAuthTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static final String NAME_SPACE = ZookeeperRegistryCenterForAuthTest.class.getName();
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), NAME_SPACE);
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        ZOOKEEPER_CONFIGURATION.setDigest("digest:password");
-        ZOOKEEPER_CONFIGURATION.setSessionTimeoutMilliseconds(5000);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(5000);
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), NAME_SPACE);
+        zookeeperConfiguration.setDigest("digest:password");
+        zookeeperConfiguration.setSessionTimeoutMilliseconds(5000);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(5000);
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
         zkRegCenter.init();
         RegistryCenterEnvironmentPreparer.persist(zkRegCenter);
     }

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterInitFailureTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterInitFailureTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.reg.zookeeper;
 
+import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.elasticjob.reg.exception.RegException;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,8 @@ class ZookeeperRegistryCenterInitFailureTest {
     @Test
     void assertInitFailure() {
         assertThrows(RegException.class, () -> {
-            ZookeeperRegistryCenter zkRegCenter = new ZookeeperRegistryCenter(new ZookeeperConfiguration("localhost:1", ZookeeperRegistryCenterInitFailureTest.class.getName()));
+            ZookeeperRegistryCenter zkRegCenter =
+                    new ZookeeperRegistryCenter(new ZookeeperConfiguration("localhost:" + InstanceSpec.getRandomPort(), ZookeeperRegistryCenterInitFailureTest.class.getName()));
             zkRegCenter.init();
         });
     }

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterMiscellaneousTest.java
@@ -30,18 +30,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class ZookeeperRegistryCenterMiscellaneousTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
-            new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterMiscellaneousTest.class.getName());
+    private static ZookeeperConfiguration zookeeperConfiguration;
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
+        zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterMiscellaneousTest.class.getName());
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
         zkRegCenter.init();
         zkRegCenter.addCacheData("/test");
     }
@@ -64,7 +64,7 @@ class ZookeeperRegistryCenterMiscellaneousTest {
     
     @Test
     void assertGetZkConfig() {
-        ZookeeperRegistryCenter zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        assertThat(zkRegCenter.getZkConfig(), is(ZOOKEEPER_CONFIGURATION));
+        ZookeeperRegistryCenter zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        assertThat(zkRegCenter.getZkConfig(), is(zookeeperConfiguration));
     }
 }

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterModifyTest.java
@@ -37,17 +37,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZookeeperRegistryCenterModifyTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterModifyTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterModifyTest.class.getName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
         RegistryCenterEnvironmentPreparer.persist(zkRegCenter);
     }

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithCacheTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithCacheTest.java
@@ -29,18 +29,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ZookeeperRegistryCenterQueryWithCacheTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
-            new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterQueryWithCacheTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterQueryWithCacheTest.class.getName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
         RegistryCenterEnvironmentPreparer.persist(zkRegCenter);
         zkRegCenter.addCacheData("/test");

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithoutCacheTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterQueryWithoutCacheTest.java
@@ -34,18 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZookeeperRegistryCenterQueryWithoutCacheTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
-            new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterQueryWithoutCacheTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterQueryWithoutCacheTest.class.getName());
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
         zkRegCenter.init();
         RegistryCenterEnvironmentPreparer.persist(zkRegCenter);
         zkRegCenter.addCacheData("/other");

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterTransactionTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterTransactionTest.java
@@ -34,18 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ZookeeperRegistryCenterTransactionTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION =
-            new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterTransactionTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterTransactionTest.class.getName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
     }
     

--- a/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterWatchTest.java
+++ b/registry-center/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenterWatchTest.java
@@ -37,17 +37,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class ZookeeperRegistryCenterWatchTest {
     
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(9181);
-    
-    private static final ZookeeperConfiguration ZOOKEEPER_CONFIGURATION = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterWatchTest.class.getName());
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
     
     private static ZookeeperRegistryCenter zkRegCenter;
     
     @BeforeAll
     static void setUp() {
         EMBED_TESTING_SERVER.start();
-        zkRegCenter = new ZookeeperRegistryCenter(ZOOKEEPER_CONFIGURATION);
-        ZOOKEEPER_CONFIGURATION.setConnectionTimeoutMilliseconds(30000);
+        ZookeeperConfiguration zookeeperConfiguration = new ZookeeperConfiguration(EMBED_TESTING_SERVER.getConnectionString(), ZookeeperRegistryCenterWatchTest.class.getName());
+        zkRegCenter = new ZookeeperRegistryCenter(zookeeperConfiguration);
+        zookeeperConfiguration.setConnectionTimeoutMilliseconds(30000);
         zkRegCenter.init();
         RegistryCenterEnvironmentPreparer.persist(zkRegCenter);
     }

--- a/spring/boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/ZookeeperPropertiesTest.java
+++ b/spring/boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/ZookeeperPropertiesTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.spring.boot.reg;
 
+import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,7 @@ class ZookeeperPropertiesTest {
     @Test
     void assertToZookeeperConfiguration() {
         ZookeeperProperties properties = new ZookeeperProperties();
-        properties.setServerLists("localhost:18181");
+        properties.setServerLists("localhost:" + InstanceSpec.getRandomPort());
         properties.setNamespace("test");
         properties.setBaseSleepTimeMilliseconds(2000);
         properties.setMaxSleepTimeMilliseconds(4000);

--- a/spring/boot-starter/src/test/resources/application-elasticjob.yml
+++ b/spring/boot-starter/src/test/resources/application-elasticjob.yml
@@ -27,7 +27,7 @@ elasticjob:
     type: RDB
     excludeJobNames: [customTestJob]
   regCenter:
-    serverLists: localhost:18181
+    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter
   jobs:
     customTestJob:

--- a/spring/boot-starter/src/test/resources/application-snapshot.yml
+++ b/spring/boot-starter/src/test/resources/application-snapshot.yml
@@ -19,5 +19,5 @@ elasticjob:
   dump:
     port: 0
   regCenter:
-    serverLists: localhost:18181
+    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter

--- a/spring/boot-starter/src/test/resources/application-tracing.yml
+++ b/spring/boot-starter/src/test/resources/application-tracing.yml
@@ -17,5 +17,5 @@
 
 elasticjob:
   regCenter:
-    serverLists: localhost:18181
+    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter

--- a/spring/namespace/src/test/resources/conf/job/conf.properties
+++ b/spring/namespace/src/test/resources/conf/job/conf.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-regCenter.serverLists=localhost:3181
+regCenter.serverLists=127.0.0.1:3181
 regCenter.namespace=elasticjob-spring-test
 regCenter.baseSleepTimeMilliseconds=1000
 regCenter.maxSleepTimeMilliseconds=3000

--- a/spring/namespace/src/test/resources/conf/reg/conf.properties
+++ b/spring/namespace/src/test/resources/conf/reg/conf.properties
@@ -15,13 +15,13 @@
 # limitations under the License.
 #
 
-regCenter1.serverLists=localhost:3181
+regCenter1.serverLists=127.0.0.1:3181
 regCenter1.namespace=regCenter1
 regCenter1.baseSleepTimeMilliseconds=1000
 regCenter1.maxSleepTimeMilliseconds=3000
 regCenter1.maxRetries=3
 
-regCenter2.serverLists=localhost:3181
+regCenter2.serverLists=127.0.0.1:3181
 regCenter2.namespace=regCenter2
 regCenter2.baseSleepTimeMilliseconds=1000
 regCenter2.maxSleepTimeMilliseconds=3000

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/annotation/OneOffEnabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/annotation/OneOffEnabledJobE2ETest.java
@@ -46,20 +46,20 @@ class OneOffEnabledJobE2ETest extends BaseAnnotationE2ETest {
     void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(1));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));
-        JobConfiguration jobConfig = YamlEngine.unmarshal(getREGISTRY_CENTER().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
+        JobConfiguration jobConfig = YamlEngine.unmarshal(getRegistryCenter().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
         assertThat(jobConfig.getShardingTotalCount(), is(1));
         assertNull(jobConfig.getCron());
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        getREGISTRY_CENTER().remove("/" + getJobName() + "/leader/election");
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        getRegistryCenter().remove("/" + getJobName() + "/leader/election");
         assertTrue(getLeaderService().isLeaderUntilBlock());
     }
     
     @Test
     void assertJobInit() {
         Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> MatcherAssert.assertThat(((AnnotationUnShardingJob) getElasticJob()).isCompleted(), is(true)));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/sharding"));
     }
     
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/annotation/ScheduleEnabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/annotation/ScheduleEnabledJobE2ETest.java
@@ -46,22 +46,22 @@ class ScheduleEnabledJobE2ETest extends BaseAnnotationE2ETest {
     void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));
-        JobConfiguration jobConfig = YamlEngine.unmarshal(getREGISTRY_CENTER().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
+        JobConfiguration jobConfig = YamlEngine.unmarshal(getRegistryCenter().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
         assertThat(jobConfig.getShardingTotalCount(), is(3));
         assertThat(jobConfig.getCron(), is("*/10 * * * * ?"));
         assertNull(jobConfig.getTimeZone());
         assertThat(jobConfig.getShardingItemParameters(), is("0=a,1=b,2=c"));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        getREGISTRY_CENTER().remove("/" + getJobName() + "/leader/election");
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        getRegistryCenter().remove("/" + getJobName() + "/leader/election");
         assertTrue(getLeaderService().isLeaderUntilBlock());
     }
     
     @Test
     void assertJobInit() {
         Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> MatcherAssert.assertThat(((AnnotationSimpleJob) getElasticJob()).isCompleted(), is(true)));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/sharding"));
     }
     
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/disable/DisabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/disable/DisabledJobE2ETest.java
@@ -46,7 +46,7 @@ public abstract class DisabledJobE2ETest extends BaseE2ETest {
             assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
             assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));
         });
-        JobConfiguration jobConfig = YamlEngine.unmarshal(getREGISTRY_CENTER().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
+        JobConfiguration jobConfig = YamlEngine.unmarshal(getRegistryCenter().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
         assertThat(jobConfig.getShardingTotalCount(), is(3));
         if (getJobBootstrap() instanceof ScheduleJobBootstrap) {
             assertThat(jobConfig.getCron(), is("0/1 * * * * ?"));
@@ -54,7 +54,7 @@ public abstract class DisabledJobE2ETest extends BaseE2ETest {
             assertNull(jobConfig.getCron());
         }
         assertThat(jobConfig.getShardingItemParameters(), is("0=A,1=B,2=C"));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.DISABLED.name()));
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/leader/election/instance"), is(IsNull.nullValue())));
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.DISABLED.name()));
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(getRegistryCenter().get("/" + getJobName() + "/leader/election/instance"), is(IsNull.nullValue())));
     }
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/disable/ScheduleDisabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/disable/ScheduleDisabledJobE2ETest.java
@@ -51,12 +51,12 @@ class ScheduleDisabledJobE2ETest extends DisabledJobE2ETest {
     }
     
     private void setJobEnable() {
-        getREGISTRY_CENTER().persist("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), ServerStatus.ENABLED.name());
+        getRegistryCenter().persist("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), ServerStatus.ENABLED.name());
     }
     
     private void assertEnabledRegCenterInfo() {
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        getREGISTRY_CENTER().remove("/" + getJobName() + "/leader/election");
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        getRegistryCenter().remove("/" + getJobName() + "/leader/election");
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/sharding"));
     }
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/EnabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/EnabledJobE2ETest.java
@@ -43,7 +43,7 @@ public abstract class EnabledJobE2ETest extends BaseE2ETest {
     void assertEnabledRegCenterInfo() {
         assertThat(JobRegistry.getInstance().getCurrentShardingTotalCount(getJobName()), is(3));
         assertThat(JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp(), is(IpUtils.getIp()));
-        JobConfiguration jobConfig = YamlEngine.unmarshal(getREGISTRY_CENTER().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
+        JobConfiguration jobConfig = YamlEngine.unmarshal(getRegistryCenter().get("/" + getJobName() + "/config"), JobConfigurationPOJO.class).toJobConfiguration();
         assertThat(jobConfig.getShardingTotalCount(), is(3));
         if (getJobBootstrap() instanceof ScheduleJobBootstrap) {
             assertThat(jobConfig.getCron(), is("0/1 * * * * ?"));
@@ -51,10 +51,10 @@ public abstract class EnabledJobE2ETest extends BaseE2ETest {
             assertNull(jobConfig.getCron());
         }
         assertThat(jobConfig.getShardingItemParameters(), is("0=A,1=B,2=C"));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
-        assertThat(getREGISTRY_CENTER().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
-        getREGISTRY_CENTER().remove("/" + getJobName() + "/leader/election");
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/servers/" + JobRegistry.getInstance().getJobInstance(getJobName()).getServerIp()), is(ServerStatus.ENABLED.name()));
+        assertThat(getRegistryCenter().get("/" + getJobName() + "/leader/election/instance"), is(JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/instances/" + JobRegistry.getInstance().getJobInstance(getJobName()).getJobInstanceId()));
+        getRegistryCenter().remove("/" + getJobName() + "/leader/election");
         assertTrue(getLeaderService().isLeaderUntilBlock());
     }
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/OneOffEnabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/OneOffEnabledJobE2ETest.java
@@ -43,6 +43,6 @@ class OneOffEnabledJobE2ETest extends EnabledJobE2ETest {
     @Test
     void assertJobInit() {
         Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(((E2EFixtureJobImpl) getElasticJob()).isCompleted(), is(true)));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/sharding"));
     }
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/ScheduleEnabledJobE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/raw/enable/ScheduleEnabledJobE2ETest.java
@@ -43,6 +43,6 @@ class ScheduleEnabledJobE2ETest extends EnabledJobE2ETest {
     @Test
     void assertJobInit() {
         Awaitility.await().atMost(10L, TimeUnit.SECONDS).untilAsserted(() -> assertThat(((E2EFixtureJobImpl) getElasticJob()).isCompleted(), is(true)));
-        assertTrue(getREGISTRY_CENTER().isExisted("/" + getJobName() + "/sharding"));
+        assertTrue(getRegistryCenter().isExisted("/" + getJobName() + "/sharding"));
     }
 }

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/snapshot/SnapshotServiceDisableE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/snapshot/SnapshotServiceDisableE2ETest.java
@@ -41,13 +41,13 @@ class SnapshotServiceDisableE2ETest extends BaseSnapshotServiceE2ETest {
     
     @Test
     void assertPortInvalid() {
-        assertThrows(IllegalArgumentException.class, () -> new SnapshotService(getREG_CENTER(), -1).listen());
+        assertThrows(IllegalArgumentException.class, () -> new SnapshotService(getRegCenter(), -1).listen());
     }
     
     @Test
     void assertListenException() throws IOException {
         ServerSocket serverSocket = new ServerSocket(9898);
-        SnapshotService snapshotService = new SnapshotService(getREG_CENTER(), 9898);
+        SnapshotService snapshotService = new SnapshotService(getRegCenter(), 9898);
         snapshotService.listen();
         serverSocket.close();
         assertNull(ReflectionUtils.getFieldValue(snapshotService, "serverSocket"));

--- a/test/util/src/main/java/org/apache/shardingsphere/elasticjob/test/util/EmbedTestingServer.java
+++ b/test/util/src/main/java/org/apache/shardingsphere/elasticjob/test/util/EmbedTestingServer.java
@@ -17,12 +17,13 @@
 
 package org.apache.shardingsphere.elasticjob.test.util;
 
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.KeeperException;
 
@@ -33,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Embed ZooKeeper testing server.
  */
-@RequiredArgsConstructor
+@AllArgsConstructor
 @Slf4j
 public final class EmbedTestingServer {
     
@@ -42,6 +43,13 @@ public final class EmbedTestingServer {
     private static final Object INIT_LOCK = new Object();
     
     private final int port;
+    
+    /**
+     * Create the server using a random port.
+     */
+    public EmbedTestingServer() {
+        port = InstanceSpec.getRandomPort();
+    }
     
     /**
      * Start embed zookeeper server.
@@ -64,7 +72,7 @@ public final class EmbedTestingServer {
     
     private void start0() {
         try {
-            testingServer = new TestingServer(port, true);
+            testingServer = new TestingServer(port);
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
@@ -132,6 +140,6 @@ public final class EmbedTestingServer {
      * @return connection string
      */
     public String getConnectionString() {
-        return "localhost:" + port;
+        return testingServer.getConnectString();
     }
 }


### PR DESCRIPTION
Fixes #2408.

Changes proposed in this pull request:
- Prevent unit tests and E2E from using host ports `1`, `2181`, `7181`, `8181`, `8899`, `9000`, `9181`, `9872` and `9875`. Starting from this PR, unit tests and E2E will automatically look for free ports to prevent third-party Docker Images such as portainer from using specific ports.
- Since the host ports of `3181` and `18181` in the unit test are hard-coded into Spring Boot and various configuration files, they are retained.
- Bump `apache/curator` to 5.7.0 .
