### PR TITLE
add destroyMethod for zookeeperRegistryCenter bean

### DIFF
--- a/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/ElasticJobRegistryCenterConfiguration.java
+++ b/spring/boot-starter/src/main/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/ElasticJobRegistryCenterConfiguration.java
@@ -33,7 +33,7 @@ public class ElasticJobRegistryCenterConfiguration {
      * @param zookeeperProperties factory
      * @return zookeeper registry center
      */
-    @Bean(initMethod = "init")
+    @Bean(initMethod = "init", destroyMethod = "close")
     public ZookeeperRegistryCenter zookeeperRegistryCenter(final ZookeeperProperties zookeeperProperties) {
         return new ZookeeperRegistryCenter(zookeeperProperties.toZookeeperConfiguration());
     }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
- Add a `destroyMethod` for the `zookeeperRegistryCenter` bean to ensure that the application removes the Zookeeper ephemeral node upon exit.