### PR TITLE
Bump Quartz to 2.4.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,7 @@
 1. Build: Support for building with OpenJDK 22 - [#2407](https://github.com/apache/shardingsphere-elasticjob/issues/2407)
 1. Spring Boot Starter: Block `elasticjob-spring-boot-starter` from passing `spring-boot-starter` test scope dependencies - [#2418](https://github.com/apache/shardingsphere-elasticjob/issues/2418)
 1. Doc: Adds documentation for connecting to Zookeeper Server with SASL enabled - [#2442](https://github.com/apache/shardingsphere-elasticjob/pull/2442)
+1. Dependencies: Bump Quartz to 2.4.0 - [#2439](https://github.com/apache/shardingsphere-elasticjob/issues/2439)
 1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <gson.version>2.10.1</gson.version>
         
-        <quartz.version>2.3.2</quartz.version>
+        <quartz.version>2.4.0</quartz.version>
         
         <zookeeper.version>3.9.2</zookeeper.version>
         <curator.version>5.7.1</curator.version>
@@ -188,12 +188,6 @@
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
                 <version>${quartz.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.mchange</groupId>
-                        <artifactId>c3p0</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Fixes #2439.

Changes proposed in this pull request:
- Bump Quartz to 2.4.0 . See https://github.com/quartz-scheduler/quartz/discussions/1166 .
