### PR TITLE
Allows to skip Ensemble Tracker for ZookeeperConfiguration to allow connecting to HA enabled Zookeeper clusters in Kubernetes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,14 +6,15 @@
 
 ### New Features
 
+1. Bootstrap: Provides built-in GraalVM Reachability Metadata and nativeTest on Elasticjob Bootstrap - [#2268](https://github.com/apache/shardingsphere-elasticjob/pull/2268)
+1. Lifecycle: Support dynamic configuration of jobs through the Operation API in GraalVM Native Image - [#2426](https://github.com/apache/shardingsphere-elasticjob/pull/2426)
+1. Registry Center: Allows to skip Ensemble Tracker for ZookeeperConfiguration to allow connecting to HA enabled Zookeeper clusters in Kubernetes - [#2072](https://github.com/apache/shardingsphere-elasticjob/issues/2072)
+
 ### Enhancements
 
-1. Bootstrap: Provides built-in GraalVM Reachability Metadata and nativeTest on Elasticjob Bootstrap - [#2268](https://github.com/apache/shardingsphere-elasticjob/pull/2268)
 1. Build: Support for building with OpenJDK 22 - [#2407](https://github.com/apache/shardingsphere-elasticjob/issues/2407)
 1. Spring Boot Starter: Block `elasticjob-spring-boot-starter` from passing `spring-boot-starter` test scope dependencies - [#2418](https://github.com/apache/shardingsphere-elasticjob/issues/2418)
-1. Lifecycle: Support dynamic configuration of jobs through the Operation API in GraalVM Native Image - [#2426](https://github.com/apache/shardingsphere-elasticjob/pull/2426)
 1. Doc: Adds documentation for connecting to Zookeeper Server with SASL enabled - [#2442](https://github.com/apache/shardingsphere-elasticjob/pull/2442)
-1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
 1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
 
 ### Bug Fixes

--- a/docs/content/user-manual/configuration/external-integration/sasl.cn.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.cn.md
@@ -48,16 +48,15 @@ public class ExampleUtils {
         Configuration configuration = new Configuration() {
             @Override
             public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
-                Map<String, String> options = new HashMap<>();
-                options.put("username", "bob");
-                options.put("password", "bobsecret");
-                AppConfigurationEntry entry = new AppConfigurationEntry(
+                Map<String, String> conf = new HashMap<>();
+                conf.put("username", "bob");
+                conf.put("password", "bobsecret");
+                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
+                entries[0] = new AppConfigurationEntry(
                         "org.apache.zookeeper.server.auth.DigestLoginModule",
                         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        options);
-                AppConfigurationEntry[] array = new AppConfigurationEntry[1];
-                array[0] = entry;
-                return array;
+                        conf);
+                return entries;
             }
         };
         Configuration.setConfiguration(configuration);

--- a/docs/content/user-manual/configuration/external-integration/sasl.en.md
+++ b/docs/content/user-manual/configuration/external-integration/sasl.en.md
@@ -52,16 +52,15 @@ public class ExampleUtils {
         Configuration configuration = new Configuration() {
             @Override
             public AppConfigurationEntry[] getAppConfigurationEntry(final String name) {
-                Map<String, String> options = new HashMap<>();
-                options.put("username", "bob");
-                options.put("password", "bobsecret");
-                AppConfigurationEntry entry = new AppConfigurationEntry(
+                Map<String, String> conf = new HashMap<>();
+                conf.put("username", "bob");
+                conf.put("password", "bobsecret");
+                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
+                entries[0] = new AppConfigurationEntry(
                         "org.apache.zookeeper.server.auth.DigestLoginModule",
                         AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        options);
-                AppConfigurationEntry[] array = new AppConfigurationEntry[1];
-                array[0] = entry;
-                return array;
+                        conf);
+                return entries;
             }
         };
         Configuration.setConfiguration(configuration);

--- a/registry-center/provider/zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfiguration.java
+++ b/registry-center/provider/zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperConfiguration.java
@@ -74,4 +74,15 @@ public final class ZookeeperConfiguration {
      * Zookeeper digest.
      */
     private String digest;
+    
+    /**
+     * Allows configuring if the ensemble configuration changes are watched.
+     * If the HA enabled Zookeeper clusters are hidden under a virtual IP of Kubernetes,
+     * the Zookeeper Client can return a URL during Ensemble Tracking,
+     * which will cause an unresolved host exception within the Curator Framework.
+     * At the ElasticJob level, this will cause a cluster restart.
+     *
+     * @see org.apache.curator.framework.CuratorFrameworkFactory.Builder#ensembleTracker(boolean)
+     */
+    private boolean ensembleTracker = true;
 }

--- a/registry-center/provider/zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
+++ b/registry-center/provider/zookeeper-curator/src/main/java/org/apache/shardingsphere/elasticjob/reg/zookeeper/ZookeeperRegistryCenter.java
@@ -98,6 +98,7 @@ public final class ZookeeperRegistryCenter implements CoordinatorRegistryCenter 
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
                 .connectString(zkConfig.getServerLists())
                 .retryPolicy(new ExponentialBackoffRetry(zkConfig.getBaseSleepTimeMilliseconds(), zkConfig.getMaxRetries(), zkConfig.getMaxSleepTimeMilliseconds()))
+                .ensembleTracker(zkConfig.isEnsembleTracker())
                 .namespace(zkConfig.getNamespace());
         if (0 != zkConfig.getSessionTimeoutMilliseconds()) {
             builder.sessionTimeoutMs(zkConfig.getSessionTimeoutMilliseconds());


### PR DESCRIPTION
Fixes #2072.

Changes proposed in this pull request:
- Allows to skip Ensemble Tracker for ZookeeperConfiguration to allow connecting to HA enabled Zookeeper clusters in Kubernetes. See https://issues.apache.org/jira/browse/FLINK-31780 and https://issues.apache.org/jira/browse/CURATOR-568 .
- If the HA enabled Zookeeper clusters are hidden under a virtual IP of Kubernetes, the Zookeeper Client can return a URL during Ensemble Tracking, which will cause an unresolved host exception within the Curator Framework. At the ElasticJob level, this will cause a cluster restart.
- Updates documentation to match variable naming conventions in https://github.com/apache/zookeeper/blob/release-3.9.2/zookeeper-server/src/test/java/org/apache/zookeeper/JaasConfiguration.java .
- Also fixes https://github.com/apache/shardingsphere-elasticjob/issues/1812 .
