### PR TITLE
Bump Quartz to 2.4.0-rc3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,7 +14,7 @@
 1. Lifecycle: Support dynamic configuration of jobs through the Operation API in GraalVM Native Image - [#2426](https://github.com/apache/shardingsphere-elasticjob/pull/2426)
 1. Doc: Adds documentation for connecting to Zookeeper Server with SASL enabled - [#2442](https://github.com/apache/shardingsphere-elasticjob/pull/2442)
 1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
-1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
+1. Dependencies: Bump Quartz to 2.4.0-rc3 - [#2439](https://github.com/apache/shardingsphere-elasticjob/issues/2439)
 
 ### Bug Fixes
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <gson.version>2.10.1</gson.version>
         
-        <quartz.version>2.3.2</quartz.version>
+        <quartz.version>2.4.0-rc3</quartz.version>
         
         <zookeeper.version>3.9.2</zookeeper.version>
         <curator.version>5.7.1</curator.version>
@@ -188,12 +188,6 @@
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
                 <version>${quartz.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.mchange</groupId>
-                        <artifactId>c3p0</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Fixes #2439.

Changes proposed in this pull request:
- Bump Quartz to 2.4.0-rc3 . Also for https://github.com/quartz-scheduler/quartz/discussions/1166 .
- Update the Release Notes of my personal PR according to the requirements of https://shardingsphere.apache.org/community/cn/involved/contribute/contributor/ .
