### PR TITLE
Block `elasticjob-test-native` module from compiling on JDK 8 to JDK16

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
         java: [ '22.0.2' ]
@@ -45,4 +46,4 @@ jobs:
           native-image-job-reports: 'true'
       - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
         continue-on-error: true
-        run: ./mvnw -PnativeTestInElasticJob -T1C -B -e -Dspring-boot-dependencies.version=3.3.2 clean test
+        run: ./mvnw -PnativeTestInElasticJob -T1C -B -e clean test

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,21 +26,20 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
         java: [ 8, 17, 21, 22 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Configure Git
         if: matrix.os == 'windows-latest'
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/required-check.yml
+++ b/.github/workflows/required-check.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   check-checkstyle:
     name: Check - CheckStyle
+    if: github.repository == 'apache/shardingsphere-elasticjob'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -38,6 +39,7 @@ jobs:
 
   check-spotless:
     name: Check - Spotless
+    if: github.repository == 'apache/shardingsphere-elasticjob'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -47,6 +49,7 @@ jobs:
 
   check-license:
     name: Check - License
+    if: github.repository == 'apache/shardingsphere-elasticjob'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/content/user-manual/configuration/graalvm-native-image.cn.md
+++ b/docs/content/user-manual/configuration/graalvm-native-image.cn.md
@@ -256,7 +256,7 @@ sudo apt-get install build-essential zlib1g-dev -y
 
 git clone git@github.com:apache/shardingsphere-elasticjob.git
 cd ./shardingsphere-elasticjob/
-./mvnw -PnativeTestInElasticJob -T1C -e -Dspring-boot-dependencies.version=3.3.2 clean test
+./mvnw -PnativeTestInElasticJob -T1C -e clean test
 ```
 
 当贡献者发现缺少与 ElasticJob 无关的第三方库的 GraalVM Reachability Metadata 时，应当在
@@ -285,5 +285,5 @@ ElasticJob 定义了 `generateMetadata` 的 Maven Profile 用于在 GraalVM JIT 
 ```bash
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -PgenerateMetadata -DskipNativeTests -e -T1C -Dspring-boot-dependencies.version=3.3.2 clean test native:metadata-copy
+./mvnw -PgenerateMetadata -DskipNativeTests -e -T1C clean test native:metadata-copy
 ```

--- a/docs/content/user-manual/configuration/graalvm-native-image.en.md
+++ b/docs/content/user-manual/configuration/graalvm-native-image.en.md
@@ -259,7 +259,7 @@ sudo apt-get install build-essential zlib1g-dev -y
 
 git clone git@github.com:apache/shardingsphere-elasticjob.git
 cd ./shardingsphere-elasticjob/
-./mvnw -PnativeTestInElasticJob -T1C -e -Dspring-boot-dependencies.version=3.3.2 clean test
+./mvnw -PnativeTestInElasticJob -T1C -e clean test
 ```
 
 When contributors find that GraalVM Reachability Metadata for third-party libraries not related to ElasticJob is missing, 
@@ -289,5 +289,5 @@ contributors should place it in the classpath of the shardingsphere-test-native 
 ```bash
 git clone git@github.com:apache/shardingsphere.git
 cd ./shardingsphere/
-./mvnw -PgenerateMetadata -DskipNativeTests -e -T1C -Dspring-boot-dependencies.version=3.3.2 clean test native:metadata-copy
+./mvnw -PgenerateMetadata -DskipNativeTests -e -T1C clean test native:metadata-copy
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -757,9 +757,6 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -28,7 +28,8 @@
     
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <!--TODO Unfortunately, ElasticJob is still using Slf4j API 1.7.36 -->
+        <!--TODO Blocked by https://github.com/apache/shardingsphere-elasticjob/issues/2425 -->
+        <spring-boot-dependencies.version>3.3.2</spring-boot-dependencies.version>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.6</logback.version>
     </properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -30,6 +30,18 @@
     <modules>
         <module>e2e</module>
         <module>util</module>
-        <module>native</module>
     </modules>
+    
+    <profiles>
+        <!-- Block `elasticjob-test-native` module from compiling on JDK 8 to JDK16 -->
+        <profile>
+            <id>jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>native</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixes #2420 .

Changes proposed in this pull request:
- Block `elasticjob-test-native` module from compiling on JDK 8 to JDK16.
- Also fixes #2423 . I prefer the current PR handling, which even allows to compile with JDK 8 and execute unit tests of `elasticjob-test-native` under Spring Boot 3.3.2 in IntelliJ IDEA out of the box.
- ![image](https://github.com/user-attachments/assets/bd66a569-209a-48a0-8249-5de896276281)
