### PR TITLE
Fix registerJobCompleted to retain running node for failed sharding items

### DIFF
--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutor.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutor.java
@@ -37,6 +37,7 @@ import org.apache.shardingsphere.elasticjob.spi.tracing.event.JobStatusTraceEven
 import org.apache.shardingsphere.infra.spi.type.typed.TypedSPILoader;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -134,7 +135,8 @@ public final class ElasticJobExecutor {
             process(jobConfig, shardingContexts, executionSource);
         } finally {
             // TODO Consider increasing the status of job failure, and how to handle the overall loop of job failure
-            jobFacade.registerJobCompleted(shardingContexts);
+            Collection<Integer> failedItems = new HashSet<>(itemErrorMessages.keySet());
+            jobFacade.registerJobCompleted(shardingContexts, failedItems);
             if (itemErrorMessages.isEmpty()) {
                 jobFacade.postJobStatusTraceEvent(taskId, State.TASK_FINISHED, "");
             } else {

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/AbstractJobFacade.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/AbstractJobFacade.java
@@ -118,12 +118,15 @@ abstract class AbstractJobFacade implements JobFacade {
      * Register job completed.
      *
      * @param shardingContexts sharding contexts
+     * @param failedItems
      */
     @Override
-    public void registerJobCompleted(final ShardingContexts shardingContexts) {
-        executionService.registerJobCompleted(shardingContexts);
+    public void registerJobCompleted(final ShardingContexts shardingContexts, final Collection<Integer> failedItems) {
+        executionService.registerJobCompleted(shardingContexts, failedItems);
         if (configService.load(true).isFailover()) {
-            failoverService.updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
+            Collection<Integer> successItems = shardingContexts.getShardingItemParameters().keySet()
+                    .stream().filter(item -> !failedItems.contains(item)).collect(Collectors.toSet());
+            failoverService.updateFailoverComplete(successItems);
         }
     }
     

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/AbstractJobFacade.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/AbstractJobFacade.java
@@ -118,7 +118,7 @@ abstract class AbstractJobFacade implements JobFacade {
      * Register job completed.
      *
      * @param shardingContexts sharding contexts
-     * @param failedItems
+     * @param failedItems failed sharding items
      */
     @Override
     public void registerJobCompleted(final ShardingContexts shardingContexts, final Collection<Integer> failedItems) {

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/JobFacade.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/JobFacade.java
@@ -62,8 +62,9 @@ public interface JobFacade {
      * Register job completed.
      *
      * @param shardingContexts sharding contexts
+     * @param failedItems failed sharding items
      */
-    void registerJobCompleted(ShardingContexts shardingContexts);
+    void registerJobCompleted(ShardingContexts shardingContexts, Collection<Integer> failedItems);
     
     /**
      * Get sharding contexts.

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacade.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacade.java
@@ -81,10 +81,10 @@ public final class SingleShardingJobFacade extends AbstractJobFacade {
         jobNodeStorage = new JobNodeStorage(regCenter, jobName);
         instanceService = new InstanceService(regCenter, jobName);
     }
-    
+
     @Override
-    public void registerJobCompleted(final ShardingContexts shardingContexts) {
-        super.registerJobCompleted(shardingContexts);
+    public void registerJobCompleted(final ShardingContexts shardingContexts, final Collection<Integer> failedItems) {
+        super.registerJobCompleted(shardingContexts, failedItems);
         
         JobConfiguration jobConfig = configService.load(true);
         JobInstance jobInst = JobRegistry.getInstance().getJobInstance(jobConfig.getJobName());

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacade.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacade.java
@@ -81,7 +81,7 @@ public final class SingleShardingJobFacade extends AbstractJobFacade {
         jobNodeStorage = new JobNodeStorage(regCenter, jobName);
         instanceService = new InstanceService(regCenter, jobName);
     }
-
+    
     @Override
     public void registerJobCompleted(final ShardingContexts shardingContexts, final Collection<Integer> failedItems) {
         super.registerJobCompleted(shardingContexts, failedItems);

--- a/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionService.java
+++ b/kernel/src/main/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionService.java
@@ -73,14 +73,17 @@ public final class ExecutionService {
      * Register job completed.
      * 
      * @param shardingContexts sharding contexts
+     * @param failedItems failed sharding items
      */
-    public void registerJobCompleted(final ShardingContexts shardingContexts) {
+    public void registerJobCompleted(final ShardingContexts shardingContexts, final Collection<Integer> failedItems) {
         JobRegistry.getInstance().setJobRunning(jobName, false);
         if (!configService.load(true).isMonitorExecution()) {
             return;
         }
         for (int each : shardingContexts.getShardingItemParameters().keySet()) {
-            jobNodeStorage.removeJobNodeIfExisted(ShardingNode.getRunningNode(each));
+            if (!failedItems.contains(each)) {
+                jobNodeStorage.removeJobNodeIfExisted(ShardingNode.getRunningNode(each));
+            }
         }
     }
     

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/ElasticJobExecutorTest.java
@@ -139,7 +139,7 @@ class ElasticJobExecutorTest {
             verify(jobFacade).postJobStatusTraceEvent(eq(shardingContexts.getTaskId()), eq(State.TASK_ERROR), argThat(msg -> isValidErrorMessage(msg, shardingContexts)));
             verify(jobFacade).registerJobBegin(shardingContexts);
             verify(jobItemExecutor, times(shardingContexts.getShardingTotalCount())).process(eq(fooJob), eq(jobConfig), eq(jobRuntimeService), any());
-            verify(jobFacade).registerJobCompleted(shardingContexts);
+            verify(jobFacade).registerJobCompleted(eq(shardingContexts), argThat(items -> !items.isEmpty()));
         }
     }
     
@@ -202,7 +202,7 @@ class ElasticJobExecutorTest {
         verify(jobFacade).misfireIfRunning(shardingContexts.getShardingItemParameters().keySet());
         verify(jobFacade, times(2)).registerJobBegin(shardingContexts);
         verify(jobItemExecutor, times(4)).process(eq(fooJob), eq(jobConfig), eq(jobRuntimeService), any());
-        verify(jobFacade, times(2)).registerJobCompleted(shardingContexts);
+        verify(jobFacade, times(2)).registerJobCompleted(shardingContexts, Collections.emptySet());
     }
     
     @Test
@@ -261,7 +261,7 @@ class ElasticJobExecutorTest {
         verify(jobFacade).postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, "Job 'test_job' execute begin.");
         verify(jobFacade).beforeJobExecuted(shardingContexts);
         verify(jobFacade).registerJobBegin(shardingContexts);
-        verify(jobFacade).registerJobCompleted(shardingContexts);
+        verify(jobFacade).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(jobFacade).afterJobExecuted(shardingContexts);
     }
 }

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/ShardingJobFacadeTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/ShardingJobFacadeTest.java
@@ -130,8 +130,8 @@ class ShardingJobFacadeTest {
     void assertRegisterJobCompletedWhenFailoverDisabled() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.emptyMap());
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").failover(false).build());
-        shardingJobFacade.registerJobCompleted(shardingContexts);
-        verify(executionService).registerJobCompleted(shardingContexts);
+        shardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService, times(0)).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
     }
     
@@ -139,8 +139,8 @@ class ShardingJobFacadeTest {
     void assertRegisterJobCompletedWhenFailoverEnabled() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.emptyMap());
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").failover(true).monitorExecution(true).build());
-        shardingJobFacade.registerJobCompleted(shardingContexts);
-        verify(executionService).registerJobCompleted(shardingContexts);
+        shardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
     }
     

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacadeTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacadeTest.java
@@ -173,7 +173,7 @@ class SingleShardingJobFacadeTest {
         jobInstance2.setServerIp("192.168.1.3");
         availJobInst.add(jobInstance2);
         when(instanceService.getAvailableJobInstances()).thenReturn(availJobInst);
-
+        
         singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
@@ -193,9 +193,9 @@ class SingleShardingJobFacadeTest {
         jobInstance2.setServerIp("192.168.1.3");
         availJobInst.add(jobInstance2);
         when(instanceService.getAvailableJobInstances()).thenReturn(availJobInst);
-
+        
         singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
-
+        
         verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
         verify(jobNodeStorage, times(0)).fillEphemeralJobNode("next-job-instance-ip", availJobInst.get(0).getServerIp());

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacadeTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/executor/facade/SingleShardingJobFacadeTest.java
@@ -145,8 +145,8 @@ class SingleShardingJobFacadeTest {
     void assertRegisterJobCompletedWhenFailoverDisabled() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 1, "", Collections.emptyMap());
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 1).cron("0/1 * * * * ?").failover(false).build());
-        singleShardingJobFacade.registerJobCompleted(shardingContexts);
-        verify(executionService).registerJobCompleted(shardingContexts);
+        singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService, times(0)).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
     }
     
