### PR TITLE
Support for building with OpenJDK 22

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ 8, 17, 21 ]
+        java: [ 8, 17, 21, 22 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
 
     runs-on: ${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         
-        <netty.version>4.1.99.Final</netty.version>
+        <netty.version>4.1.112.Final</netty.version>
         
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>
@@ -87,7 +87,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>4.11.0</mockito.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <bytebuddy.version>1.14.8</bytebuddy.version>
+        <bytebuddy.version>1.14.18</bytebuddy.version>
         
         <h2.version>2.2.224</h2.version>
         <hikari-cp.version>4.0.3</hikari-cp.version>
@@ -113,7 +113,7 @@
         <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         
         <!-- Report plugin versions -->
         <maven-site-plugin.version>4.0.0-M6</maven-site-plugin.version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -34,9 +34,8 @@
     </modules>
     
     <properties>
-        <springboot.version>2.7.10</springboot.version>
-        <springframework.version>5.3.26</springframework.version>
-        <aspectj.version>1.9.1</aspectj.version>
+        <springboot.version>2.7.18</springboot.version>
+        <aspectj.version>1.9.22.1</aspectj.version>
     </properties>
     
     <dependencyManagement>
@@ -47,30 +46,6 @@
                 <version>${springboot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context</artifactId>
-                <version>${springframework.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context-support</artifactId>
-                <version>${springframework.version}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.springframework</groupId>
-                        <artifactId>spring-context</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${springframework.version}</version>
-                <scope>test</scope>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Fixes #2407.

Changes proposed in this pull request:
- Support for building with OpenJDK 22.
    - `org.aspectj:aspectjweaver` 
    - `net.bytebuddy:byte-buddy`
    - `net.bytebuddy:byte-buddy-agent`
    - `org.jacoco:jacoco-maven-plugin`
- Removed Spring Framework version constraints that had no practical effect.
- Update dependencies to fix CVE.
     - `io.netty:netty-bom`
     - `org.springframework.boot:spring-boot-dependencies`
