### PR TITLE
Support building and using ElasticJob with JDK23

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
-        java: [ 8, 17, 21, 22 ]
+        java: [ 8, 17, 21, 23 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/content/user-manual/usage/operation-api/_index.cn.md
+++ b/docs/content/user-manual/usage/operation-api/_index.cn.md
@@ -22,7 +22,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 获取作业配置
 
-方法签名：YamlJobConfiguration getJobConfiguration(String jobName)
+方法签名：`JobConfigurationPOJO getJobConfiguration(String jobName)`
 
 * **Parameters:** 
   * jobName — 作业名称
@@ -31,14 +31,14 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 更新作业配置
 
-方法签名：void updateJobConfiguration(YamlJobConfiguration yamlJobConfiguration)
+方法签名：`void updateJobConfiguration(JobConfigurationPOJO jobConfig)`
 
 * **Parameters:** 
-  * jobConfiguration — 作业配置对象
+  * jobConfig — 作业配置对象
 
 ### 删除作业设置 
 
-方法签名：void removeJobConfiguration(String jobName)
+方法签名：`void removeJobConfiguration(String jobName)`
 
 * **Parameters:** 
   * jobName — 作业名称
@@ -51,7 +51,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 作业在不与当前运行中作业冲突的情况下才会触发执行，并在启动后自动清理此标记。
 
-方法签名：void trigger(Optional<String> jobName)
+方法签名：`void trigger(String jobName)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -60,7 +60,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 禁用作业将会导致分布式的其他作业触发重新分片。
 
-方法签名：void disable(Optional<String> jobName, Optional<String> serverIp)
+方法签名：`void disable(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -68,7 +68,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 启用作业
 
-方法签名：void enable(Optional<String> jobName, Optional<String> serverIp)
+方法签名：`void enable(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -76,7 +76,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 停止调度作业
 
-方法签名：void shutdown(Optional<String> jobName, Optional<String> serverIp)
+方法签名：`void shutdown(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -84,7 +84,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 删除作业
 
-方法签名：void remove(Optional<String> jobName, Optional<String> serverIp)
+方法签名：`void remove(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -92,7 +92,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### Dump 作业
 
-方法签名：String dump(String jobName, String instanceIp, int dumpPort)
+方法签名：`String dump(String jobName, String instanceIp, int dumpPort) throws IOException`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -105,7 +105,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 禁用作业分片
 
-方法签名：void disable(String jobName, String item)
+方法签名：`void disable(String jobName, String item)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -113,7 +113,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 启用作业分片
 
-方法签名：void enable(String jobName, String item)
+方法签名：`void enable(String jobName, String item)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -125,13 +125,13 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 获取作业总数
 
-方法签名：int getJobsTotalCount()
+方法签名：`int getJobsTotalCount()`
 
 * **Returns:** 作业总数
 
 ### 获取作业简明信息
 
-方法签名：JobBriefInfo getJobBriefInfo(String jobName)
+方法签名：`JobBriefInfo getJobBriefInfo(String jobName)`
 
 * **Parameters:**
   * jobName — 作业名称
@@ -140,13 +140,13 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 获取所有作业简明信息
 
-方法签名：Collection<JobBriefInfo> getAllJobsBriefInfo()
+方法签名：`Collection<JobBriefInfo> getAllJobsBriefInfo()`
 
 * **Returns:** 作业简明信息集合
 
 ### 获取该 IP 下所有作业简明信息
 
-方法签名：Collection<JobBriefInfo> getJobsBriefInfo(String ip)
+方法签名：`Collection<JobBriefInfo> getJobsBriefInfo(String ip)`
 
 * **Parameters:**
   * ip — 服务器 IP
@@ -159,13 +159,13 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 获取作业服务器总数
 
-方法签名：int getServersTotalCount()
+方法签名：`int getServersTotalCount()`
 
 * **Returns:** 作业服务器总数
 
 ### 获取所有作业服务器简明信息
 
-方法签名：Collection<ServerBriefInfo> getAllServersBriefInfo()
+方法签名：`Collection<ServerBriefInfo> getAllServersBriefInfo()`
 
 * **Returns:** 作业服务器简明信息集合
 
@@ -175,7 +175,7 @@ ElasticJob 提供了 Java API，可以通过直接对注册中心进行操作的
 
 ### 获取作业分片信息集合
 
-方法签名：Collection<ShardingInfo> getShardingInfo(String jobName)
+方法签名：`Collection<ShardingInfo> getShardingInfo(String jobName)`
 
 * **Parameters:**
   * jobName — 作业名称

--- a/docs/content/user-manual/usage/operation-api/_index.en.md
+++ b/docs/content/user-manual/usage/operation-api/_index.en.md
@@ -22,7 +22,7 @@ Class name: `org.apache.shardingsphere.elasticjob.lifecycle.api.JobConfiguration
 
 ### Get job configuration
 
-Method signature：YamlJobConfiguration getJobConfiguration(String jobName)
+Method signature：`JobConfigurationPOJO getJobConfiguration(String jobName)`
 
 * **Parameters:** 
   * jobName — Job name
@@ -31,14 +31,14 @@ Method signature：YamlJobConfiguration getJobConfiguration(String jobName)
 
 ### Update job configuration
 
-Method signature：void updateJobConfiguration(YamlJobConfiguration yamlJobConfiguration)
+Method signature：`void updateJobConfiguration(JobConfigurationPOJO jobConfig)`
 
 * **Parameters:** 
-  * jobConfiguration — Job configuration object
+  * jobConfig — Job configuration object
 
 ### Remove job configuration 
 
-Method signature：void removeJobConfiguration(String jobName)
+Method signature：`void removeJobConfiguration(String jobName)`
 
 * **Parameters:** 
   * jobName — Job name
@@ -51,7 +51,7 @@ Class name：`org.apache.shardingsphere.elasticjob.lifecycle.api.JobOperateAPI`
 
 The job will only trigger execution if it does not conflict with the currently running job, and this flag will be automatically cleared after it is started.
 
-Method signature：void trigger(Optional<String> jobName)
+Method signature：`void trigger(String jobName)`
 
 * **Parameters:**
   * jobName — Job name
@@ -60,7 +60,7 @@ Method signature：void trigger(Optional<String> jobName)
 
 Disabling a job will cause other distributed jobs to trigger resharding.
 
-Method signature：void disable(Optional<String> jobName, Optional<String> serverIp)
+Method signature：`void disable(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — Job name
@@ -68,7 +68,7 @@ Method signature：void disable(Optional<String> jobName, Optional<String> serve
 
 ### Enable job
 
-Method signature：void enable(Optional<String> jobName, Optional<String> serverIp)
+Method signature：`void enable(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — Job name
@@ -76,7 +76,7 @@ Method signature：void enable(Optional<String> jobName, Optional<String> server
 
 ### Shutdown scheduling job
 
-Method signature：void shutdown(Optional<String> jobName, Optional<String> serverIp)
+Method signature：`void shutdown(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — Job name
@@ -84,7 +84,7 @@ Method signature：void shutdown(Optional<String> jobName, Optional<String> serv
 
 ### Remove job
 
-Method signature：void remove(Optional<String> jobName, Optional<String> serverIp)
+Method signature：`void remove(String jobName, String serverIp)`
 
 * **Parameters:**
   * jobName — Job name
@@ -92,7 +92,7 @@ Method signature：void remove(Optional<String> jobName, Optional<String> server
 
 ### Dump job
 
-Method signature：String dump(String jobName, String instanceIp, int dumpPort)
+Method signature：`String dump(String jobName, String instanceIp, int dumpPort) throws IOException`
 
 * **Parameters:**
   * jobName — Job name
@@ -105,7 +105,7 @@ Class name：`org.apache.shardingsphere.elasticjob.lifecycle.api.ShardingOperate
 
 ### Disable job sharding
 
-Method signature：void disable(String jobName, String item)
+Method signature：`void disable(String jobName, String item)`
 
 * **Parameters:**
   * jobName — Job name
@@ -113,7 +113,7 @@ Method signature：void disable(String jobName, String item)
 
 ### Enable job sharding
 
-Method signature：void enable(String jobName, String item)
+Method signature：`void enable(String jobName, String item)`
 
 * **Parameters:**
   * jobName — Job name
@@ -125,13 +125,13 @@ Class name：`org.apache.shardingsphere.elasticjob.lifecycle.api.JobStatisticsAP
 
 ### Get the total count of jobs
 
-Method signature：int getJobsTotalCount()
+Method signature：`int getJobsTotalCount()`
 
 * **Returns:** the total count of jobs
 
 ### Get brief job information
 
-Method signature：JobBriefInfo getJobBriefInfo(String jobName)
+Method signature：`JobBriefInfo getJobBriefInfo(String jobName)`
 
 * **Parameters:**
   * jobName — Job name
@@ -140,13 +140,13 @@ Method signature：JobBriefInfo getJobBriefInfo(String jobName)
 
 ### Get brief information about all jobs.
 
-Method signature：Collection<JobBriefInfo> getAllJobsBriefInfo()
+Method signature：`Collection<JobBriefInfo> getAllJobsBriefInfo()`
 
 * **Returns:** Brief collection of all job information
 
 ### Get brief information of all jobs under this IP
 
-Method signature：Collection<JobBriefInfo> getJobsBriefInfo(String ip)
+Method signature：`Collection<JobBriefInfo> getJobsBriefInfo(String ip)`
 
 * **Parameters:**
   * ip — server IP
@@ -159,13 +159,13 @@ Class name：`org.apache.shardingsphere.elasticjob.lifecycle.api.ServerStatistic
 
 ### Total count of job servers
 
-Method signature：int getServersTotalCount()
+Method signature：`int getServersTotalCount()`
 
 * **Returns:** Get the total count of job servers
 
 ### Get brief information about all job servers
 
-Method signature：Collection<ServerBriefInfo> getAllServersBriefInfo()
+Method signature：`Collection<ServerBriefInfo> getAllServersBriefInfo()`
 
 * **Returns:** Brief collection of job information
 
@@ -175,7 +175,7 @@ Class name：`org.apache.shardingsphere.elasticjob.lifecycle.api.ShardingStatist
 
 ### Get job sharding information collection
 
-Method signature：Collection<ShardingInfo> getShardingInfo(String jobName)
+Method signature：`Collection<ShardingInfo> getShardingInfo(String jobName)`
 
 * **Parameters:**
   * jobName — Job name

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -50,7 +50,7 @@
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
         
-        <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
     </properties>
     

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <quartz.version>2.3.2</quartz.version>
         
         <zookeeper.version>3.9.2</zookeeper.version>
-        <curator.version>5.7.0</curator.version>
+        <curator.version>5.7.1</curator.version>
         
         <mail.version>1.6.0</mail.version>
         <commons-codec.version>1.16.0</commons-codec.version>
@@ -97,7 +97,7 @@
         
         <!-- Compile plugin versions -->
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
@@ -433,6 +433,13 @@
                         <target>${java.version}</target>
                         <testSource>${java.version}</testSource>
                         <testTarget>${java.version}</testTarget>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere-elasticjob/issues/2453 .

Changes proposed in this pull request:
- Support building and using ElasticJob with JDK23 .
- This does not change the integration of GraalVM Native Image. We will continue to use GraalVM CE For JDK22 to compile GraalVM Native Image until https://github.com/oracle/graal/issues/9929 is resolved. There are serious bugs on GraalVM CE For JDK 23.
- Fixes documentation's incorrect reference to JavaDoc.
