### PR TITLE
Prevent unit tests from using host ports `18181` and `9898`

### DIFF
--- a/spring/boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/snapshot/ElasticJobSnapshotServiceConfigurationTest.java
+++ b/spring/boot-starter/src/test/java/org/apache/shardingsphere/elasticjob/spring/boot/reg/snapshot/ElasticJobSnapshotServiceConfigurationTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.shardingsphere.elasticjob.spring.boot.reg.snapshot;
 
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
 import org.apache.shardingsphere.elasticjob.kernel.internal.snapshot.SnapshotService;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +31,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -34,12 +44,32 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ActiveProfiles("snapshot")
 class ElasticJobSnapshotServiceConfigurationTest {
     
+    private static TestingServer testingServer;
+    
     @Autowired
     private ApplicationContext applicationContext;
     
+    @DynamicPropertySource
+    static void elasticjobProperties(final DynamicPropertyRegistry registry) {
+        registry.add("elasticjob.regCenter.serverLists", () -> testingServer.getConnectString());
+        registry.add("elasticjob.dump.port", InstanceSpec::getRandomPort);
+    }
+    
     @BeforeAll
-    static void init() {
-        new EmbedTestingServer(18181).start();
+    static void init() throws Exception {
+        testingServer = new TestingServer();
+        try (
+                CuratorZookeeperClient client = new CuratorZookeeperClient(testingServer.getConnectString(),
+                        60000, 500, null,
+                        new ExponentialBackoffRetry(500, 3, 1500))) {
+            client.start();
+            Awaitility.await().atMost(Duration.ofSeconds(30L)).ignoreExceptions().until(client::isConnected);
+        }
+    }
+    
+    @AfterAll
+    static void afterAll() throws IOException {
+        testingServer.close();
     }
     
     @Test

--- a/spring/boot-starter/src/test/resources/application-elasticjob.yml
+++ b/spring/boot-starter/src/test/resources/application-elasticjob.yml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+# `elasticjob.regCenter.serverLists` is dynamically defined in `org.springframework.test.context.DynamicPropertySource`
 spring:
   datasource:
     url: jdbc:h2:mem:job_event_storage
@@ -27,7 +28,6 @@ elasticjob:
     type: RDB
     excludeJobNames: [customTestJob]
   regCenter:
-    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter
   jobs:
     customTestJob:

--- a/spring/boot-starter/src/test/resources/application-snapshot.yml
+++ b/spring/boot-starter/src/test/resources/application-snapshot.yml
@@ -15,9 +15,8 @@
 # limitations under the License.
 #
 
+# `elasticjob.regCenter.serverLists` is dynamically defined in `org.springframework.test.context.DynamicPropertySource`
+# `elasticjob.dump.port` is dynamically defined in `org.springframework.test.context.DynamicPropertySource`
 elasticjob:
-  dump:
-    port: 0
   regCenter:
-    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter

--- a/spring/boot-starter/src/test/resources/application-tracing.yml
+++ b/spring/boot-starter/src/test/resources/application-tracing.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
+# `elasticjob.regCenter.serverLists` is dynamically defined in `org.springframework.test.context.DynamicPropertySource`
 elasticjob:
   regCenter:
-    serverLists: 127.0.0.1:18181
     namespace: elasticjob-spring-boot-starter

--- a/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/snapshot/SnapshotServiceDisableE2ETest.java
+++ b/test/e2e/src/test/java/org/apache/shardingsphere/elasticjob/test/e2e/snapshot/SnapshotServiceDisableE2ETest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.test.e2e.snapshot;
 
+import org.apache.curator.test.InstanceSpec;
 import org.apache.shardingsphere.elasticjob.kernel.internal.snapshot.SnapshotService;
 import org.apache.shardingsphere.elasticjob.test.e2e.raw.fixture.job.E2EFixtureJobImpl;
 import org.apache.shardingsphere.elasticjob.test.util.ReflectionUtils;
@@ -46,8 +47,9 @@ class SnapshotServiceDisableE2ETest extends BaseSnapshotServiceE2ETest {
     
     @Test
     void assertListenException() throws IOException {
-        ServerSocket serverSocket = new ServerSocket(9898);
-        SnapshotService snapshotService = new SnapshotService(getRegCenter(), 9898);
+        int randomPort = InstanceSpec.getRandomPort();
+        ServerSocket serverSocket = new ServerSocket(randomPort);
+        SnapshotService snapshotService = new SnapshotService(getRegCenter(), randomPort);
         snapshotService.listen();
         serverSocket.close();
         assertNull(ReflectionUtils.getFieldValue(snapshotService, "serverSocket"));

--- a/test/native/pom.xml
+++ b/test/native/pom.xml
@@ -29,9 +29,9 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <!--TODO Blocked by https://github.com/apache/shardingsphere-elasticjob/issues/2425 -->
-        <spring-boot-dependencies.version>3.3.5</spring-boot-dependencies.version>
-        <slf4j.version>2.0.16</slf4j.version>
-        <logback.version>1.5.11</logback.version>
+        <spring-boot-dependencies.version>3.5.5</spring-boot-dependencies.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.5.18</logback.version>
     </properties>
     
     <dependencies>

--- a/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/it/staticd/SpringBootDTest.java
+++ b/test/native/src/test/java/org/apache/shardingsphere/elasticjob/test/natived/it/staticd/SpringBootDTest.java
@@ -53,9 +53,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+/**
+ * ElasticJob Spring Boot Starter requires that all Spring Boot Applications be shut down before shutting down Zookeeper Server.
+ * That's why this unit test uses {@link DirtiesContext}.
+ * Refer to <a href="https://github.com/spring-projects/spring-framework/issues/26196">spring-projects/spring-framework#26196</a> .
+ */
+@DirtiesContext
+@SpringBootTest(webEnvironment = org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnabledInNativeImage
-class SpirngBootTest {
+class SpringBootDTest {
     
     private static TestingServer testingServer;
     
@@ -94,12 +100,6 @@ class SpirngBootTest {
                 .build();
     }
     
-    /**
-     * ElasticJob Spring Boot Starter requires that all Spring Boot Applications be shut down before shutting down Zookeeper Server.
-     * That's why this unit test uses {@link DirtiesContext}.
-     * Refer to <a href="https://github.com/spring-projects/spring-framework/issues/26196">spring-projects/spring-framework#26196</a> .
-     */
-    @DirtiesContext
     @Test
     public void testOneOffJob() throws Exception {
         String contentAsString = mockMvc.perform(
@@ -115,7 +115,6 @@ class SpirngBootTest {
         assertThat(contentAsString, is("{\"msg\":\"OK\"}"));
     }
     
-    @DirtiesContext
     @Test
     void testIssue2012() {
         ZookeeperRegistryCenter zookeeperRegistryCenter = zookeeperRegistryCenterProvider.getIfAvailable();


### PR DESCRIPTION
For #2410 .

Changes proposed in this pull request:
- Prevent unit tests from using host ports `18181` and `9898`. Verified under Spring Boot `2.7.18` and `3.5.5`.
- It's unfortunate to see that https://github.com/spring-projects/spring-framework/issues/26196 remains unresolved after 5 years. The use of `org.springframework.test.annotation.DirtiesContext` has become more widespread than ever. Otherwise,

```shell
[ERROR] 2025-09-12 22:47:58,443 --Quartz Shutdown-Hook printTestJob-- [org.apache.zookeeper.server.NIOServerCnxnFactory] Thread Thread[#113,Quartz Shutdown-Hook printTestJob,5,main] died 
org.apache.shardingsphere.elasticjob.reg.exception.RegException: java.lang.IllegalStateException: Client is not started
	at org.apache.shardingsphere.elasticjob.reg.exception.RegExceptionHandler.handleException(RegExceptionHandler.java:46)
	at org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter.getDirectly(ZookeeperRegistryCenter.java:184)
	at org.apache.shardingsphere.elasticjob.reg.zookeeper.ZookeeperRegistryCenter.lambda$get$1(ZookeeperRegistryCenter.java:165)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
```