### PR TITLE
Revert "feat: Support business code capture interruption during exit"

### DIFF
--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/threadpool/ExecutorServiceReloader.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/threadpool/ExecutorServiceReloader.java
@@ -47,7 +47,7 @@ public final class ExecutorServiceReloader implements Closeable {
         if (jobExecutorThreadPoolSizeProviderType.equals(jobConfig.getJobExecutorThreadPoolSizeProviderType())) {
             return;
         }
-        executorService.shutdownNow();
+        executorService.shutdown();
         init(jobConfig);
     }
     
@@ -59,6 +59,6 @@ public final class ExecutorServiceReloader implements Closeable {
     
     @Override
     public void close() {
-        executorService.shutdownNow();
+        executorService.shutdown();
     }
 }

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/schedule/JobScheduler.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/schedule/JobScheduler.java
@@ -178,7 +178,6 @@ public final class JobScheduler {
         result.put("org.quartz.jobStore.misfireThreshold", "1");
         result.put("org.quartz.plugin.shutdownhook.class", JobShutdownHookPlugin.class.getName());
         result.put("org.quartz.plugin.shutdownhook.cleanShutdown", Boolean.TRUE.toString());
-        result.put("org.quartz.scheduler.interruptJobsOnShutdown", Boolean.TRUE.toString());
         return result;
     }
     
@@ -201,7 +200,6 @@ public final class JobScheduler {
     public void shutdown() {
         setUpFacade.tearDown();
         schedulerFacade.shutdownInstance();
-        jobScheduleController.shutdown(false);
         jobExecutor.shutdown();
     }
 }

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/schedule/LiteJob.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/schedule/LiteJob.java
@@ -19,36 +19,20 @@ package org.apache.shardingsphere.elasticjob.kernel.internal.schedule;
 
 import lombok.Setter;
 import org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor;
-import org.quartz.InterruptableJob;
+import org.quartz.Job;
 import org.quartz.JobExecutionContext;
-import org.quartz.UnableToInterruptJobException;
-
-import java.util.Objects;
 
 /**
  * Lite job.
  */
 @Setter
-public final class LiteJob implements InterruptableJob {
+public final class LiteJob implements Job {
     
     private ElasticJobExecutor jobExecutor;
     
-    private volatile Thread currentThread;
-    
     @Override
     public void execute(final JobExecutionContext context) {
-        try {
-            currentThread = Thread.currentThread();
-            jobExecutor.execute();
-        } finally {
-            currentThread = null;
-        }
+        jobExecutor.execute();
     }
     
-    @Override
-    public void interrupt() throws UnableToInterruptJobException {
-        if (Objects.nonNull(currentThread)) {
-            currentThread.interrupt();
-        }
-    }
 }

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/threadpool/ExecutorServiceReloaderTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/threadpool/ExecutorServiceReloaderTest.java
@@ -57,7 +57,7 @@ class ExecutorServiceReloaderTest {
         ReflectionUtils.setFieldValue(executorServiceReloader, "executorService", mockExecutorService);
         JobConfiguration jobConfig = JobConfiguration.newBuilder("job", 1).build();
         executorServiceReloader.reloadIfNecessary(jobConfig);
-        verify(mockExecutorService).shutdownNow();
+        verify(mockExecutorService).shutdown();
         ExecutorService actual = executorServiceReloader.getExecutorService();
         assertFalse(actual.isShutdown());
         assertFalse(actual.isTerminated());
@@ -81,6 +81,6 @@ class ExecutorServiceReloaderTest {
         ExecutorServiceReloader executorServiceReloader = new ExecutorServiceReloader(JobConfiguration.newBuilder("job", 1).jobExecutorThreadPoolSizeProviderType("SINGLE_THREAD").build());
         ReflectionUtils.setFieldValue(executorServiceReloader, "executorService", mockExecutorService);
         executorServiceReloader.close();
-        verify(mockExecutorService).shutdownNow();
+        verify(mockExecutorService).shutdown();
     }
 }


### PR DESCRIPTION
- Reverts apache/shardingsphere-elasticjob#2475 .
- The unit test actually fails. See https://github.com/apache/shardingsphere-elasticjob/issues/2473#issuecomment-3278848510 .