### PR TITLE
Use direct reads for lifecycle job configurations

### DIFF
--- a/lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/settings/JobConfigurationAPIImpl.java
+++ b/lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/settings/JobConfigurationAPIImpl.java
@@ -36,7 +36,7 @@ public final class JobConfigurationAPIImpl implements JobConfigurationAPI {
     
     @Override
     public JobConfigurationPOJO getJobConfiguration(final String jobName) {
-        String yamlContent = regCenter.get(new JobNodePath(jobName).getConfigNodePath());
+        String yamlContent = regCenter.getDirectly(new JobNodePath(jobName).getConfigNodePath());
         if (null == yamlContent) {
             return null;
         }

--- a/lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/statistics/JobStatisticsAPIImpl.java
+++ b/lifecycle/src/main/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/statistics/JobStatisticsAPIImpl.java
@@ -66,7 +66,7 @@ public final class JobStatisticsAPIImpl implements JobStatisticsAPI {
         JobNodePath jobNodePath = new JobNodePath(jobName);
         JobBriefInfo result = new JobBriefInfo();
         result.setJobName(jobName);
-        String jobConfigYaml = regCenter.get(jobNodePath.getConfigNodePath());
+        String jobConfigYaml = regCenter.getDirectly(jobNodePath.getConfigNodePath());
         if (null == jobConfigYaml) {
             return null;
         }

--- a/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/settings/JobConfigurationAPIImplTest.java
+++ b/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/settings/JobConfigurationAPIImplTest.java
@@ -53,28 +53,28 @@ class JobConfigurationAPIImplTest {
     
     @Test
     void assertGetJobConfigNull() {
-        when(regCenter.get("/test_job/config")).thenReturn(null);
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(null);
         JobConfigurationPOJO actual = jobConfigAPI.getJobConfiguration("test_job");
         assertNull(actual);
-        verify(regCenter).get("/test_job/config");
+        verify(regCenter).getDirectly("/test_job/config");
     }
     
     @Test
     void assertGetDataflowJobConfig() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getDataflowJobYaml());
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getDataflowJobYaml());
         JobConfigurationPOJO actual = jobConfigAPI.getJobConfiguration("test_job");
         assertJobConfig(actual);
         assertThat(actual.getProps().getProperty(DataflowJobProperties.STREAM_PROCESS_KEY), is("true"));
-        verify(regCenter).get("/test_job/config");
+        verify(regCenter).getDirectly("/test_job/config");
     }
     
     @Test
     void assertGetScriptJobConfig() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getScriptJobYaml());
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getScriptJobYaml());
         JobConfigurationPOJO actual = jobConfigAPI.getJobConfiguration("test_job");
         assertJobConfig(actual);
         assertThat(actual.getProps().getProperty(ScriptJobProperties.SCRIPT_KEY), is("echo"));
-        verify(regCenter).get("/test_job/config");
+        verify(regCenter).getDirectly("/test_job/config");
     }
     
     private void assertJobConfig(final JobConfigurationPOJO pojo) {

--- a/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
+++ b/lifecycle/src/test/java/org/apache/shardingsphere/elasticjob/lifecycle/internal/statistics/JobStatisticsAPIImplTest.java
@@ -56,7 +56,7 @@ class JobStatisticsAPIImplTest {
     
     @Test
     void assertGetOKJobBriefInfo() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
         when(regCenter.getChildrenKeys("/test_job/servers")).thenReturn(Arrays.asList("ip1", "ip2"));
         when(regCenter.getChildrenKeys("/test_job/instances")).thenReturn(Arrays.asList("ip1@-@defaultInstance", "ip2@-@defaultInstance"));
         when(regCenter.getChildrenKeys("/test_job/sharding")).thenReturn(Arrays.asList("0", "1", "2"));
@@ -75,7 +75,7 @@ class JobStatisticsAPIImplTest {
     
     @Test
     void assertGetOKJobBriefInfoWithPartialDisabledServer() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
         when(regCenter.getChildrenKeys("/test_job/servers")).thenReturn(Arrays.asList("ip1", "ip2"));
         when(regCenter.get("/test_job/servers/ip1")).thenReturn("DISABLED");
         when(regCenter.getChildrenKeys("/test_job/instances")).thenReturn(Arrays.asList("ip1@-@defaultInstance", "ip2@-@defaultInstance"));
@@ -88,7 +88,7 @@ class JobStatisticsAPIImplTest {
     
     @Test
     void assertGetDisabledJobBriefInfo() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
         when(regCenter.getChildrenKeys("/test_job/servers")).thenReturn(Arrays.asList("ip1", "ip2"));
         when(regCenter.get("/test_job/servers/ip1")).thenReturn("DISABLED");
         when(regCenter.get("/test_job/servers/ip2")).thenReturn("DISABLED");
@@ -99,7 +99,7 @@ class JobStatisticsAPIImplTest {
     
     @Test
     void assertGetShardingErrorJobBriefInfo() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
         when(regCenter.getChildrenKeys("/test_job/servers")).thenReturn(Arrays.asList("ip1", "ip2"));
         when(regCenter.getChildrenKeys("/test_job/instances")).thenReturn(Arrays.asList("ip1@-@defaultInstance", "ip2@-@defaultInstance"));
         when(regCenter.getChildrenKeys("/test_job/sharding")).thenReturn(Arrays.asList("0", "1", "2"));
@@ -112,7 +112,7 @@ class JobStatisticsAPIImplTest {
     
     @Test
     void assertGetCrashedJobBriefInfo() {
-        when(regCenter.get("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
+        when(regCenter.getDirectly("/test_job/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job", "desc"));
         JobBriefInfo jobBrief = jobStatisticsAPI.getJobBriefInfo("test_job");
         assertThat(jobBrief.getStatus(), is(JobBriefInfo.JobStatus.CRASHED));
     }
@@ -126,8 +126,8 @@ class JobStatisticsAPIImplTest {
     @Test
     void assertGetAllJobsBriefInfo() {
         when(regCenter.getChildrenKeys("/")).thenReturn(Arrays.asList("test_job_1", "test_job_2"));
-        when(regCenter.get("/test_job_1/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job_1", "desc1"));
-        when(regCenter.get("/test_job_2/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job_2", "desc2"));
+        when(regCenter.getDirectly("/test_job_1/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job_1", "desc1"));
+        when(regCenter.getDirectly("/test_job_2/config")).thenReturn(LifecycleYamlConstants.getSimpleJobYaml("test_job_2", "desc2"));
         when(regCenter.getChildrenKeys("/test_job_1/servers")).thenReturn(Arrays.asList("ip1", "ip2"));
         when(regCenter.getChildrenKeys("/test_job_2/servers")).thenReturn(Arrays.asList("ip3", "ip4"));
         when(regCenter.getChildrenKeys("/test_job_1/sharding")).thenReturn(Arrays.asList("0", "1"));


### PR DESCRIPTION
Fixes #2526.

Changes proposed in this pull request:
- Use direct reads for lifecycle job configurations
