### PR TITLE
Prevent unit tests and E2E from using host ports `3181`

### DIFF
--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/EmbedTestingServerInitializer.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/EmbedTestingServerInitializer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.spring.namespace;
+
+import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EmbedTestingServerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    
+    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer();
+    
+    @Override
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
+        EMBED_TESTING_SERVER.start();
+        Map<String, Object> props = new HashMap<>();
+        String connectionString = EMBED_TESTING_SERVER.getConnectionString();
+        props.put("regCenter.serverLists", connectionString);
+        props.put("regCenter1.serverLists", connectionString);
+        props.put("regCenter2.serverLists", connectionString);
+        applicationContext.getEnvironment().getPropertySources()
+                .addFirst(new MapPropertySource("embedTestingServerProperties", props));
+    }
+}

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractJobSpringIntegrateTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractJobSpringIntegrateTest.java
@@ -20,16 +20,16 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.job;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.FooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -39,10 +39,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
+@ContextConfiguration(initializers = EmbedTestingServerInitializer.class)
 @RequiredArgsConstructor
 public abstract class AbstractJobSpringIntegrateTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String simpleJobName;
     
@@ -50,11 +49,6 @@ public abstract class AbstractJobSpringIntegrateTest {
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @BeforeEach
     @AfterEach

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractOneOffJobSpringIntegrateTest.java
@@ -21,17 +21,17 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.bootstrap.type.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.DataflowElasticJob;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.FooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -41,10 +41,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
+@ContextConfiguration(initializers = EmbedTestingServerInitializer.class)
 @RequiredArgsConstructor
 public abstract class AbstractOneOffJobSpringIntegrateTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String simpleJobName;
     
@@ -55,11 +54,6 @@ public abstract class AbstractOneOffJobSpringIntegrateTest {
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @BeforeEach
     @AfterEach

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithRefTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithRefTest.java
@@ -19,11 +19,10 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,20 +37,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/job/withJobRef.xml")
+@ContextConfiguration(locations = "classpath:META-INF/job/withJobRef.xml", initializers = EmbedTestingServerInitializer.class)
 class JobSpringNamespaceWithRefTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String simpleJobName = "simpleElasticJob_job_ref";
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @BeforeEach
     @AfterEach

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/JobSpringNamespaceWithTypeTest.java
@@ -19,10 +19,9 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.job;
 
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.quartz.Scheduler;
@@ -41,10 +40,8 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/job/withJobType.xml", initializers = JobSpringNamespaceWithTypeTest.ScriptCommandLineInitializer.class)
+@ContextConfiguration(locations = "classpath:META-INF/job/withJobType.xml", initializers = {EmbedTestingServerInitializer.class, JobSpringNamespaceWithTypeTest.ScriptCommandLineInitializer.class})
 class JobSpringNamespaceWithTypeTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String scriptJobName = "scriptElasticJob_job_type";
     
@@ -52,11 +49,6 @@ class JobSpringNamespaceWithTypeTest {
     private CoordinatorRegistryCenter regCenter;
     
     private Scheduler scheduler;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @AfterEach
     void tearDown() {

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithRefTest.java
@@ -20,11 +20,10 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.job;
 import org.apache.shardingsphere.elasticjob.bootstrap.type.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.ref.RefFooSimpleElasticJob;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,10 +39,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobRef.xml")
+@ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobRef.xml", initializers = EmbedTestingServerInitializer.class)
 class OneOffJobSpringNamespaceWithRefTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String oneOffSimpleJobName = "oneOffSimpleElasticJobRef";
     
@@ -52,11 +49,6 @@ class OneOffJobSpringNamespaceWithRefTest {
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @BeforeEach
     @AfterEach

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/OneOffJobSpringNamespaceWithTypeTest.java
@@ -20,10 +20,9 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.job;
 import org.apache.shardingsphere.elasticjob.bootstrap.type.OneOffJobBootstrap;
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,10 +39,9 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobType.xml", initializers = OneOffJobSpringNamespaceWithTypeTest.ScriptCommandLineInitializer.class)
+@ContextConfiguration(locations = "classpath:META-INF/job/oneOffWithJobType.xml",
+        initializers = {EmbedTestingServerInitializer.class, OneOffJobSpringNamespaceWithTypeTest.ScriptCommandLineInitializer.class})
 class OneOffJobSpringNamespaceWithTypeTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String scriptJobName = "oneOffScriptElasticJob_job_type";
     
@@ -52,11 +50,6 @@ class OneOffJobSpringNamespaceWithTypeTest {
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @AfterEach
     void tearDown() {

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/scanner/AbstractJobSpringIntegrateTest.java
@@ -20,15 +20,15 @@ package org.apache.shardingsphere.elasticjob.spring.namespace.scanner;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.elasticjob.kernel.internal.schedule.JobRegistry;
 import org.apache.shardingsphere.elasticjob.reg.base.CoordinatorRegistryCenter;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.apache.shardingsphere.elasticjob.spring.namespace.fixture.job.annotation.AnnotationSimpleJob;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -38,20 +38,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
+@ContextConfiguration(initializers = EmbedTestingServerInitializer.class)
 @RequiredArgsConstructor
 public abstract class AbstractJobSpringIntegrateTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
     
     private final String simpleJobName;
     
     @Autowired
     private CoordinatorRegistryCenter regCenter;
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @BeforeEach
     @AfterEach

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/snapshot/SnapshotSpringNamespaceDisableTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/snapshot/SnapshotSpringNamespaceDisableTest.java
@@ -18,8 +18,7 @@
 package org.apache.shardingsphere.elasticjob.spring.namespace.snapshot;
 
 import org.apache.shardingsphere.elasticjob.kernel.internal.snapshot.SnapshotService;
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -30,15 +29,8 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotDisabled.xml")
+@ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotDisabled.xml", initializers = EmbedTestingServerInitializer.class)
 class SnapshotSpringNamespaceDisableTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @Test
     void assertSnapshotDisable() {

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/snapshot/SnapshotSpringNamespaceEnableTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/snapshot/SnapshotSpringNamespaceEnableTest.java
@@ -17,8 +17,7 @@
 
 package org.apache.shardingsphere.elasticjob.spring.namespace.snapshot;
 
-import org.apache.shardingsphere.elasticjob.test.util.EmbedTestingServer;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.shardingsphere.elasticjob.spring.namespace.EmbedTestingServerInitializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -29,15 +28,8 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotEnabled.xml")
+@ContextConfiguration(locations = "classpath:META-INF/snapshot/snapshotEnabled.xml", initializers = EmbedTestingServerInitializer.class)
 class SnapshotSpringNamespaceEnableTest {
-    
-    private static final EmbedTestingServer EMBED_TESTING_SERVER = new EmbedTestingServer(3181);
-    
-    @BeforeAll
-    static void init() {
-        EMBED_TESTING_SERVER.start();
-    }
     
     @Test
     void assertSnapshotEnable() throws IOException {

--- a/spring/namespace/src/test/resources/conf/job/conf.properties
+++ b/spring/namespace/src/test/resources/conf/job/conf.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-regCenter.serverLists=127.0.0.1:3181
+regCenter.serverLists=
 regCenter.namespace=elasticjob-spring-test
 regCenter.baseSleepTimeMilliseconds=1000
 regCenter.maxSleepTimeMilliseconds=3000

--- a/spring/namespace/src/test/resources/conf/reg/conf.properties
+++ b/spring/namespace/src/test/resources/conf/reg/conf.properties
@@ -15,13 +15,13 @@
 # limitations under the License.
 #
 
-regCenter1.serverLists=127.0.0.1:3181
+regCenter1.serverLists=
 regCenter1.namespace=regCenter1
 regCenter1.baseSleepTimeMilliseconds=1000
 regCenter1.maxSleepTimeMilliseconds=3000
 regCenter1.maxRetries=3
 
-regCenter2.serverLists=127.0.0.1:3181
+regCenter2.serverLists=
 regCenter2.namespace=regCenter2
 regCenter2.baseSleepTimeMilliseconds=1000
 regCenter2.maxSleepTimeMilliseconds=3000


### PR DESCRIPTION
Fixes #2410 .

Changes proposed in this pull request:
- Prevent unit tests and E2E from using host ports `3181`.
- This seems to be the only option for the Spring namespace.
