### PR TITLE
Support using DIGEST-MD5 as the SASL mechanism for ElasticJob `CoordinatorRegistryCenter` under GraalVM Native Image

### DIFF
--- a/docs/content/user-manual/configuration/external-integration/sasl.cn.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.cn.md
@@ -48,16 +48,15 @@ public class ExampleUtils {
         Configuration configuration = new Configuration() {
             @Override
             public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
-                Map<String, String> options = new HashMap<>();
-                options.put("username", "bob");
-                options.put("password", "bobsecret");
-                AppConfigurationEntry entry = new AppConfigurationEntry(
+                Map<String, String> conf = new HashMap<>();
+                conf.put("username", "bob");
+                conf.put("password", "bobsecret");
+                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
+                entries[0] = new AppConfigurationEntry(
                         "org.apache.zookeeper.server.auth.DigestLoginModule",
                         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        options);
-                AppConfigurationEntry[] array = new AppConfigurationEntry[1];
-                array[0] = entry;
-                return array;
+                        conf);
+                return entries;
             }
         };
         Configuration.setConfiguration(configuration);

--- a/docs/content/user-manual/configuration/external-integration/sasl.en.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.en.md
@@ -52,16 +52,15 @@ public class ExampleUtils {
         Configuration configuration = new Configuration() {
             @Override
             public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
-                Map<String, String> options = new HashMap<>();
-                options.put("username", "bob");
-                options.put("password", "bobsecret");
-                AppConfigurationEntry entry = new AppConfigurationEntry(
+                Map<String, String> conf = new HashMap<>();
+                conf.put("username", "bob");
+                conf.put("password", "bobsecret");
+                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
+                entries[0] = new AppConfigurationEntry(
                         "org.apache.zookeeper.server.auth.DigestLoginModule",
                         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        options);
-                AppConfigurationEntry[] array = new AppConfigurationEntry[1];
-                array[0] = entry;
-                return array;
+                        conf);
+                return entries;
             }
         };
         Configuration.setConfiguration(configuration);

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <mockito.version>4.11.0</mockito.version>
         <awaitility.version>4.2.0</awaitility.version>
         <bytebuddy.version>1.14.18</bytebuddy.version>
+        <testcontainers-bom.version>1.20.1</testcontainers-bom.version>
         
         <h2.version>2.2.224</h2.version>
         <hikari-cp.version>4.0.3</hikari-cp.version>
@@ -349,6 +350,13 @@
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             
             <dependency>
@@ -951,8 +959,8 @@
                                     <defaultMode>Conditional</defaultMode>
                                     <modes>
                                         <conditional>
-                                            <userCodeFilterPath>${user.dir}/test/native/native-image-filter/user-code-filter.json</userCodeFilterPath>
-                                            <extraFilterPath>${user.dir}/test/native/native-image-filter/extra-filter.json</extraFilterPath>
+                                            <userCodeFilterPath>${user.dir}/test/native/native-image-filter/user-code-filter-zookeeper.json</userCodeFilterPath>
+                                            <extraFilterPath>${user.dir}/test/native/native-image-filter/extra-filter-zookeeper.json</extraFilterPath>
                                             <parallel>true</parallel>
                                         </conditional>
                                     </modes>
@@ -961,7 +969,7 @@
                                             <stage>main</stage>
                                         </disabledStages>
                                         <merge>false</merge>
-                                        <outputDirectory>${user.dir}/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.shardingsphere.elasticjob/generated-reachability-metadata/</outputDirectory>
+                                        <outputDirectory>${user.dir}/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.2/</outputDirectory>
                                     </metadataCopy>
                                 </agent>
                             </configuration>
@@ -995,7 +1003,7 @@
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
                                 <includes>
-                                    <include>org.apache.shardingsphere.elasticjob.test.natived.**</include>
+                                    <include>org.apache.shardingsphere.elasticjob.test.natived.it.staticd.ZookeeperAuthTest</include>
                                 </includes>
                             </configuration>
                         </plugin>
@@ -1006,6 +1014,13 @@
                             <extensions>true</extensions>
                             <configuration>
                                 <quickBuild>true</quickBuild>
+                                <buildArgs>
+                                    <buildArg>-H:AdditionalSecurityProviders=com.sun.security.sasl.Provider</buildArg>
+                                    <buildArg>-H:AdditionalSecurityProviders=com.sun.security.sasl.gsskerb.JdkSASL</buildArg>
+                                    <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
+                                    <buildArg>-H:ThrowMissingRegistrationErrors=</buildArg>
+                                    <buildArg>-H:MissingRegistrationReportingMode=Warn</buildArg>
+                                </buildArgs>
                             </configuration>
                             <executions>
                                 <execution>

