### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,16 @@
-﻿* text=auto eol=lf
+﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+* text=auto eol=lf

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,12 +44,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Build with Maven in Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -T1C
-      - name: Build with Maven in Linux or macOS
-        if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+      - name: Build with Maven
         run: |
           ./mvnw --batch-mode --no-transfer-progress '-Dmaven.javadoc.skip=true' clean install -Pcheck -T1C
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Fixes #2514 

Changes proposed in this pull request:
- Add `.gitattributes` to enforce LF line endings
- Prevents CRLF being introduced automatically on Windows when running `spotless:apply`
- Verified on Windows via `git check-attr`: `pom.xml: eol: lf`