### PR TITLE
Fix flaky test in ElasticJobExecutorTest

### DIFF
--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -135,17 +136,21 @@ class ElasticJobExecutorTest {
         } finally {
             verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
             verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_RUNNING, "");
-            verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_ERROR, getErrorMessage(shardingContexts));
+            verify(jobFacade).postJobStatusTraceEvent(eq(shardingContexts.getTaskId()), eq(State.TASK_ERROR), argThat(msg -> isValidErrorMessage(msg, shardingContexts)));
             verify(jobFacade).registerJobBegin(shardingContexts);
             verify(jobItemExecutor, times(shardingContexts.getShardingTotalCount())).process(eq(fooJob), eq(jobConfig), eq(jobRuntimeService), any());
             verify(jobFacade).registerJobCompleted(shardingContexts);
         }
     }
     
-    private String getErrorMessage(final ShardingContexts shardingContexts) {
-        return 1 == shardingContexts.getShardingItemParameters().size()
-                ? "{0=java.lang.RuntimeException" + System.lineSeparator() + "}"
-                : "{0=java.lang.RuntimeException" + System.lineSeparator() + ", 1=java.lang.RuntimeException" + System.lineSeparator() + "}";
+    private boolean isValidErrorMessage(final String errorMessage, final ShardingContexts shardingContexts) {
+        if (1 == shardingContexts.getShardingItemParameters().size()) {
+            return errorMessage.equals("{0=java.lang.RuntimeException" + System.lineSeparator() + "}");
+        } else {
+            String pattern1 = "{0=java.lang.RuntimeException" + System.lineSeparator() + ", 1=java.lang.RuntimeException" + System.lineSeparator() + "}";
+            String pattern2 = "{1=java.lang.RuntimeException" + System.lineSeparator() + ", 0=java.lang.RuntimeException" + System.lineSeparator() + "}";
+            return errorMessage.equals(pattern1) || errorMessage.equals(pattern2);
+        }
     }
     
     @Test

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
@@ -145,7 +145,7 @@ class ElasticJobExecutorTest {
     
     private boolean isValidErrorMessage(final String errorMessage, final ShardingContexts shardingContexts) {
         if (1 == shardingContexts.getShardingItemParameters().size()) {
-            return errorMessage.equals("{0=java.lang.RuntimeException" + System.lineSeparator() + "}");
+            return ("{0=java.lang.RuntimeException" + System.lineSeparator() + "}").equals(errorMessage);
         } else {
             String pattern1 = "{0=java.lang.RuntimeException" + System.lineSeparator() + ", 1=java.lang.RuntimeException" + System.lineSeparator() + "}";
             String pattern2 = "{1=java.lang.RuntimeException" + System.lineSeparator() + ", 0=java.lang.RuntimeException" + System.lineSeparator() + "}";


### PR DESCRIPTION
Fixes #2485 .

### Changes proposed in this pull request:
- Modified `getErrorMessage` to `isValidErrorMessage()` method in `ElasticJobExecutorTest` to accept both possible orderings of `ConcurrentHashMap` entries (`{0=..., 1=...}` or `{1=..., 0=...}`)
- This fix eliminates the flaky test failure caused by non-deterministic HashMap iteration order