--- a/reachability-metadata/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.3.6/reflect-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.3.6/reflect-config.json
@@ -1,0 +1,7 @@
+[
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.RuntimeInfo"},
+  "name":"com.github.dockerjava.api.model.RuntimeInfo",
+  "allPublicConstructors": true
+}
+]

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -63,6 +63,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
             <version>${spring-boot-dependencies.version}</version>

--- a/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/it/staticd/ZookeeperAuthTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/it/staticd/ZookeeperAuthTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.test.natived.it.staticd;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.shardingsphere.elasticjob.api.JobConfiguration;
+import org.apache.shardingsphere.elasticjob.bootstrap.type.ScheduleJobBootstrap;
+import org.apache.shardingsphere.elasticjob.kernel.tracing.config.TracingConfiguration;
+import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperConfiguration;
+import org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter;
+import org.apache.shardingsphere.elasticjob.test.natived.commons.job.simple.JavaSimpleJob;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledInNativeImage;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.sql.DataSource;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@EnabledInNativeImage
+@Testcontainers
+public class ZookeeperAuthTest {
+    
+    @SuppressWarnings("resource")
+    @Container
+    private static final GenericContainer<?> CONTAINER = new GenericContainer<>("zookeeper:3.9.2")
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("test-native/conf/jaas-server-test-native.conf", Transferable.DEFAULT_FILE_MODE),
+                    "/jaas-server-test-native.conf")
+            .withEnv("JVMFLAGS", "-Djava.security.auth.login.config=/jaas-server-test-native.conf")
+            .withEnv("ZOO_CFG_EXTRA", "authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider sessionRequireClientSASLAuth=true")
+            .withExposedPorts(2181);
+    
+    @BeforeAll
+    static void beforeAll() {
+        Configuration.setConfiguration(new Configuration() {
+
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
+                Map<String, String> conf = new HashMap<>();
+                conf.put("username", "bob");
+                conf.put("password", "bobsecret");
+                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
+                entries[0] = new AppConfigurationEntry(
+                        "org.apache.zookeeper.server.auth.DigestLoginModule",
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        conf);
+                return entries;
+            }
+        });
+    }
+    
+    @AfterAll
+    static void afterAll() {
+        Configuration.setConfiguration(null);
+    }
+    
+    /**
+     * For {@link org.apache.curator.test.TestingServer}, a lot of system properties are set in the background,
+     * refer to
+     * <a href="https://github.com/apache/zookeeper/blob/release-3.9.2/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslDigestAuthOverSSLTest.java">SaslDigestAuthOverSSLTest.java</a> .
+     * Therefore, in order to test Zookeeper Server with SASL mechanism enabled under ElasticJob {@link CoordinatorRegistryCenter},
+     * ElasticJob should never start Zookeeper Server through {@link org.apache.curator.test.TestingServer}.
+     * Running Zookeeper Server and Curator Client in the same JVM process will pollute system properties.
+     * For more information on this unit test,
+     * refer to <a href="https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html">ZooKeeper Administrator's Guide</a> and
+     * <a href="https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+and+SASL">ZooKeeper and SASL</a> .
+     *
+     * @throws Exception exception
+     */
+    @Test
+    void testSaslDigestMd5() throws Exception {
+        String connectionString = CONTAINER.getHost() + ":" + CONTAINER.getMappedPort(2181);
+        Thread.sleep(Duration.ofSeconds(5L).toMillis());
+        CoordinatorRegistryCenter regCenter = new ZookeeperRegistryCenter(
+                new ZookeeperConfiguration(connectionString, "elasticjob-test-native-sasl-digest-md5"));
+        regCenter.init();
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDriverClassName("org.h2.Driver");
+        hikariConfig.setJdbcUrl("jdbc:h2:mem:job_event_storage");
+        hikariConfig.setUsername("sa");
+        hikariConfig.setPassword("");
+        TracingConfiguration<DataSource> tracingConfig = new TracingConfiguration<>("RDB", new HikariDataSource(hikariConfig));
+        ScheduleJobBootstrap jobBootstrap = new ScheduleJobBootstrap(
+                regCenter,
+                new JavaSimpleJob(),
+                JobConfiguration.newBuilder("testSaslDigestMd5", 3)
+                        .cron("0/5 * * * * ?")
+                        .shardingItemParameters("0=Norddorf,1=Bordeaux,2=Somerset")
+                        .addExtraConfigurations(tracingConfig)
+                        .build());
+        assertDoesNotThrow(() -> {
+            jobBootstrap.schedule();
+            jobBootstrap.shutdown();
+        });
+        regCenter.close();
+    }
+}

