### PR TITLE
Bump Spring Framework from 5.3.31 to 5.3.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <hikari-cp.version>4.0.3</hikari-cp.version>
         
         <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
+        <spring-framework.version>5.3.39</spring-framework.version>
         
         <!-- Compile plugin versions -->
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -47,6 +47,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>


### PR DESCRIPTION
Fix CVE:
- https://www.cve.org/CVERecord?id=CVE-2024-22259

> Note that version 5.3.39 is the last open-source version of the Spring Framework 5.3.x series.