### PR TITLE
Bump Netty from 4.1.112.Final to 4.2.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         
-        <netty.version>4.1.112.Final</netty.version>
+        <netty.version>4.2.9.Final</netty.version>
         
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>


### PR DESCRIPTION
Fix CVE:
- https://www.cve.org/CVERecord?id=CVE-2025-25193
- https://www.cve.org/CVERecord?id=CVE-2024-47535

Ref:
- https://mvnrepository.com/artifact/io.netty/netty-transport/4.1.112.Final
