### PR TITLE
fix: remove UTF-8 BOM from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0


### PR DESCRIPTION
Fixes #2523 

Changes proposed in this pull request:
-Remove the UTF-8 BOM from the first line of `.gitattributes`
-The BOM was causing git to fail parsing the license header comment, resulting in `(ASF) is not a valid attribute name: .gitattributes:1` when cloning
