### PR TITLE
Fixes incorrect environment variable definition in SASL integration doc

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -44,6 +44,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
-      - name: Run nativeTest with GraalVM CE for ${{ matrix.java-version }}
-        continue-on-error: true
+      - name: Run nativeTest with GraalVM CE for ${{ matrix.java }}
         run: ./mvnw -PnativeTestInElasticJob -T1C -B -e clean test

--- a/docs/content/user-manual/configuration/external-integration/sasl.cn.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.cn.md
@@ -21,7 +21,7 @@ services:
       - ./jaas-server-test.conf:/jaas-test.conf
     environment:
       JVMFLAGS: "-Djava.security.auth.login.config=/jaas-test.conf"
-      ZOO_CFG_EXTRA: "org.apache.zookeeper.server.auth.SASLAuthenticationProvider sessionRequireClientSASLAuth=true"
+      ZOO_CFG_EXTRA: "authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider sessionRequireClientSASLAuth=true"
     ports:
       - "2181:2181"
 ```
@@ -100,4 +100,4 @@ public class ExampleUtils {
 要使 ElasticJob 的 `org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter` 连接至开启 Kerberos 鉴权的 Zookeeper Server，
 流程类似于 DIGEST-MD5。以 https://cwiki.apache.org/confluence/display/ZOOKEEPER/Client-Server+mutual+authentication 为准。
 
-部分地区可能不被允许使用 MIT Kerberos 的源代码或二进制产物，可参考 MIT Kerberos 的分发站点 https://web.mit.edu/kerberos/dist/index.html 。
+Kerberos KDC 不存在可用的 Docker Image，用户可能需要手动启动 Kerberos KDC。

--- a/docs/content/user-manual/configuration/external-integration/sasl.en.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.en.md
@@ -23,7 +23,7 @@ services:
       - ./jaas-server-test.conf:/jaas-test.conf
     environment:
       JVMFLAGS: "-Djava.security.auth.login.config=/jaas-test.conf"
-      ZOO_CFG_EXTRA: "org.apache.zookeeper.server.auth.SASLAuthenticationProvider sessionRequireClientSASLAuth=true"
+      ZOO_CFG_EXTRA: "authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider sessionRequireClientSASLAuth=true"
     ports:
       - "2181:2181"
 ```
@@ -109,5 +109,4 @@ To connect ElasticJob's `org.apache.shardingsphere.elasticjob.reg.zookeeper.Zook
 the process is similar to DIGEST-MD5. 
 Refer to https://cwiki.apache.org/confluence/display/ZOOKEEPER/Client-Server+mutual+authentication .
 
-Some regions may not allow the use of MIT Kerberos source code or binary products. 
-Please refer to the MIT Kerberos distribution site https://web.mit.edu/kerberos/dist/index.html .
+There is no available Docker Image for Kerberos KDC. Users may need to start Kerberos KDC manually.

