### PR TITLE
Bump the JDK requirement for build time from JDK 8 to JDK 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
-        java: [ 8, 17, 21, 24 ]
+        java: [ 17, 21, 24 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,9 +53,30 @@ jobs:
         run: |
           ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -Pcheck -T1C
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '8'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '17'
         uses: codecov/codecov-action@v3
         with:
           file: '**/target/site/jacoco/jacoco.xml'
       - name: Build Examples with Maven
         run: ./mvnw clean package -B -f examples/pom.xml -T1C
+
+  build-jdk17-test-with-jdk8:
+    if: github.repository == 'apache/shardingsphere-elasticjob'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 8
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
+      - name: Build with JDK 17
+        run: ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -DskipTests -T1C
+      - name: Run Tests with JDK 8
+        run: JAVA_HOME=$JAVA_HOME_8_X64 ./mvnw --batch-mode --no-transfer-progress surefire:test -fae -T1C

--- a/.github/workflows/required-check.yml
+++ b/.github/workflows/required-check.yml
@@ -34,6 +34,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
       - name: Run CheckStyle
         run: ./mvnw checkstyle:check -Pcheck -T1C
 
@@ -44,6 +50,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
       - name: Run Spotless
         run: ./mvnw spotless:check -Pcheck -T1C
 
@@ -54,5 +66,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
       - name: Run Apache Rat
         run: ./mvnw apache-rat:check -Pcheck -T1C

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,9 @@
+## 3.0.6-SNAPSHOT
+
+### Enhancements
+
+1. Bump the JDK requirement for build time from JDK 8 to JDK 17 - [#2509](https://github.com/apache/shardingsphere-elasticjob/issues/2509)
+
 ## 3.0.5
 
 ### CVE

--- a/pom.xml
+++ b/pom.xml
@@ -600,7 +600,7 @@
                                     <version>${maven.version.range}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>${java.version}</version>
+                                    <version>[17,)</version>
                                 </requireJavaVersion>
                             </rules>
                             <fail>true</fail>


### PR DESCRIPTION
Fixes #2509 .

Changes proposed in this pull request:
- Bump the JDK requirement for build time from JDK 8 to JDK 17.
