### PR TITLE
Support building and using ElasticJob with JDK25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'apache/shardingsphere-elasticjob'
     strategy:
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,8 +2,9 @@
 
 ### Enhancements
 
-1. Bump the JDK requirement for build time from JDK 8 to JDK 17 - [#2509](https://github.com/apache/shardingsphere-elasticjob/issues/2509)
-1. Registry Center: Support etcd3 as a registry center - [#2221](https://github.com/apache/shardingsphere-elasticjob/issues/2221)
+1. Build: Support building and using ElasticJob with JDK25 - [#2518](https://github.com/apache/shardingsphere-elasticjob/pull/2518)
+1. Build: Bump the JDK requirement for build time from JDK 8 to JDK 17 - [#2509](https://github.com/apache/shardingsphere-elasticjob/issues/2509)
+1. Registry Center: Support etcd as a registry center - [#2221](https://github.com/apache/shardingsphere-elasticjob/issues/2221)
 
 ## 3.0.5
 

--- a/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractJobSpringIntegrateTest.java
+++ b/spring/namespace/src/test/java/org/apache/shardingsphere/elasticjob/spring/namespace/job/AbstractJobSpringIntegrateTest.java
@@ -70,13 +70,13 @@ public abstract class AbstractJobSpringIntegrateTest {
     }
     
     private void assertSimpleElasticJobBean() {
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(FooSimpleElasticJob.isCompleted(), is(true)));
+        Awaitility.await().atMost(2L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(FooSimpleElasticJob.isCompleted(), is(true)));
         assertTrue(FooSimpleElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + simpleJobName + "/sharding"));
     }
     
     private void assertThroughputDataflowElasticJobBean() {
-        Awaitility.await().atMost(1L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(DataflowElasticJob.isCompleted(), is(true)));
+        Awaitility.await().atMost(2L, TimeUnit.MINUTES).untilAsserted(() -> assertThat(DataflowElasticJob.isCompleted(), is(true)));
         assertTrue(DataflowElasticJob.isCompleted());
         assertTrue(regCenter.isExisted("/" + throughputDataflowJobName + "/sharding"));
     }


### PR DESCRIPTION
For #2457 .

Changes proposed in this pull request:
- Support building and using ElasticJob with JDK25.
- The current PR is a prerequisite for building a GraalVM Native Image using GraalVM CE for JDK 25.0.2. Also for https://github.com/apache/shardingsphere/issues/38943 .
- Fixed an unstable unit test. See https://github.com/apache/shardingsphere-elasticjob/actions/runs/28487025674/job/84435592115?pr=2518 . In `JobSpringNamespaceWithListenerAndCglibTest`, the Quartz cron `0/1 * * * * ?` in `dataflowElasticJob_namespace_listener_cglib` was initially triggered before the ZK configuration node had been persisted. `ConfigurationService.load()` threw a `JobConfigurationException`, causing `DataflowElasticJob.completed` to never be set to `true`, and Awaitility to time out after 1 minute.
