### PR TITLE
Removes non-existent `elasticjob-tracing-api` and `elasticjob-error-handler-spi` module

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,16 +44,19 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
+          cache: 'maven'
       - name: Build with Maven in Windows
         if: matrix.os == 'windows-latest'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install
+          ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -T1C
       - name: Build with Maven in Linux or macOS
         if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
         run: |
-          ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -Pcheck
+          ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -Pcheck -T1C
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
         uses: codecov/codecov-action@v3
         with:
           file: '**/target/site/jacoco/jacoco.xml'
+      - name: Build Examples with Maven
+        run: ./mvnw clean package -B -f examples/pom.xml -T1C

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -34,17 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
-            <artifactId>elasticjob-error-handler-spi</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere.elasticjob</groupId>
             <artifactId>elasticjob-registry-center-zookeeper-curator</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere.elasticjob</groupId>
-            <artifactId>elasticjob-tracing-api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         

--- a/restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultJsonRequestBodyDeserializer.java
+++ b/restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/deserializer/impl/DefaultJsonRequestBodyDeserializer.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.restful.deserializer.impl;
 
 import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
+import org.apache.shardingsphere.elasticjob.kernel.infra.json.GsonFactory;
 import org.apache.shardingsphere.elasticjob.restful.deserializer.RequestBodyDeserializer;
 
 import java.nio.charset.StandardCharsets;

--- a/restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/impl/DefaultJsonResponseBodySerializer.java
+++ b/restful/src/main/java/org/apache/shardingsphere/elasticjob/restful/serializer/impl/DefaultJsonResponseBodySerializer.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.elasticjob.restful.serializer.impl;
 
 import com.google.gson.Gson;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.apache.shardingsphere.elasticjob.infra.json.GsonFactory;
+import org.apache.shardingsphere.elasticjob.kernel.infra.json.GsonFactory;
 import org.apache.shardingsphere.elasticjob.restful.serializer.ResponseBodySerializer;
 
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
For #2258.

Changes proposed in this pull request:
- Removes non-existent `elasticjob-tracing-api` and `elasticjob-error-handler-spi` module. This will resolve the following build-time Warning.
```shell
[WARNING] The POM for org.apache.shardingsphere.elasticjob:elasticjob-infra-common:jar:3.1.0-SNAPSHOT is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for org.apache.shardingsphere.elasticjob:elasticjob-infra-common:jar:3.1.0-SNAPSHOT is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for org.apache.shardingsphere.elasticjob:elasticjob-tracing-api:jar:3.1.0-SNAPSHOT is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for org.apache.shardingsphere.elasticjob:elasticjob-tracing-api:jar:3.1.0-SNAPSHOT is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details

```
- Add the Example build process to CI verification.