--- a/docs/content/user-manual/configuration/graalvm-native-image.cn.md
+++ b/docs/content/user-manual/configuration/graalvm-native-image.cn.md
@@ -34,7 +34,6 @@ ElasticJob 不为已停止维护的 GraalVM CE 版本设置 CI。
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
             <artifactId>elasticjob-bootstrap</artifactId>
             <version>${elasticjob.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     
@@ -43,7 +42,7 @@ ElasticJob 不为已停止维护的 GraalVM CE 版本设置 CI。
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>0.10.2</version>
+                <version>0.10.3</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -76,12 +75,12 @@ ElasticJob 不为已停止维护的 GraalVM CE 版本设置 CI。
 
 ```groovy
 plugins {
-   id 'org.graalvm.buildtools.native' version '0.10.2'
+   id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 dependencies {
    implementation 'org.apache.shardingsphere.elasticjob:elasticjob-bootstrap:${elasticjob.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.2', classifier: 'repository', ext: 'zip')
+   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {
@@ -105,18 +104,16 @@ graalvmNative {
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
             <artifactId>elasticjob-spring-boot-starter</artifactId>
             <version>${elasticjob.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
-            <version>3.3.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.3.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -126,7 +123,7 @@ graalvmNative {
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>0.10.2</version>
+                <version>0.10.3</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -148,7 +145,7 @@ graalvmNative {
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.3.4</version>
                 <executions>
                     <execution>
                         <id>process-test-aot</id>
@@ -172,16 +169,17 @@ graalvmNative {
 
 ```groovy
 plugins {
-   id 'org.springframework.boot' version '3.3.2'
-   id 'io.spring.dependency-management' version '1.1.6'
-   id 'org.graalvm.buildtools.native' version '0.10.2'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 dependencies {
-   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-   implementation 'org.springframework.boot:spring-boot-starter-web'
-   implementation 'org.apache.shardingsphere.elasticjob:elasticjob-spring-boot-starter:${elasticjob.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.2', classifier: 'repository', ext: 'zip')
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.apache.shardingsphere.elasticjob:elasticjob-spring-boot-starter:${elasticjob.version}'
+    implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {
@@ -190,7 +188,6 @@ graalvmNative {
    }
 }
 ```
-
 
 ## 对于 sbt 等不被 GraalVM Native Build Tools 支持的构建工具
 

--- a/docs/content/user-manual/configuration/graalvm-native-image.en.md
+++ b/docs/content/user-manual/configuration/graalvm-native-image.en.md
@@ -36,7 +36,6 @@ refer to the documentation of GraalVM Native Build Tools.
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
             <artifactId>elasticjob-bootstrap</artifactId>
             <version>${elasticjob.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     
@@ -45,7 +44,7 @@ refer to the documentation of GraalVM Native Build Tools.
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>0.10.2</version>
+                <version>0.10.3</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -78,12 +77,12 @@ Refer to https://github.com/graalvm/native-build-tools/issues/572.
 
 ```groovy
 plugins {
-   id 'org.graalvm.buildtools.native' version '0.10.2'
+   id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 dependencies {
    implementation 'org.apache.shardingsphere.elasticjob:elasticjob-bootstrap:${elasticjob.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.2', classifier: 'repository', ext: 'zip')
+   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {
@@ -108,28 +107,26 @@ To configure additional Maven Profiles for the project, refer to the documentati
             <groupId>org.apache.shardingsphere.elasticjob</groupId>
             <artifactId>elasticjob-spring-boot-starter</artifactId>
             <version>${elasticjob.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
-            <version>3.3.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.3.2</version>
+            <version>3.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.3.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
-                <version>0.10.2</version>
+                <version>0.10.3</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -151,7 +148,7 @@ To configure additional Maven Profiles for the project, refer to the documentati
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.3.4</version>
                 <executions>
                     <execution>
                         <id>process-test-aot</id>
@@ -175,22 +172,23 @@ Refer to https://github.com/graalvm/native-build-tools/issues/572 .
 
 ```groovy
 plugins {
-   id 'org.springframework.boot' version '3.3.2'
-   id 'io.spring.dependency-management' version '1.1.6'
-   id 'org.graalvm.buildtools.native' version '0.10.2'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 dependencies {
-   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-   implementation 'org.springframework.boot:spring-boot-starter-web'
-   implementation 'org.apache.shardingsphere.elasticjob:elasticjob-spring-boot-starter:${elasticjob.version}'
-   implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.2', classifier: 'repository', ext: 'zip')
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.apache.shardingsphere.elasticjob:elasticjob-spring-boot-starter:${elasticjob.version}'
+    implementation(group: 'org.graalvm.buildtools', name: 'graalvm-reachability-metadata', version: '0.10.3', classifier: 'repository', ext: 'zip')
 }
 
 graalvmNative {
-   metadataRepository {
+    metadataRepository {
         enabled.set(false)
-   }
+    }
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <checksum-maven-plugin.version>1.10</checksum-maven-plugin.version>
         
-        <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
+        <native-maven-plugin.version>0.10.3</native-maven-plugin.version>
     </properties>
     
     <dependencyManagement>

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -29,9 +29,9 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--TODO Blocked by https://github.com/apache/shardingsphere-elasticjob/issues/2425 -->
-        <spring-boot-dependencies.version>3.3.2</spring-boot-dependencies.version>
-        <slf4j.version>2.0.13</slf4j.version>
-        <logback.version>1.5.6</logback.version>
+        <spring-boot-dependencies.version>3.3.4</spring-boot-dependencies.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <logback.version>1.5.8</logback.version>
     </properties>
     
     <dependencies>

--- a/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/TestMain.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/TestMain.java
@@ -20,6 +20,9 @@ package org.apache.shardingsphere.elasticjob.test.natived;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Spring Boot Web Server for testing only.
+ */
 @SpringBootApplication
 public class TestMain {
     


### PR DESCRIPTION
For #2428.

Changes proposed in this pull request:
- Fixes incorrect environment variable definition in SASL integration doc.
- The original PR was blocked by an issue on the GraalVM side and it was necessary to split it ahead of time.
- Bump the Spring Boot version used in unit tests to 3.3.4.