### PR TITLE
Support building and using ElasticJob with JDK24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
-        java: [ 8, 17, 21, 23 ]
+        java: [ 8, 17, 21, 24 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,19 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,7 @@
 1. Doc: Adds documentation for connecting to Zookeeper Server with SASL enabled - [#2442](https://github.com/apache/shardingsphere-elasticjob/pull/2442)
 1. Dependencies: Bump Quartz to 2.4.0 - [#2439](https://github.com/apache/shardingsphere-elasticjob/issues/2439)
 1. Build: Support building and using ElasticJob with JDK23 - [#2453](https://github.com/apache/shardingsphere-elasticjob/issues/2453)
+1. Build: Support building and using ElasticJob with JDK24 - [#2481](https://github.com/apache/shardingsphere-elasticjob/pull/2481)
 
 ### Bug Fixes
 

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -82,13 +82,13 @@
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>
         
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.40</lombok.version>
         
         <junit.version>5.10.3</junit.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>4.11.0</mockito.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <bytebuddy.version>1.14.18</bytebuddy.version>
+        <bytebuddy.version>1.17.7</bytebuddy.version>
         
         <h2.version>2.2.224</h2.version>
         <hikari-cp.version>4.0.3</hikari-cp.version>
@@ -116,7 +116,7 @@
         <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         
         <!-- Report plugin versions -->
         <maven-site-plugin.version>4.0.0-M6</maven-site-plugin.version>
@@ -567,7 +567,6 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <source>${java.version}</source>
                     <charset>${project.build.sourceEncoding}</charset>
                     <encoding>${project.build.sourceEncoding}</encoding>

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
@@ -24,6 +24,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -34,10 +36,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * todo There is no `echo` program on Windows 11 cmd. Waiting for a fix.
+ */
+@EnabledOnOs(OS.LINUX)
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = "classpath:META-INF/job/withJobType.xml")
 class JobSpringNamespaceWithTypeTest {
@@ -58,13 +62,13 @@ class JobSpringNamespaceWithTypeTest {
     
     @AfterEach
     void tearDown() {
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(scheduler.getCurrentlyExecutingJobs().isEmpty(), is(true)));
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).until(() -> scheduler.getCurrentlyExecutingJobs().isEmpty());
         JobRegistry.getInstance().getJobScheduleController(scriptJobName).shutdown();
     }
     
     @Test
     void jobScriptWithJobTypeTest() throws SchedulerException {
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(regCenter.isExisted("/" + scriptJobName + "/sharding"), is(true)));
+        Awaitility.await().atMost(1L, TimeUnit.MINUTES).until(() -> regCenter.isExisted("/" + scriptJobName + "/sharding"));
         scheduler = (Scheduler) ReflectionTestUtils.getField(JobRegistry.getInstance().getJobScheduleController(scriptJobName), "scheduler");
         assertTrue(scheduler.isStarted());
     }

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -25,6 +25,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -35,6 +37,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * todo There is no `echo` program on Windows 11 cmd. Waiting for a fix.
+ */
+@EnabledOnOs(OS.LINUX)
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobType.xml")
 class OneOffJobSpringNamespaceWithTypeTest {


### PR DESCRIPTION
Fixes #2480 .

Changes proposed in this pull request:

- Support building and using ElasticJob with JDK24 .
- Bump the hamcrest version. Otherwise, it will conflict with the jacoco Maven plugin.
- Bump `jacoco-maven-plugin` version. See https://github.com/jacoco/jacoco/pull/1631 .

> Add experimental support for Java 24 class files

-  Bump Byte Buddy version. See https://github.com/raphw/byte-buddy/commit/634b3d19b71e0ac951f00cc520bbfa3db0219495#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8 .

> Runs the build with compatibility for Java 24 JVMs.

- Bump Lombok version. See https://github.com/projectlombok/lombok/blob/v1.18.38/doc/changelog.markdown .

> PLATFORM: JDK24 support added.

- Bump the Maven version used by the Maven Wrapper. See https://github.com/apache/maven/issues/10228 .

> [MNG-8399] JDK 24+ issues warning about usage of sun.misc.Unsafe

- Remove the unused `aggregate` parameter from the javadoc plugin. See https://github.com/apache/maven-javadoc-plugin/issues/749 .
```shell
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] Parameter 'aggregate' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
[WARNING] Parameter 'aggregate' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
[WARNING] Parameter 'aggregate' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
[WARNING] Parameter 'aggregate' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
[WARNING] Parameter 'aggregate' is unknown for plugin 'maven-javadoc-plugin:3.5.0:jar (attach-javadocs)'
```

- Prevent calling `echo` program in cmd of Windows 11. I am shocked by the behavior of using PowerShell 7 as the only shell in Windows Server 2025 in CI. Does this mean that we can only support PowerShell 7 on Windows Server?

```shell
[ERROR] 2025-09-12 20:17:54,107 --elasticjob-scriptElasticJob_job_type-1-- [org.apache.shardingsphere.elasticjob.error.handler.normal.LogJobErrorHandler] Job 'scriptElasticJob_job_type' exception occur in job processing 
org.apache.shardingsphere.elasticjob.kernel.infra.exception.JobSystemException: Execute script failure.
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:48)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.process(ElasticJobExecutor.java:183)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.lambda$process$0(ElasticJobExecutor.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.io.IOException: Cannot run program "echo" (in directory "."): CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1170)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089)
	at java.base/java.lang.Runtime.exec(Runtime.java:681)
	at org.apache.commons.exec.launcher.Java13CommandLauncher.exec(Java13CommandLauncher.java:61)
	at org.apache.commons.exec.DefaultExecutor.launch(DefaultExecutor.java:279)
	at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:336)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:166)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:153)
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:46)
	... 9 common frames omitted
Caused by: java.io.IOException: CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessImpl.create(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:500)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:159)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126)
	... 17 common frames omitted
[ERROR] 2025-09-12 20:17:54,111 --elasticjob-scriptElasticJob_job_type-1-- [org.apache.shardingsphere.elasticjob.error.handler.normal.LogJobErrorHandler] Job 'scriptElasticJob_job_type' exception occur in job processing 
org.apache.shardingsphere.elasticjob.kernel.infra.exception.JobSystemException: Execute script failure.
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:48)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.process(ElasticJobExecutor.java:183)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.lambda$process$0(ElasticJobExecutor.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.io.IOException: Cannot run program "echo" (in directory "."): CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1170)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089)
	at java.base/java.lang.Runtime.exec(Runtime.java:681)
	at org.apache.commons.exec.launcher.Java13CommandLauncher.exec(Java13CommandLauncher.java:61)
	at org.apache.commons.exec.DefaultExecutor.launch(DefaultExecutor.java:279)
	at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:336)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:166)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:153)
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:46)
	... 9 common frames omitted
Caused by: java.io.IOException: CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessImpl.create(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:500)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:159)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126)
	... 17 common frames omitted
[ERROR] 2025-09-12 20:17:54,113 --elasticjob-scriptElasticJob_job_type-1-- [org.apache.shardingsphere.elasticjob.error.handler.normal.LogJobErrorHandler] Job 'scriptElasticJob_job_type' exception occur in job processing 
org.apache.shardingsphere.elasticjob.kernel.infra.exception.JobSystemException: Execute script failure.
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:48)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.process(ElasticJobExecutor.java:183)
	at org.apache.shardingsphere.elasticjob.kernel.executor.ElasticJobExecutor.lambda$process$0(ElasticJobExecutor.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.io.IOException: Cannot run program "echo" (in directory "."): CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1170)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089)
	at java.base/java.lang.Runtime.exec(Runtime.java:681)
	at org.apache.commons.exec.launcher.Java13CommandLauncher.exec(Java13CommandLauncher.java:61)
	at org.apache.commons.exec.DefaultExecutor.launch(DefaultExecutor.java:279)
	at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:336)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:166)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:153)
	at org.apache.shardingsphere.elasticjob.script.executor.ScriptJobExecutor.process(ScriptJobExecutor.java:46)
	... 9 common frames omitted
Caused by: java.io.IOException: CreateProcess error=2, 系统找不到指定的文件。
	at java.base/java.lang.ProcessImpl.create(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:500)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:159)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126)
	... 17 common frames omitted

进程已结束，退出代码为 0
```