@@ -154,8 +154,8 @@ class SingleShardingJobFacadeTest {
     void assertRegisterJobCompletedWhenFailoverEnabled() {
         ShardingContexts shardingContexts = new ShardingContexts("fake_task_id", "test_job", 1, "", Collections.emptyMap());
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 1).cron("0/1 * * * * ?").failover(true).monitorExecution(true).build());
-        singleShardingJobFacade.registerJobCompleted(shardingContexts);
-        verify(executionService).registerJobCompleted(shardingContexts);
+        singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
     }
     
@@ -173,10 +173,9 @@ class SingleShardingJobFacadeTest {
         jobInstance2.setServerIp("192.168.1.3");
         availJobInst.add(jobInstance2);
         when(instanceService.getAvailableJobInstances()).thenReturn(availJobInst);
-        
-        singleShardingJobFacade.registerJobCompleted(shardingContexts);
-        
-        verify(executionService).registerJobCompleted(shardingContexts);
+
+        singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
         verify(jobNodeStorage).fillEphemeralJobNode("next-job-instance-ip", availJobInst.get(1).getServerIp());
     }
@@ -194,10 +193,10 @@ class SingleShardingJobFacadeTest {
         jobInstance2.setServerIp("192.168.1.3");
         availJobInst.add(jobInstance2);
         when(instanceService.getAvailableJobInstances()).thenReturn(availJobInst);
-        
-        singleShardingJobFacade.registerJobCompleted(shardingContexts);
-        
-        verify(executionService).registerJobCompleted(shardingContexts);
+
+        singleShardingJobFacade.registerJobCompleted(shardingContexts, Collections.emptySet());
+
+        verify(executionService).registerJobCompleted(shardingContexts, Collections.emptySet());
         verify(failoverService).updateFailoverComplete(shardingContexts.getShardingItemParameters().keySet());
         verify(jobNodeStorage, times(0)).fillEphemeralJobNode("next-job-instance-ip", availJobInst.get(0).getServerIp());
     }

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionServiceTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionServiceTest.java
@@ -103,7 +103,7 @@ class ExecutionServiceTest {
     void assertRegisterJobCompletedWithoutMonitorExecution() {
         JobRegistry.getInstance().setJobRunning("test_job", true);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").monitorExecution(false).build());
-        executionService.registerJobCompleted(new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.emptyMap()));
+        executionService.registerJobCompleted(new ShardingContexts("fake_task_id", "test_job", 10, "", Collections.emptyMap()), Collections.emptySet());
         verify(jobNodeStorage, times(0)).removeJobNodeIfExisted(any());
         verify(jobNodeStorage, times(0)).createJobNodeIfNeeded(any());
         assertFalse(JobRegistry.getInstance().isJobRunning("test_job"));
@@ -113,9 +113,20 @@ class ExecutionServiceTest {
     void assertRegisterJobCompletedWithMonitorExecution() {
         JobRegistry.getInstance().setJobRunning("test_job", true);
         when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").monitorExecution(true).build());
-        executionService.registerJobCompleted(getShardingContext());
+        executionService.registerJobCompleted(getShardingContext(), Collections.emptySet());
         verify(jobNodeStorage).removeJobNodeIfExisted("sharding/0/running");
         verify(jobNodeStorage).removeJobNodeIfExisted("sharding/1/running");
+        verify(jobNodeStorage).removeJobNodeIfExisted("sharding/2/running");
+        assertFalse(JobRegistry.getInstance().isJobRunning("test_job"));
+    }
+
+    @Test
+    void assertRegisterJobCompletedWithFailedItems() {
+        JobRegistry.getInstance().setJobRunning("test_job", true);
+        when(configService.load(true)).thenReturn(JobConfiguration.newBuilder("test_job", 3).cron("0/1 * * * * ?").monitorExecution(true).build());
+        executionService.registerJobCompleted(getShardingContext(), Arrays.asList(1));
+        verify(jobNodeStorage).removeJobNodeIfExisted("sharding/0/running");
+        verify(jobNodeStorage, times(0)).removeJobNodeIfExisted("sharding/1/running");
         verify(jobNodeStorage).removeJobNodeIfExisted("sharding/2/running");
         assertFalse(JobRegistry.getInstance().isJobRunning("test_job"));
     }

--- a/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionServiceTest.java
+++ b/kernel/src/test/java/org/apache/shardingsphere/elasticjob/kernel/internal/sharding/ExecutionServiceTest.java
@@ -119,7 +119,7 @@ class ExecutionServiceTest {
         verify(jobNodeStorage).removeJobNodeIfExisted("sharding/2/running");
         assertFalse(JobRegistry.getInstance().isJobRunning("test_job"));
     }
-
+    
     @Test
     void assertRegisterJobCompletedWithFailedItems() {
         JobRegistry.getInstance().setJobRunning("test_job", true);


### PR DESCRIPTION
When a sharding item fails during job execution, the running node in the registry center should not be removed so that failover can be triggered correctly. Previously, registerJobCompleted always removed all running nodes regardless of execution result, causing failed items to appear as successfully completed to the cluster.



Fixes #2493 .

Changes proposed in this pull request:

- Add `registerJobCompleted(ShardingContexts, Collection<Integer>)` overload to `JobFacade`, `AbstractJobFacade`, and `ExecutionService`
- Failed items retain their ZK running node; only succeeded items have their running node removed and failover-complete node cleared
- `ElasticJobExecutor` passes `itemErrorMessages.keySet()` as `failedItems`
- Resolves the TODO comment in `ElasticJobExecutor` regarding job failure status