--- a/test/native/src/test/resources/META-INF/native-image/elasticjob-test-native-test-metadata/resource-config.json
+++ b/test/native/src/test/resources/META-INF/native-image/elasticjob-test-native-test-metadata/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.apache.shardingsphere.elasticjob.test.natived.it.staticd.ZookeeperAuthTest"},
+    "pattern":".*test-native/conf/.+\\.conf$"
+  }]},
+  "bundles":[]
+}

--- a/test/native/src/test/resources/test-native/conf/jaas-server-test-native.conf
+++ b/test/native/src/test/resources/test-native/conf/jaas-server-test-native.conf
@@ -1,0 +1,21 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+Server {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    user_bob="bobsecret";
+};


### PR DESCRIPTION
Fixes #2457.

Changes proposed in this pull request:
- Support using DIGEST-MD5 as the SASL mechanism for ElasticJob `CoordinatorRegistryCenter` under GraalVM Native Image.
- Updates documentation to match variable naming conventions in https://github.com/apache/zookeeper/blob/release-3.9.2/zookeeper-server/src/test/java/org/apache/zookeeper/JaasConfiguration.java .
- For `org.apache.curator.test.TestingServer`, a lot of system properties are set in the background, refer to https://github.com/apache/zookeeper/blob/release-3.9.2/zookeeper-server/src/test/java/org/apache/zookeeper/test/SaslDigestAuthOverSSLTest.java .
Therefore, in order to test Zookeeper Server with SASL mechanism enabled under ElasticJob `CoordinatorRegistryCenter`, ElasticJob should never start Zookeeper Server through `org.apache.curator.test.TestingServer`. Running Zookeeper Server and Curator Client in the same JVM process will pollute system properties. For more information on this unit test, refer to https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html and
https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+and+SASL .
- TODO: The PR is in Not Ready state. It is strange that the `saslToken` of Zookeeper Quorum member is empty.
```shell
10:53:09.890 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.Login -- Client successfully logged in.
10:53:09.890 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.client.ZooKeeperSaslClient -- Client will use DIGEST-MD5 as SASL mechanism.
10:53:09.890 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.ClientCnxn -- Opening socket connection to server localhost/127.0.0.1:32791.
10:53:09.890 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.ClientCnxn -- SASL config status: Will attempt to SASL-authenticate using Login Context section 'Client'
10:53:09.891 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.ClientCnxn -- Socket connection established, initiating session, client: /127.0.0.1:46578, server: localhost/127.0.0.1:32791
10:53:09.907 [main-SendThread(localhost:32791)] INFO org.apache.zookeeper.ClientCnxn -- Session establishment complete on server localhost/127.0.0.1:32791, session id = 0x100005a9c630000, negotiated timeout = 40000
10:53:09.907 [main-EventThread] INFO org.apache.curator.framework.state.ConnectionStateManager -- State change: CONNECTED
10:53:09.908 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Starting...
10:53:09.910 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Start completed.
10:53:09.911 [main] INFO org.apache.shardingsphere.elasticjob.spring.core.setup.SpringProxyJobClassNameProvider -- create SpringProxyJobClassNameProvider
10:53:09.911 [main-SendThread(localhost:32791)] ERROR org.apache.zookeeper.client.ZooKeeperSaslClient -- SASL authentication failed using login context 'Client'.
javax.security.sasl.SaslException: Error in authenticating with a Zookeeper Quorum member: the quorum member's saslToken is null.
        at org.apache.zookeeper.client.ZooKeeperSaslClient.createSaslToken(ZooKeeperSaslClient.java:310)
        at org.apache.zookeeper.client.ZooKeeperSaslClient.respondToServer(ZooKeeperSaslClient.java:270)
        at org.apache.zookeeper.ClientCnxn$SendThread.readResponse(ClientCnxn.java:921)
        at org.apache.zookeeper.ClientCnxnSocketNIO.doIO(ClientCnxnSocketNIO.java:98)
        at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:350)
        at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1274)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:853)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:829)
10:53:09.911 [main-EventThread] ERROR org.apache.curator.ConnectionState -- Authentication failed

```