### PR TITLE
Refactor of the way Lambda job classes are identified

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -23,8 +23,7 @@ on:
     paths:
       - '.github/workflows/graalvm.yml'
       - 'reachability-metadata/src/**'
-      - 'test/native/native-image-filter/**'
-      - 'test/native/src/**'
+      - 'test/native/**'
 
 jobs:
   build:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,36 @@
+## Release 3.1.0-SNAPSHOT
+
+### API Changes
+
+1. Kernel: Refactor of the way Lambda job classes are identified - [#2370](https://github.com/apache/shardingsphere-elasticjob/issues/2370)
+
+### New Features
+
+### Enhancements
+
+1. Bootstrap: Provides built-in GraalVM Reachability Metadata and nativeTest on Elasticjob Bootstrap - [#2268](https://github.com/apache/shardingsphere-elasticjob/pull/2268)
+1. Build: Support for building with OpenJDK 22 - [#2407](https://github.com/apache/shardingsphere-elasticjob/issues/2407)
+1. Spring Boot Starter: Block `elasticjob-spring-boot-starter` from passing `spring-boot-starter` test scope dependencies - [#2418](https://github.com/apache/shardingsphere-elasticjob/issues/2418)
+1. Lifecycle: Support dynamic configuration of jobs through the Operation API in GraalVM Native Image - [#2426](https://github.com/apache/shardingsphere-elasticjob/pull/2426)
+1. Doc: Adds documentation for connecting to Zookeeper Server with SASL enabled - [#2442](https://github.com/apache/shardingsphere-elasticjob/pull/2442)
+1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
+1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
+
+### Bug Fixes
+
+1. Build: Removes non-existent `elasticjob-tracing-api` and `elasticjob-error-handler-spi` module - [#2412](https://github.com/apache/shardingsphere-elasticjob/pull/2412)
+1. Spring Boot Starter: Fixes the issue that OneOffJobBootstrap cannot be used under ElasticJob Spring Boot Starter - [#2014](https://github.com/apache/shardingsphere-elasticjob/issues/2014)
+
+### Change Logs
+
+1. [MILESTONE](https://github.com/apache/shardingsphere-elasticjob/milestone/7)
+
 ## 3.0.4
 
-## Dependencies Upgrade
+### Dependencies Upgrade
 1. Update dependencies to fix CVE
 
-## Enhancements
+### Enhancements
 1. Support for building with OpenJDK 21
 2. Accelerate the startup speed of ElasticJob
 3. Migrate from Junit Vintage to Junit Jupiter

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/setup/DefaultJobClassNameProvider.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/setup/DefaultJobClassNameProvider.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.elasticjob.api.ElasticJob;
  */
 public final class DefaultJobClassNameProvider implements JobClassNameProvider {
     
-    private static final String LAMBDA_CHARACTERISTICS = "$$Lambda$";
+    private static final String LAMBDA_CHARACTERISTICS = "$$Lambda";
     
     @Override
     public String getJobClassName(final ElasticJob elasticJob) {

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/setup/DefaultJobClassNameProviderTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/setup/DefaultJobClassNameProviderTest.java
@@ -20,8 +20,6 @@ package org.apache.shardingsphere.elasticjob.kernel.internal.setup;
 import org.apache.shardingsphere.elasticjob.kernel.fixture.job.DetailedFooJob;
 import org.apache.shardingsphere.elasticjob.kernel.fixture.job.FooJob;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,14 +33,12 @@ class DefaultJobClassNameProviderTest {
         assertThat(result, is("org.apache.shardingsphere.elasticjob.kernel.fixture.job.DetailedFooJob"));
     }
     
-    // TODO OpenJDK 21 breaks this unit test.
     @Test
-    @DisabledForJreRange(min = JRE.JAVA_21, max = JRE.OTHER)
     void assertGetLambdaJobName() {
         JobClassNameProvider jobClassNameProvider = new DefaultJobClassNameProvider();
         FooJob lambdaFooJob = shardingContext -> {
         };
         String result = jobClassNameProvider.getJobClassName(lambdaFooJob);
-        assertThat(result, is("org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda$"));
+        assertThat(result, is("org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda"));
     }
 }

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -29,9 +29,9 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--TODO Blocked by https://github.com/apache/shardingsphere-elasticjob/issues/2425 -->
-        <spring-boot-dependencies.version>3.3.4</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.3.5</spring-boot-dependencies.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <logback.version>1.5.8</logback.version>
+        <logback.version>1.5.11</logback.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
Fixes #2370.

Changes proposed in this pull request:
- Refactor of the way Lambda job classes are identified. Also fixes #2224 .
- More discussion on GraalVM CE For JDK22 is at https://github.com/oracle/graal/pull/7775 .
- More discussion on OpenJDK 20 can be found at https://forums.oracle.com/ords/apexds/post/why-did-the-class-name-of-the-lambda-class-change-starting-7639 .
- Starting from this PR, 
    - For the ElasticJob Lambda job class on JDK`21`-JDK`23`, the identifier of `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda/0x00007f28230abcc0` will be changed from `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda/0x00007f28230abcc0` to `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda`.
    - For ElasticJob Lambda job classes on JDK`8`-JDK`20`, the identifier of `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda$372/0x00007f98c00accb8` will change from `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda$` to `org.apache.shardingsphere.elasticjob.kernel.internal.setup.DefaultJobClassNameProviderTest$$Lambda`.
- Update the Release Notes of my personal PR according to the requirements of https://shardingsphere.apache.org/community/cn/involved/contribute/contributor/ .
- Bump the Spring Boot version used by nativeTest in GraalVM Native Image to 3.3.5.
